### PR TITLE
Add Playwright smoke test to skaffold

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -61,7 +61,7 @@ test:
   - image: tc-ui-dev
     custom:
       - command: >-
-          docker run --rm -e CI=true "$IMAGE" /bin/sh -lc "cd /app && yarn test --watchAll=false"
+          docker run --rm -e CI=true "$IMAGE" /bin/sh -lc "cd /app && yarn test --watchAll=false && yarn playwright:test"
 
 # Post-deploy verification: run integration tests against the live cluster
 verify:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -130,3 +130,8 @@ dist
 .pnp.*
 
 .DS_Store
+# Playwright artifacts
+playwright-report/
+playwright/.launches/
+.playwright/
+test-results/

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -8,6 +8,7 @@ RUN corepack enable
 COPY .yarn/ ./.yarn/
 COPY .yarnrc.yml package.json yarn.lock ./
 RUN yarn install --immutable
+RUN npx playwright install --with-deps chromium
 
 # Copy the rest of the app
 COPY . ./

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "prettier:write": "prettier --write \"**/*.{ts,tsx}\"",
     "vitest": "vitest run",
     "vitest:watch": "vitest",
+    "playwright:test": "playwright test",
     "test": "npm run typecheck && npm run prettier && npm run lint && npm run vitest && npm run build",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@eslint/js": "^9.23.0",
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
+    "@playwright/test": "^1.55.1",
     "@storybook/react": "^9.1.2",
     "@storybook/react-vite": "^9.1.2",
     "@testing-library/dom": "^10.4.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'yarn build && yarn preview --host 0.0.0.0 --port 4173 --strictPort',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/web/tests/e2e/home.spec.ts
+++ b/web/tests/e2e/home.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test';
+
+test('home page renders welcome headline', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /welcome to/i })).toBeVisible();
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -21,5 +21,5 @@
       "@test-utils": ["./test-utils"]
     }
   },
-  "include": ["src", "test-utils"]
+  "include": ["src", "test-utils", "tests"]
 }

--- a/web/vite.config.mjs
+++ b/web/vite.config.mjs
@@ -12,5 +12,13 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './vitest.setup.mjs',
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.idea/**',
+      '**/.git/**',
+      '**/.cache/**',
+      'tests/e2e/**',
+    ],
   },
 });

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1042,6 +1042,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.55.1":
+  version: 1.55.1
+  resolution: "@playwright/test@npm:1.55.1"
+  dependencies:
+    playwright: "npm:1.55.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/23fa213844bc594b03c0a907ef69da7e26a6c3295ee602b1567d26a473d30253468b832698779b02a304b71ae14aa0875645c526678227cc0675324dbf77e118
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0-beta.32":
   version: 1.0.0-beta.32
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.32"
@@ -3686,12 +3697,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -4768,6 +4798,7 @@ __metadata:
     "@mantine/form": "npm:^7.17.3"
     "@mantine/hooks": "npm:^7.17.3"
     "@mantine/notifications": "npm:^7.17.3"
+    "@playwright/test": "npm:^1.55.1"
     "@storybook/react": "npm:^9.1.2"
     "@storybook/react-vite": "npm:^9.1.2"
     "@tabler/icons-react": "npm:^3.31.0"
@@ -5345,6 +5376,30 @@ __metadata:
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.55.1":
+  version: 1.55.1
+  resolution: "playwright-core@npm:1.55.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/39837a8c1232ec27486eac8c3fcacc0b090acc64310f7f9004b06715370fc426f944e3610fe8c29f17cd3d68280ed72c75f660c02aa5b5cf0eb34bab0031308f
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.55.1":
+  version: 1.55.1
+  resolution: "playwright@npm:1.55.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.55.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/b84a97b0d764403df512f5bbb10c7343974e151a28202cc06f90883a13e8a45f4491a0597f0ae5fb03a026746cbc0d200f0f32195bfaa381aee5ca5770626771
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context
- Add a Playwright smoke test so skaffold exercises the built UI, per issue #6.

## Changes made
- configure Playwright with a chromium project and preview server
- add an e2e home page spec and yarn script, installing browsers in the dev Docker image
- run the Playwright suite from the frontend step in `skaffold test`

## Testing
- [ ] `cargo test`
- [x] `yarn test`
- [x] Other (specify): `yarn playwright test`

## Linked Issue
- Closes #6

## AI tooling used
- Opened by: Codex
