### PR TITLE
Restrict Eleventy workflow to gh-pages

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -1,5 +1,8 @@
 name: Eleventy Build
-on: [push]
+on:
+  push:
+    branches:
+      - gh-pages
 
 jobs:
   build_deploy:


### PR DESCRIPTION
## Summary
- limit the Eleventy GitHub Pages workflow so only pushes to gh-pages trigger a build

## Testing
- no tests (workflow-only change)