### PR TITLE
Remove redundant sqlx check from dev Dockerfile

### DIFF
--- a/service/Dockerfile.dev
+++ b/service/Dockerfile.dev
@@ -32,12 +32,6 @@ COPY . .
 
 ENV SQLX_OFFLINE=true
 
-# Check sqlx prepared queries with cache mounts
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
-    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git \
-    --mount=type=cache,target=/usr/src/app/target,id=cargo-target-dev \
-    cargo sqlx prepare --check
-
 # Build with cache mounts for fast incremental compilation
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git \


### PR DESCRIPTION
## Summary
- Removes `cargo sqlx prepare --check` from `Dockerfile.dev`
- This check is redundant with the CI `sqlx-check` job which validates against an actual database
- Speeds up dev image builds without losing safety guarantees

## Test plan
- [ ] Verify dev image still builds successfully
- [ ] Confirm CI `sqlx-check` job still runs and catches issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)