### PR TITLE
Add TanStack Query infrastructure and migrate About page

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,8 @@
     "@mantine/hooks": "^8.3.10",
     "@mantine/notifications": "^8.3.10",
     "@tabler/icons-react": "^3.35.0",
+    "@tanstack/react-query": "^5.90.12",
+    "@tanstack/react-query-devtools": "^5.91.1",
     "@tanstack/react-router": "^1.141.1",
     "dayjs": "^1.11.19",
     "react": "^19.2.3",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,13 +1,16 @@
 import '@mantine/core/styles.css';
 
 import { MantineProvider } from '@mantine/core';
+import { QueryProvider } from './providers/QueryProvider';
 import { Router } from './Router';
 import { mantineTheme } from './theme/mantineTheme';
 
 export default function App() {
   return (
-    <MantineProvider theme={mantineTheme}>
-      <Router />
-    </MantineProvider>
+    <QueryProvider>
+      <MantineProvider theme={mantineTheme}>
+        <Router />
+      </MantineProvider>
+    </QueryProvider>
   );
 }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -1,0 +1,14 @@
+/**
+ * TanStack Query option factories
+ * Centralized query definitions for consistent caching and refetching behavior
+ */
+
+import { queryOptions } from '@tanstack/react-query';
+import { fetchBuildInfo } from './buildInfo';
+
+export const buildInfoQuery = queryOptions({
+  queryKey: ['build-info'],
+  queryFn: fetchBuildInfo,
+  staleTime: 60 * 60 * 1000, // 1 hour - build info rarely changes
+  gcTime: Infinity, // Keep forever - it's small and static
+});

--- a/web/src/pages/About.page.tsx
+++ b/web/src/pages/About.page.tsx
@@ -1,38 +1,10 @@
-import { useEffect, useState } from 'react';
 import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
 import { Alert, Card, Group, Loader, Stack, Text, Title } from '@mantine/core';
-import { BuildInfo, fetchBuildInfo } from '../api/buildInfo';
-
-type LoadState =
-  | { status: 'loading' }
-  | { status: 'loaded'; data: BuildInfo }
-  | { status: 'error'; message: string };
+import { buildInfoQuery } from '../api/queries';
 
 export function AboutPage() {
-  const [state, setState] = useState<LoadState>({ status: 'loading' });
-
-  useEffect(() => {
-    let active = true;
-
-    fetchBuildInfo()
-      .then((data) => {
-        if (active) {
-          setState({ status: 'loaded', data });
-        }
-      })
-      .catch((error: Error) => {
-        if (active) {
-          setState({
-            status: 'error',
-            message: error.message || 'Unable to load build metadata',
-          });
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, []);
+  const { data, isPending, isError, error } = useQuery(buildInfoQuery);
 
   return (
     <Stack gap="md">
@@ -46,7 +18,7 @@ export function AboutPage() {
         backend revision.
       </Text>
 
-      {state.status === 'loading' && (
+      {isPending && (
         <Card shadow="sm" padding="lg" radius="md" withBorder data-testid="build-info-loading">
           <Group gap="sm">
             <Loader size="sm" />
@@ -55,25 +27,25 @@ export function AboutPage() {
         </Card>
       )}
 
-      {state.status === 'error' && (
+      {isError && (
         <Alert
           icon={<IconAlertTriangle size={16} />}
           title="Unable to load build info"
           color="red"
           data-testid="build-info-error"
         >
-          {state.message}
+          {error instanceof Error ? error.message : 'Unable to load build metadata'}
         </Alert>
       )}
 
-      {state.status === 'loaded' && (
+      {data && (
         <Card shadow="sm" padding="lg" radius="md" withBorder>
           <Stack gap="sm">
-            <Metric label="API Version" value={state.data.version} testId="api-version" />
-            <Metric label="Git SHA" value={state.data.gitSha} testId="api-git-sha" />
-            <Metric label="Build time" value={state.data.buildTime} testId="api-build-time" />
-            {state.data.message && (
-              <Metric label="Message" value={state.data.message} testId="api-build-message" />
+            <Metric label="API Version" value={data.version} testId="api-version" />
+            <Metric label="Git SHA" value={data.gitSha} testId="api-git-sha" />
+            <Metric label="Build time" value={data.buildTime} testId="api-build-time" />
+            {data.message && (
+              <Metric label="Message" value={data.message} testId="api-build-message" />
             )}
           </Stack>
         </Card>

--- a/web/src/providers/QueryProvider.tsx
+++ b/web/src/providers/QueryProvider.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000, // 1 minute
+      gcTime: 5 * 60 * 1000, // 5 minutes
+      retry: 1,
+      refetchOnWindowFocus: true,
+    },
+  },
+});
+
+interface QueryProviderProps {
+  children: ReactNode;
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * Export queryClient for use in tests and manual cache operations
+ */
+export { queryClient };

--- a/web/test-utils/render.tsx
+++ b/web/test-utils/render.tsx
@@ -1,11 +1,27 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as testingLibraryRender } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import { mantineTheme } from '../src/theme/mantineTheme';
 
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false, // Don't retry in tests
+        gcTime: Infinity, // Keep cache for test duration
+      },
+    },
+  });
+}
+
 export function render(ui: React.ReactNode) {
+  const testQueryClient = createTestQueryClient();
+
   return testingLibraryRender(ui, {
     wrapper: ({ children }: { children: React.ReactNode }) => (
-      <MantineProvider theme={mantineTheme}>{children}</MantineProvider>
+      <QueryClientProvider client={testQueryClient}>
+        <MantineProvider theme={mantineTheme}>{children}</MantineProvider>
+      </QueryClientProvider>
     ),
   });
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1852,6 +1852,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-core@npm:5.90.12":
+  version: 5.90.12
+  resolution: "@tanstack/query-core@npm:5.90.12"
+  checksum: 10c0/60d5dd23d7801118d6ef84a3d76e798aaf6eb851ee5227629a1dc798fa01ac9560580553413208fcc8a003fb12a89e83d6dd1f38ebc3bd9b6e8838cfaaa45fef
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-devtools@npm:5.91.1":
+  version: 5.91.1
+  resolution: "@tanstack/query-devtools@npm:5.91.1"
+  checksum: 10c0/856d85d249fd46a9f191a345f4446dcfb11a6b48d664f18f5bf480d0802fde5089ca7ae39e26e3445256a13f12f9b77b8639c33ad26c9d1e4b4c56a00fdb9b8c
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query-devtools@npm:^5.91.1":
+  version: 5.91.1
+  resolution: "@tanstack/react-query-devtools@npm:5.91.1"
+  dependencies:
+    "@tanstack/query-devtools": "npm:5.91.1"
+  peerDependencies:
+    "@tanstack/react-query": ^5.90.10
+    react: ^18 || ^19
+  checksum: 10c0/be19d04a292168bf9404f0f98a0e3f95f0340c0e88c838028805578da5c49b014275b1014f7a04f9c865788d96112be001eb72fa8253cadd83b6905f6bd6331e
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.90.12":
+  version: 5.90.12
+  resolution: "@tanstack/react-query@npm:5.90.12"
+  dependencies:
+    "@tanstack/query-core": "npm:5.90.12"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10c0/da01ec2819d301e4be89731e82d3f091fa4f1ab2745be324e5166f9df77e2aaf1c362b0fa61aab226bb01634873f1a00562f7d7f405867fe23bdd47fe4d00fda
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-router@npm:^1.141.1":
   version: 1.141.1
   resolution: "@tanstack/react-router@npm:1.141.1"
@@ -5928,6 +5965,8 @@ __metadata:
     "@storybook/react": "npm:^10.1.7"
     "@storybook/react-vite": "npm:^10.1.7"
     "@tabler/icons-react": "npm:^3.35.0"
+    "@tanstack/react-query": "npm:^5.90.12"
+    "@tanstack/react-query-devtools": "npm:^5.91.1"
     "@tanstack/react-router": "npm:^1.141.1"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"


### PR DESCRIPTION
## Summary

- Add @tanstack/react-query and @tanstack/react-query-devtools dependencies
- Create QueryProvider with sensible defaults (1min staleTime, 5min gcTime)
- Migrate About.page.tsx from manual useState/useEffect to useQuery
- Update test utilities with QueryClientProvider wrapper

## Motivation

Manual data fetching pattern has issues:
- Boilerplate: 3x useState + useEffect + try/catch per query
- No caching: same data fetched repeatedly across navigations
- No background refetch: data goes stale
- Race conditions: cleanup handling error-prone

TanStack Query provides automatic caching, deduplication, background refetching, and declarative loading/error states.

## Changes

| File | Change |
|------|--------|
| `package.json` | Add TanStack Query deps |
| `src/providers/QueryProvider.tsx` | Query client config + devtools |
| `src/App.tsx` | Wrap with QueryProvider |
| `src/api/queries.ts` | Query option factories |
| `src/pages/About.page.tsx` | Migrate to useQuery |
| `test-utils/render.tsx` | Add QueryClientProvider |

## Before/After

**Before (35 lines):**
```typescript
const [state, setState] = useState<LoadState>({ status: 'loading' });
useEffect(() => {
  let active = true;
  fetchBuildInfo().then(data => { if (active) setState({...}) })
    .catch(err => { if (active) setState({...}) });
  return () => { active = false; };
}, []);
```

**After (1 line):**
```typescript
const { data, isPending, isError, error } = useQuery(buildInfoQuery);
```

## Test plan

- [x] `yarn vitest --run` passes
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [ ] Manual test: About page loads build info
- [ ] Manual test: React Query Devtools visible in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)