### PR TITLE
Add schema links to GitHub Pages PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,5 +886,6 @@ jobs:
             | 📊 Coverage | [${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/coverage/](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/coverage/) |
             | 📚 Storybook | [${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/storybook/](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/storybook/) |
             | 🎭 Playwright | [${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/playwright/](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/playwright/) |
+            | 📋 API Schemas | [GraphQL](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/coverage/schemas/graphql-viewer.html) · [OpenAPI](${{ env.PAGES_BASE_URL }}/pr/${{ steps.paths.outputs.pr_number }}/coverage/schemas/swagger-ui.html) |
 
             <sub>🤖 Reports auto-generated from commit ${{ github.sha }}</sub>


### PR DESCRIPTION
## Summary

- Adds a new "API Schemas" row to the PR comment table with links to interactive schema viewers
- Links to both GraphQL viewer and OpenAPI/Swagger UI

## Changes

The deploy-pages job PR comment now includes:
```markdown
| 📋 API Schemas | [GraphQL](url) · [OpenAPI](url) |
```

## Test Plan

- [ ] Verify PR comment includes the new API Schemas row
- [ ] Verify GraphQL viewer link works (points to `/coverage/schemas/graphql-viewer.html`)
- [ ] Verify OpenAPI viewer link works (points to `/coverage/schemas/swagger-ui.html`)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)