### PR TITLE
refactor(docker): Use robust sed pattern for workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+# Keep members on single line - web/Dockerfile sed pattern depends on this format
 members = ["service", "crates/tc-crypto", "crates/test-macros"]
 resolver = "2"
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -14,7 +14,7 @@ COPY Cargo.toml ./
 COPY crates/tc-crypto ./crates/tc-crypto
 
 # Modify workspace to only include tc-crypto (service isn't needed for WASM build)
-RUN sed -i 's/members = \["service", "crates\/tc-crypto", "crates\/test-macros"\]/members = ["crates\/tc-crypto"]/' Cargo.toml
+RUN sed -i 's/members = \[.*\]/members = ["crates\/tc-crypto"]/' Cargo.toml
 
 # Build WASM
 RUN cd crates/tc-crypto && wasm-pack build --target web --release --out-dir /wasm-out


### PR DESCRIPTION
## Summary
- Change sed to match any members array content instead of exact list
- Add comment in Cargo.toml documenting the single-line constraint

This prevents the Dockerfile from breaking when workspace members change.

## Test plan
- [ ] CI passes (tc-ui-release build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)