### PR TITLE
Prewarm Vite in dev container

### DIFF
--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -18,6 +18,8 @@ RUN yarn install --immutable
 # Copy the rest of the app
 COPY . ./
 
+RUN install -m 0755 bin/dev-entrypoint.sh /usr/local/bin/dev-entrypoint
+
 # Development environment setup
 ENV NODE_ENV=development
 ENV PORT=5173
@@ -26,4 +28,4 @@ ENV HOST=0.0.0.0
 # Expose development port
 EXPOSE 5173
 
-CMD ["yarn", "dev"]
+CMD ["/usr/local/bin/dev-entrypoint"]

--- a/web/bin/dev-entrypoint.sh
+++ b/web/bin/dev-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+
+# Prime Vite dependency optimizer so the first page load isn't slow.
+echo "Prewarming Vite dependency cache..."
+if ! yarn vite optimize; then
+  echo "Vite prewarm failed; starting dev server anyway."
+fi
+
+exec yarn dev --host "${HOST:-0.0.0.0}" --port "${PORT:-5173}"


### PR DESCRIPTION
## Context
Dev UI first hit waits ~10-15s for Vite to optimize dependencies; prewarm it inside the dev container.

## Changes made
- add a dev entrypoint that pre-runs 'yarn vite optimize' before starting Vite
- install and use the entrypoint from the dev Dockerfile so prewarm happens on boot

## Testing
- [ ] \
- [ ] \yarn run v1.22.22
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
- [ ] Other (specify)

## Linked Issue
- Closes #N/A

## AI tooling used
- Codex (GPT-5)
