### PR TITLE
Remove VS Code IDE setup section

### DIFF
--- a/docs/playbooks/local-dev-setup.md
+++ b/docs/playbooks/local-dev-setup.md
@@ -260,24 +260,6 @@ cargo run --release
 
 Or use `mold` linker (Linux) / `zld` (macOS).
 
-## IDE Setup
-
-### VS Code
-
-Recommended extensions:
-- rust-analyzer (Rust)
-- ESLint, Prettier (TypeScript)
-- GraphQL (schema highlighting)
-
-### Settings
-
-```json
-{
-  "rust-analyzer.cargo.features": "all",
-  "editor.formatOnSave": true
-}
-```
-
 ## See also
 
 - `docs/interfaces/environment-variables.md` - All env vars


### PR DESCRIPTION
## Summary
- Removes editor-specific VS Code configuration from local-dev-setup playbook
- Developers can configure their preferred editor independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)