### PR TITLE
Fix vitest test discovery - justfile commands and explicit patterns

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,11 +78,11 @@ dev-backend:
 
 # Run frontend unit tests (if they exist)
 test-frontend:
-    cd web && yarn vitest run
+    cd web && yarn vitest
 
 # Run frontend unit tests in watch mode (if they exist)
 test-frontend-watch:
-    cd web && yarn vitest
+    cd web && yarn vitest:watch
 
 # Run full frontend test suite (typecheck + lint + vitest + build) - includes E2E via CI
 test-frontend-full:

--- a/web/vite.config.mjs
+++ b/web/vite.config.mjs
@@ -30,6 +30,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './vitest.setup.mjs',
+    include: [
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+    ],
     exclude: [
       '**/node_modules/**',
       '**/dist/**',


### PR DESCRIPTION
Fixes two issues that prevented vitest from discovering test files:

## Primary Fix: Justfile Commands

The justfile was calling `yarn vitest run`, but package.json already defines:
```json
"vitest": "vitest run"
```

This caused `yarn vitest run` to execute `vitest run run` (double run), which failed.

**Changes:**
- `test-frontend`: `yarn vitest run` → `yarn vitest`
- `test-frontend-watch`: `yarn vitest` → `yarn vitest:watch`

## Secondary Fix: Explicit Glob Patterns

Added explicit include patterns to `vite.config.mjs`:
- `**/*.test.ts`
- `**/*.test.tsx`
- `**/*.spec.ts`
- `**/*.spec.tsx`

This avoids extended glob syntax that can behave differently across Node versions.

## Verification

`just test-frontend` now passes ✓

Related to Node 22 standardization (#77).