### PR TITLE
Document secure defaults and fail-safe configuration policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Additional notes:
 - Keep secrets out of version control; export `DATABASE_URL` and queue settings locally and in CI.
 - Backend tests use testcontainers for DB isolation. Run `just build-test-postgres` once to build the custom image.
 - Align Docker tags with `skaffold.yaml` profiles so preview, test, and prod images stay consistent.
+- Follow the secure defaults policy (`docs/interfaces/secure-defaults.md`) when adding configuration options.
 
 ## Prohibited Actions (Hard Constraints)
 - DO NOT modify files outside `service/`, `web/`, `kube/`, `dockerfiles/`, `docs/`, or repo root configs

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Contracts and standards for consistency:
 | [react-coding-standards.md](interfaces/react-coding-standards.md) | React/TypeScript patterns |
 | [signed-envelope-spec.md](interfaces/signed-envelope-spec.md) | Cryptographic envelope format |
 | [ticket-management.md](interfaces/ticket-management.md) | Issue labeling and lifecycle |
+| [secure-defaults.md](interfaces/secure-defaults.md) | Security configuration policy |
 
 ## Decisions (ADRs)
 

--- a/docs/interfaces/secure-defaults.md
+++ b/docs/interfaces/secure-defaults.md
@@ -1,0 +1,174 @@
+# Secure Defaults Policy
+
+This document establishes the security configuration policy for TinyCongress. All configuration defaults must follow these principles.
+
+## Core Principles
+
+### 1. Deny by Default
+
+Security-sensitive features default to the most restrictive option, not the most permissive.
+
+```rust
+// BAD: Defaults to permissive
+fn default_allowed_origins() -> Vec<String> {
+    vec!["*".into()]  // Allows any origin - security risk
+}
+
+// GOOD: Defaults to restrictive
+fn default_allowed_origins() -> Vec<String> {
+    vec![]  // Blocks all cross-origin requests until explicitly configured
+}
+```
+
+### 2. Explicit Opt-In
+
+Permissive or dangerous settings require explicit configuration. Users must consciously choose to reduce security.
+
+```yaml
+# Production-safe by default - no action needed
+cors:
+  allowed_origins: []  # Default: blocks all
+
+# Explicit opt-in required for permissive behavior
+cors:
+  allowed_origins:
+    - https://app.example.com
+```
+
+### 3. Loud Failures
+
+Misconfiguration should fail visibly at startup, not silently degrade security at runtime.
+
+```rust
+// BAD: Silent fallback
+let origins = config.cors.allowed_origins.unwrap_or(vec!["*".into()]);
+
+// GOOD: Fail-fast with clear error
+if config.database.url.is_empty() {
+    return Err(ConfigError::Validation(
+        "database.url is required. Set TC_DATABASE__URL environment variable.".into(),
+    ));
+}
+```
+
+### 4. Dev vs Prod Separation
+
+Development conveniences belong in example config files, not compiled defaults.
+
+| File | Purpose | Checked In |
+|------|---------|------------|
+| `config.yaml.example` | Development-friendly defaults | Yes |
+| `config.yaml` | Local dev config | No (gitignored) |
+| Environment variables | Production overrides | N/A |
+| Kubernetes secrets | Sensitive production values | No |
+
+## Configuration Categories
+
+| Category | Default Behavior | Rationale |
+|----------|------------------|-----------|
+| CORS origins | Empty (block all) | Prevents CSRF, restricts API access |
+| Debug logging | `info` level | Avoids leaking sensitive data |
+| Database URL | Required (no default) | Forces explicit connection config |
+| Server port | `8080` | Non-privileged port, standard for containers |
+| TLS verification | Enabled | Prevents MITM attacks |
+| Rate limiting | Enabled with conservative limits | Prevents DoS (when implemented) |
+| Authentication | Required | Prevents unauthorized access (when implemented) |
+
+## Implementation Checklist
+
+When adding new configuration options:
+
+- [ ] Default to the most restrictive secure value
+- [ ] Require explicit opt-in for permissive settings
+- [ ] Add validation that fails fast on invalid values
+- [ ] Document the default and security implications
+- [ ] Add development-friendly values to `config.yaml.example`
+- [ ] Update `docs/interfaces/environment-variables.md`
+
+## Current Implementations
+
+### CORS (Implemented)
+
+**Default:** Empty list (blocks all cross-origin requests)
+
+```rust
+fn default_allowed_origins() -> Vec<String> {
+    vec![]  // Safe default - configure explicitly
+}
+```
+
+**Warning on permissive config:**
+```rust
+if cors_origins.iter().any(|o| o == "*") {
+    tracing::warn!("CORS configured to allow any origin - not recommended for production");
+}
+```
+
+See: `service/src/config.rs`, PR #97
+
+### Database Connection (Implemented)
+
+**Default:** No default (required)
+
+Validation fails immediately if `database.url` is empty or not a valid PostgreSQL URL.
+
+```rust
+if self.database.url.is_empty() {
+    return Err(ConfigError::Validation(
+        "database.url is required. Set TC_DATABASE__URL environment variable.".into(),
+    ));
+}
+```
+
+### Logging Level (Implemented)
+
+**Default:** `info`
+
+Production-safe default that avoids verbose debug output which might leak sensitive information.
+
+## Anti-Patterns to Avoid
+
+### 1. Permissive Defaults
+
+```rust
+// AVOID: Makes insecure the path of least resistance
+fn default_rate_limit() -> u32 {
+    0  // Disabled by default
+}
+```
+
+### 2. Silent Degradation
+
+```rust
+// AVOID: Hides misconfiguration
+let pool_size = config.max_connections.unwrap_or(100);  // Silent fallback
+```
+
+### 3. Development Defaults in Code
+
+```rust
+// AVOID: Development convenience compiled into production
+fn default_log_level() -> String {
+    "debug".to_string()  // Too verbose for production
+}
+```
+
+### 4. Optional Security Features
+
+```rust
+// AVOID: Security should not be optional
+#[serde(default)]
+pub enable_auth: bool,  // Defaults to false
+```
+
+## References
+
+- [OWASP Secure Configuration Guidelines](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/)
+- PR #97 - CORS origin restriction (established this pattern)
+- `docs/interfaces/environment-variables.md` - Configuration reference
+
+## See Also
+
+- `service/src/config.rs` - Configuration implementation
+- `service/config.yaml.example` - Development configuration template
+- `CLAUDE.md` - Repository guidelines


### PR DESCRIPTION
## Summary
- Creates `docs/interfaces/secure-defaults.md` establishing security configuration policy
- Adds cross-reference from CLAUDE.md/AGENTS.md
- Updates docs/README.md index

### Policy Principles
1. **Deny by default** - Security features default to most restrictive
2. **Explicit opt-in** - Permissive settings require explicit configuration
3. **Loud failures** - Misconfiguration fails at startup, not silently at runtime
4. **Dev vs Prod separation** - Dev conveniences in example files, not defaults

## Test plan
- [x] Documentation is accurate and follows existing patterns
- [x] Cross-references are valid
- [ ] CI passes

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)