### PR TITLE
Add startup probe to deployment for slow-starting pods

### DIFF
--- a/kube/app/templates/deployment.yaml
+++ b/kube/app/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
             - name: BUILD_MESSAGE
               value: {{ .Values.buildInfo.message | quote }}
             {{- end }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /health

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -46,6 +46,14 @@ service:
   type: ClusterIP
   port: 8080
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 60
+  periodSeconds: 10
+  timeoutSeconds: 2
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
## Summary
- Adds a `startupProbe` configuration to the Kubernetes deployment template
- Configures 60 failure attempts with 10 second period (up to 10 minutes startup time)
- Prevents liveness probe from killing slow-starting pods

## Motivation
Pods that perform database migrations or have cold caches on startup may take longer than the default liveness probe timeout allows. The startup probe gives pods extra time to initialize before regular health checks begin.

## Test plan
- [ ] Deploy to test cluster and verify startup probe is applied
- [ ] Verify slow-starting pods are not killed during startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

```yaml
# --- Agent Compliance ---
agent_compliance:
  docs_read:
    - AGENTS.md
  constraints_followed: true
  files_modified:
    - kube/app/templates/deployment.yaml
    - kube/app/values.yaml
  deviations:
    - none
```