### PR TITLE
Centralize backend test helpers

### DIFF
--- a/service/tests/common/graphql.rs
+++ b/service/tests/common/graphql.rs
@@ -1,0 +1,51 @@
+//! GraphQL response helpers for integration tests.
+//!
+//! This module provides utilities for executing GraphQL queries/mutations
+//! and asserting on their responses.
+
+use async_graphql::{EmptySubscription, Schema};
+use serde_json::Value;
+use tinycongress_api::build_info::BuildInfoProvider;
+use tinycongress_api::graphql::{MutationRoot, QueryRoot};
+
+/// Execute a GraphQL query against the test schema and return parsed JSON.
+pub async fn execute_query(query: &str) -> Value {
+    let schema = Schema::build(QueryRoot, MutationRoot, EmptySubscription)
+        .data(BuildInfoProvider::from_env())
+        .finish();
+    let response = schema.execute(query).await;
+    serde_json::to_value(response).expect("Failed to serialize GraphQL response")
+}
+
+/// Helper to extract the "data" field from a GraphQL response.
+pub fn extract_data(response: &Value) -> Option<&Value> {
+    response.get("data").filter(|v| !v.is_null())
+}
+
+/// Helper to extract errors from a GraphQL response.
+pub fn extract_errors(response: &Value) -> &[Value] {
+    response
+        .get("errors")
+        .and_then(|e| e.as_array())
+        .map(|a| a.as_slice())
+        .unwrap_or(&[])
+}
+
+/// Assert that a GraphQL response has no errors.
+pub fn assert_no_errors(response: &Value) {
+    let errors = extract_errors(response);
+    assert!(
+        errors.is_empty(),
+        "Expected no GraphQL errors, but got: {:?}",
+        errors
+    );
+}
+
+/// Assert that a GraphQL response contains at least one error.
+pub fn assert_has_errors(response: &Value) {
+    let errors = extract_errors(response);
+    assert!(
+        !errors.is_empty(),
+        "Expected GraphQL errors, but response had none"
+    );
+}

--- a/service/tests/common/mod.rs
+++ b/service/tests/common/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! - [`app_builder::TestAppBuilder`] - Build test Axum apps that mirror main.rs wiring
 //! - [`test_db`] - Shared PostgreSQL container for database integration tests
+//! - [`graphql`] - GraphQL response helpers for testing schema behavior
 //!
 //! # App Builder Usage
 //!
@@ -76,6 +77,7 @@
 //!   In CI, set to the GHCR image: `ghcr.io/icook/tiny-congress/postgres:$SHA`
 
 pub mod app_builder;
+pub mod graphql;
 
 pub mod test_db {
     use once_cell::sync::Lazy;


### PR DESCRIPTION
## Context
Align backend testing docs with the shared testcontainers runtime and centralize GraphQL helpers.

## Changes made
- Align backend testing docs to `run_test`/testcontainers usage
- Centralize GraphQL response helpers under `service/tests/common/graphql.rs`
- Use structured JSON assertions in HTTP GraphQL/REST/identity tests

## Testing
- [x] `cargo test`
- [ ] `yarn test`
- [x] Other (specify): `just test-backend`

## Linked Issue
- Closes #N/A

## AI tooling used
- Codex CLI (GPT-5)
