### PR TITLE
feat(security): Disable GraphQL Playground and Swagger UI by default

### DIFF
--- a/docs/interfaces/environment-variables.md
+++ b/docs/interfaces/environment-variables.md
@@ -85,6 +85,34 @@ TC_SECURITY_HEADERS__FRAME_OPTIONS=SAMEORIGIN
 TC_SECURITY_HEADERS__CONTENT_SECURITY_POLICY="default-src 'self'; script-src 'self' 'unsafe-inline'"
 ```
 
+### GraphQL Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TC_GRAPHQL__PLAYGROUND_ENABLED` | No | `false` | Enable GraphQL Playground UI at `/graphql` (GET) |
+
+**Security note:** GraphQL Playground is disabled by default for security. It exposes the full API schema and provides an interactive interface that could help attackers. Enable only in development environments.
+
+Examples:
+```bash
+# Enable for local development
+TC_GRAPHQL__PLAYGROUND_ENABLED=true
+```
+
+### Swagger UI Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TC_SWAGGER__ENABLED` | No | `false` | Enable Swagger UI at `/swagger-ui` |
+
+**Security note:** Swagger UI is disabled by default for security. It exposes REST API documentation. Enable only in development environments.
+
+Examples:
+```bash
+# Enable for local development
+TC_SWAGGER__ENABLED=true
+```
+
 ### Build Info (unchanged)
 
 | Variable | Default | Description |

--- a/kube/app/templates/deployment.yaml
+++ b/kube/app/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
               value: "8080"
             - name: TC_CORS__ALLOWED_ORIGINS
               value: {{ .Values.cors.allowedOrigins | default "http://localhost:5173,http://127.0.0.1:5173" | quote }}
+            - name: TC_GRAPHQL__PLAYGROUND_ENABLED
+              value: {{ .Values.graphql.playgroundEnabled | default false | quote }}
+            - name: TC_SWAGGER__ENABLED
+              value: {{ .Values.swagger.enabled | default false | quote }}
             - name: APP_VERSION
               value: {{ default .Values.image.tag .Values.buildInfo.appVersion | quote }}
             - name: GIT_SHA

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -27,6 +27,20 @@ cors:
   # Empty by default (blocks all cross-origin requests) - must be explicitly configured
   allowedOrigins: ""
 
+# GraphQL configuration
+graphql:
+  # Enable GraphQL Playground UI at /graphql (GET)
+  # Default: false (disabled for security - exposes schema)
+  # Enable for local development via skaffold.yaml setValues
+  playgroundEnabled: false
+
+# Swagger UI configuration
+swagger:
+  # Enable Swagger UI at /swagger-ui
+  # Default: false (disabled for security - exposes API documentation)
+  # Enable for local development via skaffold.yaml setValues
+  enabled: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -20,6 +20,10 @@ pub struct Config {
     pub cors: CorsConfig,
     #[serde(default)]
     pub security_headers: SecurityHeadersConfig,
+    #[serde(default)]
+    pub graphql: GraphQLConfig,
+    #[serde(default)]
+    pub swagger: SwaggerConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -177,6 +181,24 @@ impl Default for SecurityHeadersConfig {
     }
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct GraphQLConfig {
+    /// Enable GraphQL Playground UI at /graphql (GET).
+    /// Default: false (disabled for security - exposes schema to potential attackers).
+    /// Enable in development via `TC_GRAPHQL__PLAYGROUND_ENABLED=true`
+    #[serde(default)]
+    pub playground_enabled: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct SwaggerConfig {
+    /// Enable Swagger UI at /swagger-ui.
+    /// Default: false (disabled for security - exposes API documentation).
+    /// Enable in development via `TC_SWAGGER__ENABLED=true`
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -194,6 +216,8 @@ impl Default for Config {
             },
             cors: CorsConfig::default(),
             security_headers: SecurityHeadersConfig::default(),
+            graphql: GraphQLConfig::default(),
+            swagger: SwaggerConfig::default(),
         }
     }
 }
@@ -414,5 +438,31 @@ mod tests {
         let json = r#"{"allowed_origins": ""}"#;
         let config: CorsConfig = serde_json::from_str(json).expect("should parse");
         assert!(config.allowed_origins.is_empty());
+    }
+
+    #[test]
+    fn test_graphql_playground_disabled_by_default() {
+        let config = GraphQLConfig::default();
+        assert!(!config.playground_enabled);
+    }
+
+    #[test]
+    fn test_graphql_playground_can_be_enabled() {
+        let json = r#"{"playground_enabled": true}"#;
+        let config: GraphQLConfig = serde_json::from_str(json).expect("should parse");
+        assert!(config.playground_enabled);
+    }
+
+    #[test]
+    fn test_swagger_disabled_by_default() {
+        let config = SwaggerConfig::default();
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn test_swagger_can_be_enabled() {
+        let json = r#"{"enabled": true}"#;
+        let config: SwaggerConfig = serde_json::from_str(json).expect("should parse");
+        assert!(config.enabled);
     }
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -76,6 +76,11 @@ deploy:
             create: false
           cargoCache:
             enabled: true
+          # Enable dev tools in local development (disabled by default for security)
+          graphql:
+            playgroundEnabled: true
+          swagger:
+            enabled: true
 
 # PRE-DEPLOY TESTS (cluster not required)
 # - Rust: unit tests via cargo llvm-cov (auto-discovers all tests except integration tests)


### PR DESCRIPTION
## Summary

- Add `TC_GRAPHQL__PLAYGROUND_ENABLED` config option (default: false)
- Add `TC_SWAGGER__ENABLED` config option (default: false)
- Conditionally register routes based on configuration
- Enable both tools in local development via skaffold.yaml

## Why

GraphQL Playground and Swagger UI expose API schema and documentation that could help attackers. Following security best practices, these dev tools should be opt-in for production deployments.

## Changes

- **service/src/config.rs**: New `GraphQLConfig` and `SwaggerConfig` structs with tests
- **service/src/main.rs**: Conditional route registration based on config
- **kube/app/templates/deployment.yaml**: New env vars for K8s deployments
- **kube/app/values.yaml**: Default values (both disabled)
- **skaffold.yaml**: Enable both for local development
- **docs/interfaces/environment-variables.md**: Document new options

## Test plan

- [x] All 23 library tests pass
- [x] All 12 API tests pass
- [x] Backend linting passes
- [x] `/graphql` POST endpoint works regardless of playground setting
- [x] Playground accessible when `TC_GRAPHQL__PLAYGROUND_ENABLED=true`
- [x] Swagger UI accessible when `TC_SWAGGER__ENABLED=true`

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)