### PR TITLE
Add prettier to web linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
         run: cargo fmt --all -- --check
 
   # ============================================================
-  # JOB 0b: Lint web (ESLint)
+  # JOB 0b: Lint web
   # ============================================================
   lint-web:
-    name: Lint web (ESLint)
+    name: Lint web
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,9 +59,9 @@ jobs:
         working-directory: web
         run: yarn install --immutable
 
-      - name: Run ESLint
+      - name: Run Linters
         working-directory: web
-        run: yarn eslint
+        run: yarn lint
 
   # ============================================================
   # JOB 1: Build all container images in parallel

--- a/web/README.md
+++ b/web/README.md
@@ -21,12 +21,12 @@ This template comes with the following features:
 ### Testing scripts
 
 - `typecheck` – checks TypeScript types
-- `lint` – runs ESLint
+- `lint` – runs Prettier, ESLint, and Stylelint
 - `prettier` – checks files with Prettier
 - `prettier:write` – formats all files with Prettier
 - `vitest` – runs unit tests
 - `vitest:watch` – starts vitest watch
-- `test` – runs `typecheck`, `prettier`, `lint`, `vitest` and `build`
+- `test` – runs `typecheck`, `lint`, `vitest` and `build`
 - `playwright:test` – executes Chromium end-to-end tests (without code coverage instrumentation)
 - `playwright:report` – merges `.nyc_output` artifacts into `coverage/playwright/` (LCOV, HTML, JSON, text)
 - `playwright:clean` – removes previous Playwright junit, coverage, and trace artifacts

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "npm run eslint && npm run stylelint",
+    "lint": "npm run prettier && npm run eslint && npm run stylelint",
     "eslint": "eslint . --cache --cache-location .eslintcache --max-warnings=0 --report-unused-disable-directives",
     "stylelint": "stylelint '**/*.css' --cache",
     "prettier": "prettier --check \"**/*.{ts,tsx}\"",
@@ -19,7 +19,7 @@
     "playwright:report": "nyc report --reporter=lcov --reporter=html --reporter=text-summary --reporter=json-summary --report-dir coverage/playwright",
     "playwright:clean": "node ./scripts/reset-playwright-coverage.mjs",
     "playwright:ci": "node ./scripts/run-playwright-ci.mjs",
-    "test": "npm run typecheck && npm run prettier && npm run lint && npm run vitest && npm run build",
+    "test": "npm run typecheck && npm run lint && npm run vitest && npm run build",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },


### PR DESCRIPTION
## Context
Include Prettier in the web lint script so formatting checks run with linting.

## Changes made
- Run Prettier before ESLint and Stylelint in `yarn lint`
- Update `yarn test` to rely on lint for Prettier coverage without duplicate work
- Refresh README script descriptions to match the new lint pipeline

## Testing
- [ ] `cargo test`
- [ ] `yarn test`
- [x] Other (specify)
  - `cd web && yarn lint`

## Linked Issue
- Closes #000

## AI tooling used
- ChatGPT via Codex CLI

Opened by: Codex
