### PR TITLE
Make cargo-machete check blocking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,11 @@ jobs:
 
       - name: Check for unused dependencies
         working-directory: service
-        run: cargo machete
+        run: |
+          if ! cargo machete; then
+            echo "::error::Unused dependencies detected. Remove them or add to Cargo.toml [package.metadata.cargo-machete] ignored list."
+            exit 1
+          fi
 
       # Frontend: vulnerabilities via yarn audit
       - name: Set up Node


### PR DESCRIPTION
## Summary
- Updates security-audit job to fail when unused Rust dependencies are detected
- Adds actionable error message pointing to the ignore list option

## Test plan
- [ ] CI passes (no unused dependencies currently exist)
- [ ] Verify blocking behavior by temporarily adding an unused dep (optional)

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)