### PR TITLE
Add Storybook build to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,42 @@ jobs:
         run: just lint-frontend
 
   # ============================================================
+  # JOB 0b2: Build Storybook
+  # ============================================================
+  storybook-build:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: web/.nvmrc
+          cache: yarn
+          cache-dependency-path: web/yarn.lock
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install dependencies
+        run: just install-frontend
+
+      - name: Build Storybook
+        run: just storybook-build
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: storybook-static
+          path: web/storybook-static/
+          retention-days: 30
+
+  # ============================================================
   # JOB 0c: Verify GraphQL codegen is up-to-date
   # ============================================================
   codegen-check:
@@ -369,6 +405,7 @@ jobs:
       - scan-images
       - lint
       - lint-web
+      - storybook-build
       - codegen-check
       - sqlx-check
       - security-audit


### PR DESCRIPTION
- Add new storybook-build job that runs in parallel with lint jobs
- Build output uploaded as storybook-static artifact (30 day retention)
- Build failures block integration tests via needs dependency

Closes #179

## Context

## Changes made
-

## Testing
- [ ] `cargo test`
- [ ] `yarn test`
- [ ] Other (specify)

## Linked Issue
- Closes #

## AI tooling used
