### PR TITLE
Auto-discover Rust tests with feature-gated integration tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,13 +27,17 @@ default:
 # Backend (Rust) Commands
 # =============================================================================
 
-# Run backend unit tests
+# Run backend unit tests (auto-discovers all tests except integration tests)
 test-backend:
-    cd service && cargo test --test api_tests --test graphql_tests --test model_tests
+    cd service && cargo test
 
 # Run backend unit tests with coverage
 test-backend-cov:
-    cd service && cargo llvm-cov --test api_tests --test graphql_tests --test model_tests
+    cd service && cargo llvm-cov
+
+# Run backend integration tests locally (requires DATABASE_URL)
+test-backend-integration-local:
+    cd service && cargo test --features integration-tests --test integration_tests
 
 # Run backend integration tests via Skaffold (RECOMMENDED - requires Docker + Kubernetes)
 test-backend-integration:

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -37,6 +37,9 @@ hyper = "1.6"
 sqlx-cli = { version = "0.8.6", features = ["postgres"] }
 tower = { version = "0.5", features = ["util"] }
 
+[features]
+integration-tests = []
+
 [[bin]]
 name = "client"
 path = "src/bin/client.rs"

--- a/service/tests/integration_tests.rs
+++ b/service/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration-tests")]
+
 use sqlx_core::{executor::Executor, query::query, query_as::query_as, query_scalar::query_scalar};
 use sqlx_postgres::PgPool;
 use tinycongress_api::db;

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -75,7 +75,7 @@ deploy:
             create: false
 
 # PRE-DEPLOY TESTS (cluster not required)
-# - Rust: unit tests via cargo llvm-cov
+# - Rust: unit tests via cargo llvm-cov (auto-discovers all tests except integration tests)
 # - Web: vitest unit tests
 test:
   - image: tc-api-release
@@ -87,9 +87,6 @@ test:
           cargo llvm-cov --lcov \
             --output-path coverage/backend-unit.lcov \
             --remap-path-prefix \
-            --test api_tests \
-            --test graphql_tests \
-            --test model_tests \
             -- --test-threads=1 --nocapture
   - image: tc-ui-release
     custom:


### PR DESCRIPTION
## Summary
- Enables automatic test discovery to prevent accidentally missing test modules
- Gates integration tests behind `integration-tests` feature flag
- Previously missing `build_info_tests` now run automatically in CI

## Changes
- Added `integration-tests` feature in `Cargo.toml`
- Removed explicit test enumeration from `justfile` and `skaffold.yaml`
- Gated `integration_tests.rs` with `#![cfg(feature = "integration-tests")]`
- Added `test-backend-integration-local` command for local integration testing

## Test Plan
- [x] Verified `just test-backend` runs all unit tests (4 test files, 14 tests total)
- [x] Verified `build_info_tests` now runs automatically (was previously missing)
- [x] Verified integration tests excluded by default (0 tests in `integration_tests.rs`)
- [x] Verified `just test-backend-integration-local` runs integration tests with feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)