### PR TITLE
feat: Add test watch mode commands for development

### DIFF
--- a/docs/playbooks/local-dev-setup.md
+++ b/docs/playbooks/local-dev-setup.md
@@ -136,6 +136,15 @@ just test-frontend   # Vitest
 just test            # Both
 ```
 
+### Watch Mode (Automatic Re-run on File Changes)
+
+```bash
+just test-backend-watch   # Re-runs cargo test on changes
+just test-frontend-watch  # Re-runs vitest on changes
+```
+
+Watch mode automatically re-runs tests when source files change, useful for TDD workflows.
+
 ### Integration Tests (Requires Database)
 
 ```bash
@@ -161,7 +170,8 @@ export DATABASE_URL=postgres://postgres:postgres@localhost:5432/prioritization
 just dev-backend
 
 # Terminal 2: Run tests as you work
-just test-backend
+just test-backend             # Single run
+just test-backend-watch       # Auto re-run on changes
 just lint-backend
 ```
 
@@ -172,7 +182,8 @@ just lint-backend
 just dev-frontend
 
 # In another terminal, run tests
-just test-frontend
+just test-frontend            # Single run
+just test-frontend-watch      # Auto re-run on changes
 just lint-frontend
 ```
 

--- a/justfile
+++ b/justfile
@@ -6,12 +6,14 @@
 #   2. just dev             # Start full-stack dev environment (requires Skaffold + cluster)
 #
 # Local Development (no cluster needed):
-#   - just lint             # Lint all code
-#   - just fmt              # Format all code
-#   - just test-backend     # Run backend unit tests
-#   - just build-backend    # Build backend
-#   - just dev-backend      # Start backend with hot reload
-#   - just dev-frontend     # Start Vite frontend dev server
+#   - just lint                 # Lint all code
+#   - just fmt                  # Format all code
+#   - just test-backend         # Run backend unit tests
+#   - just test-backend-watch   # Run backend tests in watch mode
+#   - just test-frontend-watch  # Run frontend tests in watch mode
+#   - just build-backend        # Build backend
+#   - just dev-backend          # Start backend with hot reload
+#   - just dev-frontend         # Start Vite frontend dev server
 #
 # Full-Stack Testing (requires Docker + Kubernetes):
 #   - just test-full        # Build images, run all tests via Skaffold (mirrors CI)
@@ -30,6 +32,10 @@ default:
 # Run backend unit tests (auto-discovers all tests except integration tests)
 test-backend:
     cd service && cargo test
+
+# Run backend unit tests in watch mode (re-runs on file changes)
+test-backend-watch:
+    cd service && cargo watch -x test
 
 # Run backend unit tests with coverage
 test-backend-cov:


### PR DESCRIPTION
## Summary

- Add `test-backend-watch` recipe to justfile using `cargo watch -x test`
- Document watch mode commands in `docs/playbooks/local-dev-setup.md`
- Update justfile header comments to include watch commands

Closes #94

## Test plan

- [ ] Run `just test-backend-watch` and verify tests re-run on file changes
- [ ] Run `just test-frontend-watch` and verify vitest runs in watch mode
- [ ] Verify `just --list` shows both watch commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

```yaml
# --- Agent Compliance ---
agent_compliance:
  docs_read:
    - AGENTS.md
  constraints_followed: true
  files_modified:
    - justfile
    - docs/playbooks/local-dev-setup.md
  deviations:
    - none
```