### PR TITLE
feat: Publish CI artifacts to GitHub Pages with PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,3 +714,167 @@ jobs:
           kubectl get events -A --sort-by=.lastTimestamp || true
           echo '--- All Resources ---'
           kubectl get all -n default || true
+
+  # ============================================================
+  # JOB 3: Deploy reports to GitHub Pages
+  # ============================================================
+  deploy-pages:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [integration-tests, storybook-build]
+    if: always() && needs.integration-tests.result != 'cancelled'
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      PAGES_BASE_URL: https://icook.github.io/tiny-congress
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-report
+          path: artifacts/coverage
+        continue-on-error: true
+
+      - name: Download Storybook
+        uses: actions/download-artifact@v6
+        with:
+          name: storybook-static
+          path: artifacts/storybook
+        continue-on-error: true
+
+      - name: Download Playwright report
+        uses: actions/download-artifact@v6
+        with:
+          name: playwright-test-results
+          path: artifacts/playwright
+        continue-on-error: true
+
+      - name: Determine deployment paths
+        id: paths
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "base_path=pr/${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+            echo "base_path=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare deployment directory
+        run: |
+          set -euo pipefail
+          BASE_PATH="${{ steps.paths.outputs.base_path }}"
+
+          # For PRs, clean the PR-specific directory; for main, clean root reports
+          if [ -n "$BASE_PATH" ]; then
+            rm -rf "$BASE_PATH"
+            mkdir -p "$BASE_PATH"
+          fi
+
+          # Copy artifacts to appropriate locations
+          if [ -d artifacts/coverage ]; then
+            if [ -n "$BASE_PATH" ]; then
+              cp -r artifacts/coverage "$BASE_PATH/coverage"
+            else
+              rm -rf coverage
+              cp -r artifacts/coverage coverage
+            fi
+          fi
+
+          if [ -d artifacts/storybook ]; then
+            if [ -n "$BASE_PATH" ]; then
+              cp -r artifacts/storybook "$BASE_PATH/storybook"
+            else
+              rm -rf storybook
+              cp -r artifacts/storybook storybook
+            fi
+          fi
+
+          if [ -d artifacts/playwright ]; then
+            # Playwright report is in playwright-report subdirectory
+            if [ -d artifacts/playwright/playwright-report ]; then
+              if [ -n "$BASE_PATH" ]; then
+                cp -r artifacts/playwright/playwright-report "$BASE_PATH/playwright"
+              else
+                rm -rf playwright
+                cp -r artifacts/playwright/playwright-report playwright
+              fi
+            fi
+          fi
+
+          # Clean up artifacts directory
+          rm -rf artifacts
+
+          # Generate index page for PR previews
+          if [ -n "$BASE_PATH" ]; then
+            cat > "$BASE_PATH/index.html" <<EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>PR #${{ steps.paths.outputs.pr_number }} Reports</title>
+            <style>
+              body { font-family: system-ui, sans-serif; max-width: 600px; margin: 50px auto; padding: 20px; }
+              h1 { color: #333; }
+              ul { list-style: none; padding: 0; }
+              li { margin: 10px 0; }
+              a { color: #0066cc; text-decoration: none; padding: 10px 15px; display: inline-block; background: #f5f5f5; border-radius: 5px; }
+              a:hover { background: #e5e5e5; }
+              .timestamp { color: #666; font-size: 0.9em; margin-top: 20px; }
+            </style>
+          </head>
+          <body>
+            <h1>PR #${{ steps.paths.outputs.pr_number }} Reports</h1>
+            <ul>
+              <li><a href="coverage/">📊 Coverage Report</a></li>
+              <li><a href="storybook/">📚 Storybook</a></li>
+              <li><a href="playwright/">🎭 Playwright Report</a></li>
+            </ul>
+            <p class="timestamp">Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")</p>
+          </body>
+          </html>
+          EOF
+          fi
+
+      - name: Commit and push to gh-pages
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to deploy"
+            exit 0
+          fi
+
+          if [ "${{ steps.paths.outputs.is_pr }}" = "true" ]; then
+            git commit -m "Deploy PR #${{ steps.paths.outputs.pr_number }} reports"
+          else
+            git commit -m "Deploy main branch reports from ${{ github.sha }}"
+          fi
+
+          git push origin gh-pages
+
+      - name: Add PR comment with report links
+        if: steps.paths.outputs.is_pr == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pages-reports
+          message: |
+            ## 📊 CI Reports
+
+            | Report | Link |
+            |--------|------|
+            | 📊 Coverage | [${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/coverage/](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/coverage/) |
+            | 📚 Storybook | [${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/storybook/](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/storybook/) |
+            | 🎭 Playwright | [${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/playwright/](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/playwright/) |
+
+            <sub>🤖 Reports auto-generated from commit ${{ github.sha }}</sub>

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,0 +1,42 @@
+name: Cleanup PR Previews
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Remove PR preview from GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove PR directory
+        run: |
+          set -euo pipefail
+          PR_DIR="pr/${{ github.event.pull_request.number }}"
+
+          if [ -d "$PR_DIR" ]; then
+            echo "Removing $PR_DIR"
+            rm -rf "$PR_DIR"
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git add -A
+            if ! git diff --staged --quiet; then
+              git commit -m "Cleanup: Remove PR #${{ github.event.pull_request.number }} preview"
+              git push origin gh-pages
+              echo "Successfully removed PR #${{ github.event.pull_request.number }} preview"
+            else
+              echo "No changes to commit (directory may have been empty)"
+            fi
+          else
+            echo "PR directory $PR_DIR does not exist, nothing to clean up"
+          fi


### PR DESCRIPTION
## Summary

Implements Option B from #178:

- **GitHub Pages deployment**: Publishes coverage reports, Storybook, and Playwright reports to `gh-pages` branch
- **PR previews**: Each PR gets its own preview at `/pr/<number>/` with an index page linking to all reports
- **Main branch reports**: Merges to main publish to root paths (`/coverage/`, `/storybook/`, `/playwright/`)
- **Sticky PR comments**: Automatically adds/updates a comment on PRs with direct links to deployed reports
- **Cleanup automation**: Removes PR preview directories when PRs are closed/merged

### New workflows/jobs added

| Workflow | Description |
|----------|-------------|
| `deploy-pages` (in ci.yml) | Deploys reports after integration tests complete |
| `cleanup-pr-previews.yml` | Removes PR directories from gh-pages on PR close |

### Report URLs

- Main: `https://icook.github.io/tiny-congress/coverage/`, `/storybook/`, `/playwright/`
- PRs: `https://icook.github.io/tiny-congress/pr/<number>/`

## Test plan

- [ ] CI workflow completes successfully
- [ ] Reports are deployed to gh-pages branch
- [ ] PR comment is added with correct links
- [ ] Links in PR comment resolve to deployed reports
- [ ] On PR close, cleanup workflow removes the PR directory

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)