### PR TITLE
Standardize on just commands as single source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,11 @@ jobs:
         with:
           workspaces: service -> target
 
-      - name: Check formatting
-        working-directory: service
-        run: cargo fmt --all -- --check
+      - name: Install just
+        uses: extractions/setup-just@v2
 
-      - name: Clippy
-        working-directory: service
-        run: |
-          # Dev-only tooling pulls in unstable deps (e.g., cargo-llvm-cov via ruzstd),
-          # so keep clippy scoped to library and binaries.
-          cargo clippy --all-features -- -D warnings
+      - name: Lint backend
+        run: just lint-backend
 
   # ============================================================
   # JOB 0b: Lint web
@@ -87,13 +82,14 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
+      - name: Install just
+        uses: extractions/setup-just@v2
+
       - name: Install dependencies
-        working-directory: web
-        run: yarn install --immutable
+        run: just install-frontend
 
       - name: Run Linters
-        working-directory: web
-        run: yarn lint
+        run: just lint-frontend
 
   # ============================================================
   # JOB 1: Build all container images in parallel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,11 @@
 ## Default Delivery Flow
 - Always sync with `master` before starting work: `git checkout master && git pull --rebase`. When picking up a PR or ticket, rebase your working branch onto the refreshed `master` before any edits.
 - Create a branch for every ticket before making changes following the conventions in `docs/interfaces/branch-naming-conventions.md` (e.g., `feature/123-update-copy`, `fix/456-login-redirect`).
-- Implement the work, keep commits focused, and run the relevant backend (`cargo test`) and frontend (`yarn test`) suites.
+- Implement the work, keep commits focused, and run the relevant test suites via `just test` (unit tests) or `just test-ci` (full CI suite).
 - Treat each major checkpoint on a PR (e.g., before opening, after rebasing, after addressing review) as a moment to leave a fresh status comment with what changed and what still needs attention.
-- Once everything passes locally, push the branch and open a draft PR that links the tracked issue, fills out the Codex PR template, and explicitly notes `Opened by: Codex`.
+- Once everything passes locally, push the branch and open a draft PR that links the tracked issue, fills out the PR template, and notes which AI tool generated it (if applicable).
 - After the PR's automated checks succeed, mark it ready for review.
-- Wait for the Copilot review to land and respond to critiques when they are obviously sensible improvements.
+- Respond to review feedback when critiques are obviously sensible improvements.
 - Stick to this loop unless the issue description calls out an alternative rollout path.
 - When continuing a rebase in the CLI harness, run `GIT_EDITOR=true git rebase --continue`; otherwise Git attempts to launch `vim`, which hangs the workflow.
 
@@ -39,12 +39,28 @@ Key interfaces:
 - `docs/interfaces/branch-naming-conventions.md` - Branch naming standards
 - `docs/interfaces/agent-output-schema.md` - PR compliance format
 
+Key style guides:
+- `docs/style/STYLE_GUIDE.md` - Mantine-first styling policy
+- `docs/style/LLM_UI_GUIDE.md` - LLM instructions for UI work
+
 ## Build, Test, and Development Commands
-- Backend loop: `cd service && cargo check`, `cargo fmt`, `cargo clippy --all-targets -- -D warnings` keep builds clean.
-- Backend tests: rely on Skaffold pipelines (`skaffold build --file-output artifacts.json && skaffold test --build-artifacts artifacts.json`, or `skaffold verify -p ci`) so the Rust suites run against the built images.
-- Frontend workflows: `cd web && yarn install` once, then `yarn dev` (Vite server), `yarn build` (production assets), `yarn preview` (smoke test).
-- Frontend quality gates: `yarn lint`, `yarn typecheck`, `yarn prettier`, `yarn vitest`; CI `yarn test` chains them.
-- Full-stack verification: prefer `skaffold test -p ci` and `skaffold verify -p ci` (add `--build-artifacts <file>` when reusing prebuilt images) to mirror CI behavior; `skaffold dev -p dev` remains available for interactive loops.
+
+Use the `justfile` as the single source of truth for all commands. Run `just --list` to see all available recipes.
+
+| Task | Command | Notes |
+|------|---------|-------|
+| **Linting** | `just lint` | Runs backend + frontend linting |
+| **Formatting** | `just fmt` | Fixes all formatting issues |
+| **Unit tests** | `just test` | Backend + frontend unit tests (no cluster) |
+| **Full CI suite** | `just test-ci` | Builds images, runs all tests via Skaffold |
+| **Backend only** | `just lint-backend`, `just test-backend` | |
+| **Frontend only** | `just lint-frontend`, `just test-frontend` | |
+| **Type checking** | `just typecheck` | Frontend TypeScript checking |
+| **Dev server** | `just dev` | Full-stack with Skaffold (requires cluster) |
+| **Frontend dev** | `just dev-frontend` | Vite dev server only |
+| **Build** | `just build` | Backend + frontend builds |
+
+Additional notes:
 - CI monitoring: after pushing a branch, run `gh run watch --branch $(git rev-parse --abbrev-ref HEAD)` to stream workflow progress.
 - Rust Docker builds use cargo-chef stages by default; keep the planner/cacher/builder structure intact when editing `service/Dockerfile*` assets.
 
@@ -52,11 +68,12 @@ Key interfaces:
 - Rust uses edition 2021 with rustfmt; keep modules snake_case and favor descriptive crate names.
 - Prefer `Result<_, anyhow::Error>` for async handlers so GraphQL resolvers surface uniform errors.
 - Frontend TypeScript relies on Prettier, ESLint, Stylelint; use PascalCase components, camelCase hooks, and co-locate styles.
+- Frontend styling follows Mantine-first approach per ADR-005 (`docs/decisions/005-mantine-first-styling.md`).
 
 ## Testing Guidelines
 - Keep specs near code (`*_tests.rs`, `*.test.tsx`). Reuse fixtures before adding mocks.
 - Cover ranking, pairing, and voting flows when rules shift; add regression tests for reported bugs.
-- Run `skaffold test -p ci`, and `skaffold verify -p ci` (optionally reusing `--build-artifacts <file>`) before PRs
+- Run `just lint` and `just test` for quick local validation; run `just test-ci` for full CI suite before PRs.
 - Treat the `testing local dev` LLM skill (`docs/skills/testing-local-dev.md`) as a pre-merge requirement for any MR that changes Skaffold configuration; document the results in the PR.
 
 ## Commit & Pull Request Guidelines
@@ -70,7 +87,7 @@ Key interfaces:
 - Align Docker tags with `skaffold.yaml` profiles so preview, test, and prod images stay consistent.
 
 ## Prohibited Actions (Hard Constraints)
-- DO NOT modify files outside `service/`, `web/`, `kube/`, `docs/`, or repo root configs
+- DO NOT modify files outside `service/`, `web/`, `kube/`, `dockerfiles/`, `docs/`, or repo root configs
 - DO NOT add new database tables or migrations without explicit approval
 - DO NOT add dependencies without updating the appropriate lockfile (`Cargo.lock`, `yarn.lock`)
 - DO NOT push directly to `master`; all changes go through PRs
@@ -78,7 +95,7 @@ Key interfaces:
 - DO NOT commit secrets, credentials, or `.env` files
 - DO NOT delete or rename existing public API endpoints without deprecation
 - DO NOT modify `skaffold.yaml` profiles without running the testing-local-dev skill
-- DO NOT run bare `git push`; ALWAYS specify the remote and branch explicitly: `git push origin <branch-name>`
+- DO NOT run bare `git push`; ALWAYS specify the remote and branch explicitly: `git push origin <branch-name>` (see ADR-004)
 - DO NOT use `--force` or `--force-with-lease` without explicit branch: `git push --force-with-lease origin <branch-name>`
 
 ## Agent Acknowledgement Contract

--- a/docs/checklists/pre-pr.md
+++ b/docs/checklists/pre-pr.md
@@ -14,17 +14,13 @@ Complete before opening or marking PR ready for review.
 
 - [ ] Tests added for new functionality
 - [ ] Tests updated for changed behavior
-- [ ] All tests pass locally:
-  - [ ] `cd service && cargo test`
-  - [ ] `cd web && yarn test`
+- [ ] All tests pass locally: `just test`
 - [ ] Manual testing completed for UI changes
 
 ## Linting
 
-- [ ] Rust: `cargo fmt --all -- --check`
-- [ ] Rust: `cargo clippy --all-features -- -D warnings`
-- [ ] Web: `yarn lint`
-- [ ] Web: `yarn typecheck`
+- [ ] All linting passes: `just lint`
+- [ ] Type checking passes: `just typecheck`
 
 ## Documentation
 
@@ -70,7 +66,7 @@ Complete before opening or marking PR ready for review.
 
 ## Final steps
 
-- [ ] `skaffold test -p ci` passes locally
+- [ ] `just test-ci` passes locally (full CI suite)
 - [ ] PR description explains why, not just what
 - [ ] Issue linked in PR description
 - [ ] Appropriate reviewers assigned

--- a/docs/playbooks/adding-migration.md
+++ b/docs/playbooks/adding-migration.md
@@ -31,8 +31,8 @@
 5. Commit both the migration and updated `.sqlx/` files
 
 ## Verification
-- [ ] `cargo test` passes
-- [ ] `cargo check` passes (sqlx compile-time verification)
+- [ ] `just test-backend` passes
+- [ ] `just build-backend` passes (sqlx compile-time verification)
 - [ ] Migration is idempotent where possible
 - [ ] Rollback strategy documented if destructive
 

--- a/docs/playbooks/debugging-ci-failure.md
+++ b/docs/playbooks/debugging-ci-failure.md
@@ -17,39 +17,36 @@ gh run view <run_id> --log-failed    # Show only failed steps
 
 | Job | Common cause | Quick fix |
 |-----|--------------|-----------|
-| `lint` | Formatting | `cd service && cargo fmt` |
-| `lint-web` | ESLint/TypeScript | `cd web && yarn lint --fix` |
+| `lint` | Formatting | `just fmt-backend` |
+| `lint-web` | ESLint/TypeScript | `just fmt-frontend` |
 | `build-images` | Dockerfile error | Check build context paths |
 | `integration-tests` | Test failure | See test output for assertion |
 | `agent-compliance` | Missing YAML block | Add compliance block to PR |
 
 ## Local reproduction
 
-### Rust lint failures
+### Lint failures
 ```bash
-cd service
-cargo fmt --all -- --check          # Check formatting
-cargo clippy --all-features -- -D warnings
-```
-
-### Web lint failures
-```bash
-cd web
-yarn lint                           # ESLint + Stylelint
-yarn typecheck                      # TypeScript
-yarn prettier --check .             # Formatting
+just lint              # Check all linting
+just fmt               # Fix all formatting
+just lint-backend      # Backend only
+just lint-frontend     # Frontend only
+just typecheck         # TypeScript type checking
 ```
 
 ### Integration test failures
 ```bash
 # Full CI simulation
+just test-ci
+
+# Or manually:
 skaffold build --file-output artifacts.json
 skaffold test -p ci --build-artifacts artifacts.json
 skaffold deploy -p ci --build-artifacts artifacts.json
 
 # Port-forward and run tests
 kubectl port-forward svc/postgres 5432:5432 &
-cd service && DATABASE_URL=postgres://postgres:postgres@localhost:5432/prioritization cargo test
+just test-backend
 ```
 
 ### Playwright E2E failures
@@ -76,7 +73,7 @@ gh run download <run_id> -n playwright-artifacts
 ## Verification after fix
 - [ ] Failure reproduces locally
 - [ ] Fix applied
-- [ ] `skaffold test -p ci` passes locally
+- [ ] `just test-ci` passes locally
 - [ ] Push and verify CI passes
 
 ## Common failures

--- a/docs/playbooks/dependency-update.md
+++ b/docs/playbooks/dependency-update.md
@@ -24,9 +24,8 @@ cargo update -p <crate_name>    # Update specific crate
 
 ### After any change
 ```bash
-cargo check                     # Verify compilation
-cargo clippy --all-features -- -D warnings
-cargo test
+just lint-backend      # Format + clippy
+just test-backend      # Run tests
 ```
 
 ## Frontend (Node/Yarn)
@@ -47,10 +46,9 @@ yarn up '*'                     # Update all packages
 
 ### After any change
 ```bash
-yarn install --immutable        # Verify lockfile integrity
-yarn typecheck
-yarn lint
-yarn test
+just lint-frontend     # Prettier + ESLint + Stylelint
+just typecheck         # TypeScript checking
+just test-frontend     # Run tests
 ```
 
 ## CI cache invalidation

--- a/docs/playbooks/frontend-test-patterns.md
+++ b/docs/playbooks/frontend-test-patterns.md
@@ -9,8 +9,8 @@
 
 | Type | Tool | Location | Run command |
 |------|------|----------|-------------|
-| Unit/Component | Vitest | `web/src/**/*.test.tsx` | `yarn vitest` |
-| E2E | Playwright | `web/tests/` | `yarn playwright:test` |
+| Unit/Component | Vitest | `web/src/**/*.test.tsx` | `just test-frontend` |
+| E2E | Playwright | `web/tests/` | `just test-frontend-e2e` |
 
 ## Vitest patterns
 
@@ -95,7 +95,7 @@ CI collects coverage for both test types:
 Coverage reports uploaded as artifacts.
 
 ## Verification
-- [ ] Tests pass locally: `yarn test`
+- [ ] Tests pass locally: `just test-frontend-full`
 - [ ] No flaky tests (run 3x)
 - [ ] Coverage not decreased
 - [ ] Tests isolated (no order dependency)

--- a/docs/playbooks/new-graphql-endpoint.md
+++ b/docs/playbooks/new-graphql-endpoint.md
@@ -5,7 +5,7 @@
 - Exposing new data to the frontend
 
 ## Prerequisites
-- Backend compiles: `cd service && cargo check`
+- Backend compiles: `just build-backend`
 - Understanding of existing resolver patterns in `service/src/`
 
 ## Steps
@@ -54,8 +54,8 @@
 6. **Update frontend** to use new endpoint (see `web/src/`)
 
 ## Verification
-- [ ] `cargo test` passes
-- [ ] `cargo clippy --all-features -- -D warnings` clean
+- [ ] `just test-backend` passes
+- [ ] `just lint-backend` clean
 - [ ] Endpoint accessible via GraphQL playground
 - [ ] Frontend integration works
 


### PR DESCRIPTION
## Summary
- Updates AGENTS.md to use justfile as single source of truth for build/test/lint commands
- CI workflow now uses  and 
> mantine-vite-template@0.0.0 prettier
> prettier --check "**/*.{ts,tsx}"

Checking formatting...
All matched files use Prettier code style!

> mantine-vite-template@0.0.0 eslint
> eslint . --cache --cache-location .eslintcache --max-warnings=0 --report-unused-disable-directives


> mantine-vite-template@0.0.0 stylelint
> stylelint '**/*.css' --cache instead of raw commands
- All playbooks and checklists updated to reference just commands
- Fixes inconsistencies identified in documentation review (clippy flags, terminology, missing sections)

## Changes
- **AGENTS.md**: Command table pointing to just recipes, added style guides section, ADR-005 reference, dockerfiles/ to allowed dirs
- **CI workflow**: Installs just, uses just commands for linting
- **Pre-PR checklist**: Simplified to just test/lint/test-ci
- **Playbooks**: Updated debugging-ci-failure, dependency-update, new-graphql-endpoint, adding-migration, frontend-test-patterns

## Test plan
- [ ] CI passes with new just-based lint jobs
- [ ] Available recipes:
    build                    # Build everything locally (no images)
    build-backend            # Build backend (debug)
    build-backend-release    # Build backend (release)
    build-frontend           # Build frontend for production
    build-images             # Build all container images (for current profile)
    build-images-artifacts   # Build images and output artifacts JSON (for reuse with test)
    build-release            # Build everything in release mode
    clean                    # Clean build artifacts
    db-migrate               # Run database migrations (requires DATABASE_URL)
    default                  # Default recipe - show help
    deploy                   # Deploy to local cluster
    deploy-release           # Deploy release images to cluster
    dev                      # Prerequisites: Docker, Skaffold, Kubernetes cluster (minikube/Docker Desktop)
    dev-backend              # Run backend dev server with hot reload
    dev-frontend             # Run frontend dev server
    fmt                      # Fix all formatting (backend + frontend)
    fmt-backend              # Fix backend formatting
    fmt-frontend             # Fix frontend formatting with prettier
    install-frontend         # Install frontend dependencies
    lint                     # Run all linting (backend + frontend) - no cluster required
    lint-backend             # Run all backend linting (format + clippy)
    lint-backend-clippy      # Run clippy linter on backend
    lint-backend-fmt         # Check backend formatting
    lint-frontend            # Run all frontend linting (prettier + eslint + stylelint)
    lint-frontend-eslint     # Run eslint only
    lint-frontend-prettier   # Check frontend formatting with prettier
    lint-frontend-stylelint  # Run stylelint only
    node-check               # Check if Node version matches .nvmrc
    node-use                 # Switch to Node version from .nvmrc (requires nvm)
    node-version             # Show Node version
    pr title body=""         # Push current branch and create a PR
    pr-auto title body=""    # Push current branch, create PR, and enable auto-merge
    rust-version             # Show Rust version
    setup                    # Check prerequisites and display setup instructions
    storybook                # Run Storybook dev server (experimental - may have dependency issues)
    test                     # Run all local unit tests (backend + frontend, if they exist)
    test-backend             # Run backend unit tests
    test-backend-cov         # Run backend unit tests with coverage
    test-backend-integration # Run backend integration tests via Skaffold (RECOMMENDED - requires Docker + Kubernetes)
    test-ci                  # Alias for test-full (CI-friendly naming)
    test-cov                 # Run all unit tests with coverage
    test-frontend            # Run frontend unit tests (if they exist)
    test-frontend-e2e        # Run frontend E2E tests with Playwright (requires running backend/frontend)
    test-frontend-full       # Run full frontend test suite (typecheck + lint + vitest + build) - includes E2E via CI
    test-frontend-watch      # Run frontend unit tests in watch mode (if they exist)
    test-full                # Run full test suite via Skaffold (mirrors CI - RECOMMENDED per AGENTS.md)
    typecheck                # Type check frontend
    typecheck-frontend       # Check frontend types
    undeploy                 # Delete all deployed resources from cluster
    verify-ci                # Verify full test suite via Skaffold (CI mode - RECOMMENDED approach per AGENTS.md)
    versions                 # Show all tool versions shows all referenced commands
- [ ] Documentation links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)