### PR TITLE
Add docs/README.md index and consolidate doc placement rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,43 +18,15 @@ This file is a concise index of rules and pointers—not detailed documentation.
 - `web/`: React/Mantine client on Vite. Source under `web/src/`, shared mocks in `web/test-utils/`.
 - `dockerfiles/`, `skaffold.yaml`, `kube/`: Container and Kubernetes assets for CI, integration, and demo environments.
 
-## Working Documents
+## Documentation
 
-| Location | Purpose | Lifecycle |
-|----------|---------|-----------|
-| `.scratch/` | Ephemeral notes, analysis, brainstorming | Delete after task |
-| `.plan/` | Feature specs, tickets for large branches | Remove on merge to master |
-| `docs/` | Accepted documentation only | Permanent |
+See [docs/README.md](docs/README.md) for the full index of playbooks, interfaces, ADRs, checklists, and document placement rules.
 
-See README in each directory for details. Never put scratch/analysis files in `docs/`.
-
-## Documentation (Required Reading)
-Consult these before starting work:
-
-| Directory | Purpose | When to read |
-|-----------|---------|--------------|
-| `docs/playbooks/` | Step-by-step how-to guides | Before any unfamiliar task |
-| `docs/interfaces/` | Contracts, schemas, naming rules | Before writing new code |
-| `docs/decisions/` | ADRs explaining why decisions were made | When questioning existing patterns |
-| `docs/checklists/` | Pre-PR, pre-release, incident checklists | Before opening PRs or deploying |
-| `docs/style/` | UI styling guidelines (Mantine-first) | Before modifying frontend UI |
-| `docs/skills/` | LLM skills for specific tasks | When referenced by other docs |
-
-Key playbooks:
-- `docs/playbooks/local-dev-setup.md` - Development environment options
-- `docs/playbooks/adding-migration.md` - Database changes
-- `docs/playbooks/new-graphql-endpoint.md` - API changes
-- `docs/playbooks/debugging-ci-failure.md` - CI troubleshooting
-
-Key interfaces:
-- `docs/interfaces/environment-variables.md` - Required and optional env vars
-- `docs/interfaces/directory-conventions.md` - Where code lives
-- `docs/interfaces/naming-conventions.md` - How to name things
-- `docs/interfaces/branch-naming-conventions.md` - Branch naming standards
-
-Key style guides:
-- `docs/style/STYLE_GUIDE.md` - Mantine-first styling policy
-- `docs/style/LLM_UI_GUIDE.md` - LLM instructions for UI work
+Key references:
+- `docs/playbooks/` - How-to guides (local-dev-setup, adding-migration, new-graphql-endpoint)
+- `docs/interfaces/` - Contracts and naming conventions
+- `docs/decisions/` - ADRs explaining architectural choices
+- `docs/style/` - UI styling (Mantine-first per ADR-005)
 
 ## Build, Test, and Development Commands
 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ minikube start
 skaffold dev --port-forward
 ```
 
+# Documentation
+
+See [docs/README.md](docs/README.md) for playbooks, interfaces, ADRs, and documentation placement rules.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,93 @@
+# Documentation Index
+
+This directory contains permanent, accepted documentation for TinyCongress.
+
+## Directory Structure
+
+| Directory | Purpose | Audience |
+|-----------|---------|----------|
+| [playbooks/](playbooks/) | Step-by-step how-to guides | Developers performing tasks |
+| [interfaces/](interfaces/) | Contracts, schemas, naming rules | Developers writing new code |
+| [decisions/](decisions/) | ADRs explaining architectural choices | Anyone questioning patterns |
+| [checklists/](checklists/) | Pre-PR, pre-release, incident guides | Developers at checkpoints |
+| [style/](style/) | UI styling guidelines | Frontend developers |
+| [skills/](skills/) | LLM-specific task guides | AI assistants |
+
+## Playbooks
+
+How-to guides for common development tasks:
+
+| Playbook | When to Use |
+|----------|-------------|
+| [local-dev-setup.md](playbooks/local-dev-setup.md) | Setting up development environment |
+| [adding-migration.md](playbooks/adding-migration.md) | Making database schema changes |
+| [new-graphql-endpoint.md](playbooks/new-graphql-endpoint.md) | Adding API endpoints |
+| [debugging-ci-failure.md](playbooks/debugging-ci-failure.md) | Troubleshooting CI issues |
+| [database-schema-change.md](playbooks/database-schema-change.md) | Database migrations workflow |
+| [docker-layer-caching.md](playbooks/docker-layer-caching.md) | Optimizing Docker builds |
+| [dependency-update.md](playbooks/dependency-update.md) | Updating project dependencies |
+| [frontend-test-patterns.md](playbooks/frontend-test-patterns.md) | Writing frontend tests |
+| [graphql-codegen.md](playbooks/graphql-codegen.md) | Generating GraphQL types |
+| [pr-review-checklist.md](playbooks/pr-review-checklist.md) | Reviewing pull requests |
+| [skaffold-profiles.md](playbooks/skaffold-profiles.md) | Using Skaffold profiles |
+
+## Interfaces
+
+Contracts and standards for consistency:
+
+| Interface | Coverage |
+|-----------|----------|
+| [environment-variables.md](interfaces/environment-variables.md) | Required and optional env vars |
+| [directory-conventions.md](interfaces/directory-conventions.md) | Where code lives |
+| [naming-conventions.md](interfaces/naming-conventions.md) | How to name things |
+| [branch-naming-conventions.md](interfaces/branch-naming-conventions.md) | Git branch naming standards |
+| [api-contracts.md](interfaces/api-contracts.md) | API design patterns |
+| [rust-coding-standards.md](interfaces/rust-coding-standards.md) | Rust style guide |
+| [react-coding-standards.md](interfaces/react-coding-standards.md) | React/TypeScript patterns |
+| [signed-envelope-spec.md](interfaces/signed-envelope-spec.md) | Cryptographic envelope format |
+
+## Decisions (ADRs)
+
+Architecture Decision Records explaining why we chose specific approaches:
+
+| ADR | Decision |
+|-----|----------|
+| [001-cargo-chef-docker-builds.md](decisions/001-cargo-chef-docker-builds.md) | Using cargo-chef for Rust Docker builds |
+| [002-skaffold-orchestration.md](decisions/002-skaffold-orchestration.md) | Skaffold for dev/CI orchestration |
+| [003-pgmq-job-queue.md](decisions/003-pgmq-job-queue.md) | PostgreSQL-based job queue |
+| [004-explicit-git-push-branches.md](decisions/004-explicit-git-push-branches.md) | Always specify branch on push |
+| [005-mantine-first-styling.md](decisions/005-mantine-first-styling.md) | Mantine-first styling approach |
+
+## Checklists
+
+Pre-flight checks for critical operations:
+
+- [pre-pr.md](checklists/pre-pr.md) - Before opening a PR
+- [pre-release.md](checklists/pre-release.md) - Before deploying
+- [incident.md](checklists/incident.md) - During incidents
+
+## Style Guides
+
+- [STYLE_GUIDE.md](style/STYLE_GUIDE.md) - Mantine-first styling policy
+- [LLM_UI_GUIDE.md](style/LLM_UI_GUIDE.md) - LLM instructions for UI work
+
+## Related Documentation
+
+- [.plan/](../.plan/) - Ephemeral feature specs and tickets (removed on merge)
+- [.scratch/](../.scratch/) - Temporary working notes (deleted after task)
+- [CLAUDE.md](../CLAUDE.md) - AI assistant instructions and project rules
+
+## Where Documentation Goes
+
+| Document Type | Location | Lifecycle |
+|---------------|----------|-----------|
+| Permanent how-to guides | `docs/playbooks/` | Forever |
+| Standards and contracts | `docs/interfaces/` | Forever |
+| Architecture decisions | `docs/decisions/` | Forever |
+| Pre-flight checklists | `docs/checklists/` | Forever |
+| Styling guidelines | `docs/style/` | Forever |
+| LLM task guides | `docs/skills/` | Forever |
+| Feature specs in progress | `.plan/` | Removed on merge |
+| Working notes and analysis | `.scratch/` | Deleted after task |
+
+**Rule of thumb**: If it belongs in the repo permanently, it goes in `docs/`. If it's temporary working material, use `.plan/` or `.scratch/`.


### PR DESCRIPTION
## Summary

- Creates `docs/README.md` as single source of truth for documentation navigation
- Links to all playbooks, interfaces, ADRs, checklists, and style guides
- Includes "Where Documentation Goes" table with placement rules for `docs/`, `.plan/`, `.scratch/`
- Consolidates duplicated content: CLAUDE.md and README.md now point to docs/README.md

## Test plan

- [ ] Verify all links in docs/README.md resolve correctly
- [ ] Confirm CLAUDE.md is within target line count (~100-150 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)