### PR TITLE
Add security headers middleware (CSP, HSTS, X-Frame-Options)

### DIFF
--- a/docs/interfaces/environment-variables.md
+++ b/docs/interfaces/environment-variables.md
@@ -51,6 +51,40 @@ TC_CORS__ALLOWED_ORIGINS=https://app.example.com
 TC_CORS__ALLOWED_ORIGINS=*
 ```
 
+### Security Headers Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TC_SECURITY_HEADERS__ENABLED` | No | `true` | Enable security headers |
+| `TC_SECURITY_HEADERS__HSTS_ENABLED` | No | `false` | Enable HSTS (use with HTTPS only) |
+| `TC_SECURITY_HEADERS__HSTS_MAX_AGE` | No | `31536000` | HSTS max-age in seconds (1 year) |
+| `TC_SECURITY_HEADERS__HSTS_INCLUDE_SUBDOMAINS` | No | `true` | Include subdomains in HSTS |
+| `TC_SECURITY_HEADERS__FRAME_OPTIONS` | No | `DENY` | X-Frame-Options (`DENY` or `SAMEORIGIN`) |
+| `TC_SECURITY_HEADERS__CONTENT_SECURITY_POLICY` | No | `default-src 'self'` | Content-Security-Policy header value |
+| `TC_SECURITY_HEADERS__REFERRER_POLICY` | No | `strict-origin-when-cross-origin` | Referrer-Policy header value |
+
+**Security note:** Security headers are enabled by default with safe values. HSTS is disabled by default since it requires HTTPS.
+
+Headers applied (when enabled):
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY` (configurable)
+- `X-XSS-Protection: 1; mode=block`
+- `Content-Security-Policy: default-src 'self'` (configurable)
+- `Referrer-Policy: strict-origin-when-cross-origin` (configurable)
+- `Strict-Transport-Security` (only if `hsts_enabled: true`)
+
+Examples:
+```bash
+# Production with HSTS
+TC_SECURITY_HEADERS__HSTS_ENABLED=true
+
+# Allow iframes from same origin
+TC_SECURITY_HEADERS__FRAME_OPTIONS=SAMEORIGIN
+
+# Custom CSP for frontend compatibility
+TC_SECURITY_HEADERS__CONTENT_SECURITY_POLICY="default-src 'self'; script-src 'self' 'unsafe-inline'"
+```
+
 ### Build Info (unchanged)
 
 | Variable | Default | Description |

--- a/service/config.yaml.example
+++ b/service/config.yaml.example
@@ -28,3 +28,22 @@ cors:
   allowed_origins:
     - http://localhost:5173
     - http://127.0.0.1:5173
+
+# Security headers configuration
+# These headers provide defense-in-depth against common web vulnerabilities
+security_headers:
+  # Enable security headers (default: true)
+  enabled: true
+  # HSTS - only enable in production with HTTPS (default: false)
+  hsts_enabled: false
+  # HSTS max-age in seconds (default: 31536000 = 1 year)
+  hsts_max_age: 31536000
+  # Include subdomains in HSTS (default: true)
+  hsts_include_subdomains: true
+  # X-Frame-Options: DENY or SAMEORIGIN (default: DENY)
+  frame_options: DENY
+  # Content-Security-Policy (default: "default-src 'self'")
+  # For frontend compatibility, you may need to adjust this
+  content_security_policy: "default-src 'self'"
+  # Referrer-Policy (default: strict-origin-when-cross-origin)
+  referrer_policy: strict-origin-when-cross-origin

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -9,15 +9,23 @@
 
 use async_graphql::{EmptySubscription, Schema};
 use axum::{
-    http::{header::HeaderValue, Method, StatusCode},
-    response::IntoResponse,
+    extract::Request,
+    http::{
+        header::{
+            HeaderName, HeaderValue, CONTENT_SECURITY_POLICY, REFERRER_POLICY,
+            STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION,
+        },
+        Method, StatusCode,
+    },
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
     routing::get,
     Extension, Router,
 };
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 use tinycongress_api::{
     build_info::BuildInfoProvider,
-    config::Config,
+    config::{Config, SecurityHeadersConfig},
     db::setup_database,
     graphql::{graphql_handler, graphql_playground, MutationRoot, QueryRoot},
 };
@@ -26,6 +34,60 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 // Health check handler
 async fn health_check() -> impl IntoResponse {
     StatusCode::OK
+}
+
+/// Build security headers from configuration.
+fn build_security_headers(config: &SecurityHeadersConfig) -> Arc<Vec<(HeaderName, HeaderValue)>> {
+    let mut headers = Vec::new();
+
+    // X-Content-Type-Options: nosniff (always)
+    headers.push((X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff")));
+
+    // X-Frame-Options
+    if let Ok(value) = HeaderValue::from_str(&config.frame_options) {
+        headers.push((X_FRAME_OPTIONS, value));
+    }
+
+    // X-XSS-Protection (legacy but still useful for older browsers)
+    headers.push((X_XSS_PROTECTION, HeaderValue::from_static("1; mode=block")));
+
+    // Content-Security-Policy
+    if let Ok(value) = HeaderValue::from_str(&config.content_security_policy) {
+        headers.push((CONTENT_SECURITY_POLICY, value));
+    }
+
+    // Referrer-Policy
+    if let Ok(value) = HeaderValue::from_str(&config.referrer_policy) {
+        headers.push((REFERRER_POLICY, value));
+    }
+
+    // HSTS (only if enabled - should only be used with HTTPS)
+    if config.hsts_enabled {
+        let hsts_value = if config.hsts_include_subdomains {
+            format!("max-age={}; includeSubDomains", config.hsts_max_age)
+        } else {
+            format!("max-age={}", config.hsts_max_age)
+        };
+        if let Ok(value) = HeaderValue::from_str(&hsts_value) {
+            headers.push((STRICT_TRANSPORT_SECURITY, value));
+        }
+    }
+
+    Arc::new(headers)
+}
+
+/// Middleware to add security headers to all responses.
+async fn security_headers_middleware(
+    Extension(headers): Extension<Arc<Vec<(HeaderName, HeaderValue)>>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let mut response = next.run(request).await;
+    let response_headers = response.headers_mut();
+    for (name, value) in headers.iter() {
+        response_headers.insert(name.clone(), value.clone());
+    }
+    response
 }
 
 #[tokio::main]
@@ -81,8 +143,17 @@ async fn main() -> Result<(), anyhow::Error> {
         AllowOrigin::list(origins)
     };
 
+    // Build security headers layer if enabled
+    let security_headers = if config.security_headers.enabled {
+        tracing::info!("Security headers enabled");
+        Some(build_security_headers(&config.security_headers))
+    } else {
+        tracing::info!("Security headers disabled");
+        None
+    };
+
     // Build the API
-    let app = Router::new()
+    let mut app = Router::new()
         // GraphQL routes
         .route("/graphql", get(graphql_playground).post(graphql_handler))
         // Health check route
@@ -96,6 +167,13 @@ async fn main() -> Result<(), anyhow::Error> {
                 .allow_headers(Any)
                 .allow_origin(allow_origin),
         );
+
+    // Add security headers middleware if enabled
+    if let Some(headers) = security_headers {
+        app = app
+            .layer(middleware::from_fn(security_headers_middleware))
+            .layer(Extension(headers));
+    }
 
     // Start the server
     let addr = SocketAddr::from(([0, 0, 0, 0], config.server.port));


### PR DESCRIPTION
## Summary
- Adds configurable security headers middleware to the Axum router
- Implements all OWASP-recommended headers with safe defaults
- Headers are fully configurable via environment variables or config.yaml
- HSTS disabled by default (requires HTTPS to be useful)

### Headers Applied
| Header | Default Value |
|--------|---------------|
| X-Content-Type-Options | `nosniff` |
| X-Frame-Options | `DENY` |
| X-XSS-Protection | `1; mode=block` |
| Content-Security-Policy | `default-src 'self'` |
| Referrer-Policy | `strict-origin-when-cross-origin` |
| Strict-Transport-Security | disabled by default |

### Configuration
All settings available via `TC_SECURITY_HEADERS__*` environment variables or `security_headers:` in config.yaml.

## Test plan
- [x] Backend linting passes
- [x] Backend unit tests pass
- [ ] CI passes
- [ ] Verify headers in browser DevTools after deployment

## Acceptance Criteria
- [x] Security headers middleware added to Axum router
- [x] Headers configurable via environment/config
- [x] CSP policy reviewed for frontend compatibility (default `'self'` may need adjustment)
- [ ] Headers verified in browser DevTools

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)