### PR TITLE
fix: Generate Rust backend coverage in CI workflow (#200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,14 @@ jobs:
           set -euo pipefail
           skaffold test -p ${SKAFFOLD_PROFILE} --build-artifacts "${{ steps.artifacts.outputs.file }}"
 
+      - name: Generate Rust coverage
+        env:
+          TEST_POSTGRES_IMAGE: ${{ env.REGISTRY }}/postgres:${{ github.sha }}
+        working-directory: service
+        run: |
+          set -euo pipefail
+          cargo llvm-cov --lcov --output-path coverage/backend-unit.lcov
+
       - name: Upload Vitest coverage
         if: always()
         uses: actions/upload-artifact@v6

--- a/justfile
+++ b/justfile
@@ -37,9 +37,10 @@ test-backend: _ensure-test-postgres
 test-backend-watch: _ensure-test-postgres
     cd service && cargo watch -x test
 
-# Run backend unit tests with coverage
+# Run backend unit tests with coverage (generates LCOV for unified report)
 test-backend-cov: _ensure-test-postgres
-    cd service && cargo llvm-cov
+    mkdir -p service/coverage
+    cd service && cargo llvm-cov --lcov --output-path coverage/backend-unit.lcov
 
 # Build postgres image for testcontainers
 build-test-postgres:


### PR DESCRIPTION
## Summary

- Adds missing `cargo llvm-cov` step to generate LCOV coverage data for Rust backend
- Updates `justfile` recipe `test-backend-cov` to output LCOV format for local testing

## Problem

The unified coverage report was missing Rust backend coverage because:
1. The CI workflow installed `cargo-llvm-cov` but never ran it
2. No LCOV file was being generated at `service/coverage/backend-unit.lcov`
3. The `build-coverage-report.mjs` script correctly skipped Rust coverage since the file didn't exist

## Solution

Add a new "Generate Rust coverage" step after Skaffold tests that:
- Sets `TEST_POSTGRES_IMAGE` env var for testcontainers
- Runs `cargo llvm-cov --lcov --output-path coverage/backend-unit.lcov` from the service directory
- Outputs to the path expected by `build-coverage-report.mjs`

## Test plan

- [ ] CI workflow runs successfully
- [ ] Rust coverage LCOV file is generated
- [ ] Unified coverage report includes Rust backend section
- [ ] Coverage summary shows Rust line/function percentages

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)