### PR TITLE
[TCK-201] Fix skaffold test image references

### DIFF
--- a/doc/tickets/bug-dev-postgres-missing-pgmq.md
+++ b/doc/tickets/bug-dev-postgres-missing-pgmq.md
@@ -1,0 +1,21 @@
+# Bug: Dev/Test Postgres image lacks required `pgmq` extension
+
+## Summary / Overview
+- The Helm chart under `kube/app/templates/postgres.yaml` deploys the upstream `postgres:15` image, but our application requires the `pgmq` extension.
+- Migrations expect `pgmq` to be present and fail when run against the stock image, breaking local Skaffold dev/test environments.
+
+## Goals / Acceptance Criteria
+- [ ] Ensure Kubernetes dev/test deployments use a Postgres image that bundles `pgmq` (e.g., the custom `dockerfiles/Dockerfile.postgres`).
+- [ ] Confirm migrations succeed automatically when the pod starts.
+- [ ] Document the final image choice so contributors know how to rebuild/push it if needed.
+- [ ] Verify both `skaffold dev` and `skaffold test` succeed after the change.
+
+## Additional Context
+- The repo already ships `dockerfiles/Dockerfile.postgres` with the extension installed and enables it via init scripts.
+- Without `pgmq`, `service/migrations/01_init.sql` fails at the extension creation step; the migration runner exits with an error.
+- Developers currently need to manually install the extension inside the pod to continue testing.
+
+## Implementation Spec (if known)
+- Update the Helm chart values or templates to reference the custom Postgres image built during Skaffold workflows.
+- Regenerate manifests (`skaffold render`) to ensure the new image name is reflected.
+- Optionally add a health/readiness check confirming the `pgmq` extension exists before exposing the API deployment.

--- a/doc/tickets/bug-skaffold-test-local-image-tags.md
+++ b/doc/tickets/bug-skaffold-test-local-image-tags.md
@@ -1,0 +1,20 @@
+# Bug: `skaffold test` fails locally due to missing image tag env vars
+
+## Summary / Overview
+- Running `skaffold test` on a developer machine fails during the custom test stage because the test command references `${SKAFFOLD_DEFAULT_REPO}` and `${GITHUB_SHA}`.
+- Those environment variables are not set outside of CI, so the resulting image reference is malformed (e.g., `//tc-api-dev:`) and Docker rejects the command before tests start.
+
+## Goals / Acceptance Criteria
+- [ ] Update `skaffold.yaml` so local test runs use valid image references without relying on CI-only environment variables.
+- [ ] Ensure CI continues to use the correct fully-qualified image names.
+- [ ] Verify `skaffold test` succeeds locally after the change.
+- [ ] Capture the resolution in docs or release notes if developer workflow changes.
+
+## Additional Context
+- The failure happens in `skaffold.yaml` within the `test` section that launches Docker containers for API and UI tests.
+- Skaffold exposes a per-artifact `IMAGE=<name:tag>` environment variable to custom test commands; relying on that keeps the configuration portable between local and CI runs.
+- CI currently injects `${SKAFFOLD_DEFAULT_REPO}` and `${GITHUB_SHA}`, so this bug only affects local runs.
+
+## Implementation Spec (if known)
+- Replace the raw `${SKAFFOLD_DEFAULT_REPO}/tc-api-dev:${GITHUB_SHA}` strings with the `$IMAGE` environment variable Skaffold injects for each custom tester.
+- Run `skaffold test -p dev` locally to confirm both API and UI test commands execute.

--- a/doc/tickets/cleanup-dockerfile-dev-cargo-path.md
+++ b/doc/tickets/cleanup-dockerfile-dev-cargo-path.md
@@ -1,0 +1,20 @@
+# Cleanup: Remove Absolute Cargo Path From `service/Dockerfile.dev`
+
+## Summary / Overview
+- Document the temporary workaround that hardcodes an absolute Cargo binary path in the dev Dockerfile so we can clean it up later.
+- This change was made to unblock local and CI builds but diverges from our usual Dockerfile patterns.
+
+## Goals / Acceptance Criteria
+- [ ] Understand why the base Rust image no longer exposes `cargo` on the default `PATH` inside the dev container.
+- [ ] Remove the explicit `ENV PATH="/usr/local/cargo/bin:${PATH}"` line (or replace it with a less brittle fix) once the root cause is addressed.
+- [ ] Verify `cargo` commands still work for developer workflows and CI builds after the cleanup.
+- [ ] Update documentation to reflect the final state of the Dockerfile.
+
+## Additional Context
+- The workaround lives in `service/Dockerfile.dev:32` where we prepend `/usr/local/cargo/bin` to `PATH`.
+- The absolute path is a stopgap; if the upstream image changes its layout again we might have to revisit.
+- Consider whether setting `CARGO_HOME` alone should be sufficient, or if we should rely on the standard `/usr/local/cargo/bin` symlink provided by the Rust image.
+
+## Implementation spec (if known)
+- Start with a spike PR that reverts the `PATH` override and confirms builds still succeed.
+- If the issue reproduces, document the failure and explore adjusting the base image or leveraging `rustup` toolchains instead of manual PATH surgery.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,16 +57,11 @@ test:
   - image: tc-api-dev
     custom:
       - command: >-
-          docker run --rm
-          ${SKAFFOLD_DEFAULT_REPO}/tc-api-dev:${GITHUB_SHA}
-          /bin/sh -lc "cd /usr/src/app && /usr/local/cargo/bin/cargo test --test api_tests --test graphql_tests --test model_tests -- --test-threads=1 --nocapture"
+          docker run --rm "$IMAGE" /bin/sh -lc "cd /usr/src/app && /usr/local/cargo/bin/cargo test --test api_tests --test graphql_tests --test model_tests -- --test-threads=1 --nocapture"
   - image: tc-ui-dev
     custom:
       - command: >-
-          docker run --rm
-          -e CI=true
-          ${SKAFFOLD_DEFAULT_REPO}/tc-ui-dev:${GITHUB_SHA}
-          /bin/sh -lc "cd /app && yarn test --watchAll=false"
+          docker run --rm -e CI=true "$IMAGE" /bin/sh -lc "cd /app && yarn test --watchAll=false"
 
 # Post-deploy verification: run integration tests against the live cluster
 verify:


### PR DESCRIPTION
## Context
- `skaffold test` failed locally because the test commands referenced `${SKAFFOLD_DEFAULT_REPO}/${GITHUB_SHA}` which are only present in CI.
- Follow-up tickets (#21, #22) capture the remaining infra cleanups discovered during review.

## Changes made
- Documented the Dockerfile kludge and both dev infra issues under `doc/tickets/` so they can be scheduled.
- Updated the Skaffold custom testers to rely on the per-artifact `$IMAGE` env var, making the commands work with locally tagged images too.

## Testing
- [ ] `cargo test`
- [ ] `yarn test`
- [x] Other (specify)
  - `skaffold build --profile dev --file-output /tmp/skaffold-artifacts.json`
  - `skaffold test --profile dev --build-artifacts /tmp/skaffold-artifacts.json`

## Linked Issue
- Closes #20

## AI tooling used
- Codex (GPT-5)
