### PR TITLE
Standardize frontend test patterns

### DIFF
--- a/docs/interfaces/react-coding-standards.md
+++ b/docs/interfaces/react-coding-standards.md
@@ -326,6 +326,8 @@ test('displays fallback on error', () => {
 
 ### Query Key Testing
 
+`@test-utils` `render` supports Testing Library render options, including `wrapper`, for extra providers.
+
 Mock or use testing utilities for TanStack Query:
 
 ```tsx

--- a/docs/playbooks/frontend-test-patterns.md
+++ b/docs/playbooks/frontend-test-patterns.md
@@ -13,10 +13,11 @@
 | E2E | Playwright | `web/tests/` | `just test-frontend-e2e` |
 
 ## Vitest patterns
+Use `@test-utils` for `render`, `screen`, and `userEvent` so Mantine and Query providers are included.
 
 ### Basic component test
 ```typescript
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@test-utils';
 import { MyComponent } from './MyComponent';
 
 describe('MyComponent', () => {
@@ -29,8 +30,7 @@ describe('MyComponent', () => {
 
 ### With user interaction
 ```typescript
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, userEvent } from '@test-utils';
 
 it('handles click', async () => {
   const user = userEvent.setup();
@@ -50,17 +50,12 @@ vi.mock('@/hooks/useApi', () => ({
 }));
 ```
 
-### Using shared mocks
-```typescript
-// Import from test-utils
-import { mockUser, mockSession } from '@/test-utils/mocks';
-```
-
 ## Playwright patterns
+Use `./fixtures` so coverage collection and shared helpers stay active (lint enforced).
 
 ### Basic E2E test
 ```typescript
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test('user can navigate to dashboard', async ({ page }) => {
   await page.goto('/');
@@ -89,7 +84,7 @@ await expect(page.getByText('Success')).toBeVisible();
 ## Coverage requirements
 
 CI collects coverage for both test types:
-- Vitest: Standard Istanbul coverage
+- Vitest: V8 coverage via Vitest provider
 - Playwright: V8 coverage via instrumentation
 
 Coverage reports uploaded as artifacts.

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -142,6 +142,24 @@ export default tseslint.config(
     },
     rules: {
       ...(playwrightRecommended.rules ?? {}),
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@playwright/test',
+              message: 'Import { test, expect } from ./fixtures to enable coverage and shared helpers.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Allow fixtures to source Playwright primitives.
+    files: ['tests/e2e/fixtures.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
 

--- a/web/src/pages/About.page.test.tsx
+++ b/web/src/pages/About.page.test.tsx
@@ -1,5 +1,5 @@
+import { render, screen } from '@test-utils';
 import { beforeEach, expect, test, vi } from 'vitest';
-import { render, screen } from '../../test-utils';
 import { fetchBuildInfo } from '../api/buildInfo';
 import { AboutPage } from './About.page';
 

--- a/web/test-utils/README.md
+++ b/web/test-utils/README.md
@@ -14,7 +14,7 @@ Shared testing utilities for the TinyCongress frontend.
 Import the custom `render` function instead of `@testing-library/react`:
 
 ```tsx
-import { render } from '../../test-utils';
+import { render } from '@test-utils';
 import { MyComponent } from './MyComponent';
 
 test('renders correctly', () => {
@@ -30,6 +30,8 @@ The custom render wraps components with:
 - `MantineProvider` - Theme context matching the app's Mantine theme
 
 This ensures components render in the same context as the real app.
+
+`render` also accepts standard Testing Library render options (including `wrapper`) when needed.
 
 ## Adding Utilities
 

--- a/web/test-utils/render.tsx
+++ b/web/test-utils/render.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render as testingLibraryRender } from '@testing-library/react';
+import { render as testingLibraryRender, type RenderOptions } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import { mantineTheme } from '../src/theme/mantineTheme';
 
@@ -14,14 +14,21 @@ function createTestQueryClient() {
   });
 }
 
-export function render(ui: React.ReactNode) {
-  const testQueryClient = createTestQueryClient();
+type WrapperProps = { children: React.ReactNode };
 
-  return testingLibraryRender(ui, {
-    wrapper: ({ children }: { children: React.ReactNode }) => (
+export function render(ui: React.ReactElement, options?: RenderOptions) {
+  const testQueryClient = createTestQueryClient();
+  const { wrapper: UserWrapper, ...rest } = options ?? {};
+
+  const CombinedWrapper = ({ children }: WrapperProps) => {
+    const content = UserWrapper ? <UserWrapper>{children}</UserWrapper> : children;
+
+    return (
       <QueryClientProvider client={testQueryClient}>
-        <MantineProvider theme={mantineTheme}>{children}</MantineProvider>
+        <MantineProvider theme={mantineTheme}>{content}</MantineProvider>
       </QueryClientProvider>
-    ),
-  });
+    );
+  };
+
+  return testingLibraryRender(ui, { wrapper: CombinedWrapper, ...rest });
 }


### PR DESCRIPTION
## Context
Align frontend testing docs and tooling so fixtures and shared providers stay consistent.

## Changes made
- enforce Playwright fixtures imports in E2E linting
- allow @test-utils render to accept Testing Library render options
- update docs/examples and normalize About page test import

## Testing
- [x] `cargo test`
- [ ] `yarn test`
- [x] Other (specify): `just test` (includes `yarn vitest`)

## Linked Issue
- Closes # (n/a)

## AI tooling used
- Codex CLI (GPT-5)