### PR TITLE
Upgrade Rust to 1.91 to support latest dependencies

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,5 +1,5 @@
 # Use cargo-chef to cache dependency builds between Docker layers
-FROM lukemathwalker/cargo-chef:latest-rust-1.86 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.91 AS chef
 
 WORKDIR /usr/src/app
 
@@ -11,7 +11,7 @@ FROM chef AS cacher
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
-FROM rust:1.86 AS builder
+FROM rust:1.91 AS builder
 
 WORKDIR /usr/src/app
 COPY --from=cacher /usr/src/app/target target


### PR DESCRIPTION
Upgrades Rust from 1.86 to 1.91 to support the latest dependency versions that require newer Rust toolchains.

## Changes
- Update cargo-chef image to latest-rust-1.91
- Update builder image to rust:1.91

## Why
The  crate (and potentially other dependencies) requires Rust 1.88+. Upgrading to Rust 1.91 allows us to use the latest compatible dependency versions without downgrades.

## Testing
- ✅ Tested locally with successful Docker build
- ✅ Service compiles successfully with Rust 1.91
- ✅ All web tests passing (typecheck, lint, vitest, build)

This completes the dependency vulnerability fixes started in #81 by ensuring the Rust toolchain supports the updated dependencies.