### PR TITLE
Switch Rust builds to cargo-chef

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Repository Guidelines
 
+## Default Delivery Flow
+- Create a feature branch (`feature/<slug>`) for every ticket before making changes.
+- Implement the work, keep commits focused, and run the relevant backend (`cargo test`) and frontend (`yarn test`) suites.
+- Once everything passes locally, push the branch and open a PR that links the tracked issue and summarizes validation.
+- Stick to this loop unless the issue description calls out an alternative rollout path.
+
 ## Project Structure & Module Organization
 - `service/`: Rust GraphQL API, workers, and SQL migrations (`migrations/`). Tests live in `service/tests/` (`*_tests.rs`).
 - `web/`: React/Mantine client on Vite. Source under `web/src/`, shared mocks in `web/test-utils/`.
@@ -13,6 +19,7 @@
 - Frontend quality gates: `yarn lint`, `yarn typecheck`, `yarn prettier`, `yarn vitest`; CI `yarn test` chains them.
 - Full-stack verification: `skaffold test -p test` and `skaffold dev -p dev` build images, deploy to Kubernetes, and exercise integrations.
 - CI monitoring: after pushing a branch, run `gh run watch --branch $(git rev-parse --abbrev-ref HEAD)` to stream workflow progress.
+- Rust Docker builds use cargo-chef stages by default; keep the planner/cacher/builder structure intact when editing `service/Dockerfile*` assets.
 
 ## Coding Style & Naming Conventions
 - Rust uses edition 2021 with rustfmt; keep modules snake_case and favor descriptive crate names.

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,8 +1,24 @@
-FROM rust:1.86 as builder
+# Use cargo-chef to cache dependency builds between Docker layers
+FROM lukemathwalker/cargo-chef:latest-rust-1.86 AS chef
 
 WORKDIR /usr/src/app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS cacher
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+FROM rust:1.86 AS builder
+
+WORKDIR /usr/src/app
+COPY --from=cacher /usr/src/app/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
 COPY . .
 
+ENV SQLX_OFFLINE=true
 RUN cargo install sqlx-cli --locked --features postgres
 RUN cargo sqlx prepare --check
 RUN cargo build --release

--- a/service/Dockerfile.dev
+++ b/service/Dockerfile.dev
@@ -1,38 +1,33 @@
-FROM rust:1.86 as builder
+# Use cargo-chef to share dependency layers between builds
+FROM lukemathwalker/cargo-chef:latest-rust-1.86 AS chef
+
+WORKDIR /usr/src/app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS cacher
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+RUN cargo chef cook --recipe-path recipe.json
+
+FROM rust:1.86 AS builder
 
 WORKDIR /usr/src/app
 ENV CARGO_HOME=/usr/local/cargo
 ENV CARGO_TARGET_DIR=/usr/src/app/target
 
-# 1. Copy manifests and fetch dependencies
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo "fn main() {}" > src/main.rs
-RUN --mount=type=cache,target=/usr/src/app/target \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,target=/usr/local/cargo/git \
-  cargo build --release --bin tinycongress-api
-RUN rm -rf src
-
-# 2. Copy source and build
+COPY --from=cacher /usr/src/app/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
 COPY . .
-RUN --mount=type=cache,target=/usr/src/app/target \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,target=/usr/local/cargo/git \
-  cargo install sqlx-cli --locked --features postgres
-RUN --mount=type=cache,target=/usr/src/app/target \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,target=/usr/local/cargo/git \
-  cargo sqlx prepare --check
-RUN --mount=type=cache,target=/usr/src/app/target \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,target=/usr/local/cargo/git \
-  sh -ec 'cargo build --bin tinycongress-api && install -m 0755 target/debug/tinycongress-api /usr/local/bin/tinycongress-api'
+
+ENV SQLX_OFFLINE=true
+RUN cargo install sqlx-cli --locked --features postgres
+RUN cargo sqlx prepare --check
+RUN sh -ec 'cargo build --bin tinycongress-api && install -m 0755 target/debug/tinycongress-api /usr/local/bin/tinycongress-api'
 
 # Precompile test binaries so CI containers can run them without rebuilding dependencies
-RUN --mount=type=cache,target=/usr/src/app/target \
-  --mount=type=cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,target=/usr/local/cargo/git \
-  cargo test --no-run
+RUN cargo test --no-run
 
 # Default command: run the dev-built binary from PATH
 CMD ["tinycongress-api"]


### PR DESCRIPTION
## Summary
- switch the service Dockerfiles to cargo-chef planner/cacher/builder stages
- keep sqlx checks and binary install in the final builder layer
- document the default feature-branch/PR flow and call out cargo-chef as the standard

## Testing
- docker build -t tc-api-test -f service/Dockerfile service
- docker build -t tc-api-dev-test -f service/Dockerfile.dev service

Fixes #10