### PR TITLE
docs: add PR and commit naming conventions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Contracts and standards for consistency:
 | [directory-conventions.md](interfaces/directory-conventions.md) | Where code lives |
 | [naming-conventions.md](interfaces/naming-conventions.md) | How to name things |
 | [branch-naming-conventions.md](interfaces/branch-naming-conventions.md) | Git branch naming standards |
+| [pr-naming-conventions.md](interfaces/pr-naming-conventions.md) | PR titles and commit messages |
 | [api-contracts.md](interfaces/api-contracts.md) | API design patterns |
 | [error-handling.md](interfaces/error-handling.md) | Error handling overview and standard codes |
 | [error-handling-backend.md](interfaces/error-handling-backend.md) | Rust error types, HTTP/GraphQL responses |

--- a/docs/interfaces/branch-naming-conventions.md
+++ b/docs/interfaces/branch-naming-conventions.md
@@ -339,7 +339,8 @@ Before pushing a branch, verify:
 
 ## Related Documentation
 
-- `AGENTS.md` - Repository guidelines and workflows
-- `docs/decisions/004-explicit-git-push-branches.md` - Explicit push requirements
-- `docs/interfaces/naming-conventions.md` - General naming conventions
-- `docs/playbooks/` - Development workflows
+- `CLAUDE.md` - Repository guidelines and workflows
+- `pr-naming-conventions.md` - PR titles and commit messages
+- `naming-conventions.md` - General naming conventions
+- `../decisions/004-explicit-git-push-branches.md` - Explicit push requirements
+- `../playbooks/` - Development workflows

--- a/docs/interfaces/naming-conventions.md
+++ b/docs/interfaces/naming-conventions.md
@@ -59,9 +59,12 @@
 | Type | Convention | Example |
 |------|------------|---------|
 | Branch | `type/issue-slug` | `feature/123-add-voting` |
-| Commit | Imperative, concise | `Add vote counting endpoint` |
+| Commit | Conventional Commits | `feat(voting): add counting endpoint (#123)` |
+| PR title | Conventional Commits | `feat(voting): add counting endpoint (#123)` |
 
-For comprehensive branch naming rules, see `branch-naming-conventions.md`.
+For comprehensive rules, see:
+- `branch-naming-conventions.md` - Branch naming
+- `pr-naming-conventions.md` - PR titles and commit messages
 
 ## Anti-patterns
 

--- a/docs/interfaces/pr-naming-conventions.md
+++ b/docs/interfaces/pr-naming-conventions.md
@@ -1,0 +1,105 @@
+# PR and Commit Naming Conventions
+
+## Overview
+
+PR titles and commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format. This enables clean git logs, automated changelog generation, and consistency across the codebase.
+
+## Format
+
+```
+<type>(optional-scope): <imperative description> (#issue)
+```
+
+### Components
+
+| Component | Required | Rules | Example |
+|-----------|----------|-------|---------|
+| `type` | Yes | Lowercase, from approved list | `feat`, `fix`, `refactor` |
+| `scope` | No | Lowercase, identifies area | `auth`, `voting`, `docker` |
+| `description` | Yes | Imperative mood, lowercase start | `add vote counting` |
+| `issue` | When exists | GitHub issue number | `(#123)` |
+
+## Types
+
+| Type | Purpose | Branch Equivalent |
+|------|---------|-------------------|
+| `feat` | New functionality | `feature/` |
+| `fix` | Bug fixes | `fix/` |
+| `refactor` | Code restructuring (no behavior change) | `refactor/` |
+| `docs` | Documentation only | `docs/` |
+| `test` | Test additions or fixes | `test/` |
+| `ci` | CI/CD and build changes | `ci/` |
+| `chore` | Maintenance, dependencies | `chore/` |
+| `perf` | Performance improvements | `perf/` |
+| `security` | Security fixes or improvements | `security/` |
+
+## Examples
+
+### With Scope
+
+```
+feat(voting): add ranked choice support (#234)
+fix(auth): resolve login redirect loop (#456)
+refactor(api): extract response helpers (#217)
+perf(queries): optimize member search (#789)
+```
+
+### Without Scope
+
+```
+docs: update API examples (#444)
+chore: bump dependencies (#112)
+test: improve coverage for vote module (#888)
+ci: add parallel test execution (#303)
+```
+
+### Breaking Changes
+
+Add `!` after type/scope for breaking changes:
+
+```
+feat(api)!: change vote endpoint response format (#567)
+refactor!: rename VoteResult to BallotResult (#890)
+```
+
+## PR Title to Commit Message
+
+GitHub populates squash commit messages from PR titles. Keep PR titles in this format so merged commits maintain a clean, consistent log.
+
+**PR Title:** `feat(voting): add ranked choice support (#234)`
+**Squash Commit:** Same as above, automatically
+
+## Rules
+
+### DO
+
+- Use imperative mood: "add feature" not "added feature" or "adds feature"
+- Keep descriptions concise (50 chars or less ideal)
+- Include scope when it clarifies the change area
+- Reference the issue number when one exists
+- Start description with lowercase
+
+### DON'T
+
+- Use past tense: `feat: added voting`
+- Use vague descriptions: `fix: bug fixes`
+- Include redundant words: `feat: add new feature for voting`
+- End with punctuation: `fix: resolve login issue.`
+- Use scope for obvious context: `docs(documentation): update readme`
+
+## Validation
+
+Before submitting a PR, verify the title:
+
+- [ ] Starts with valid type
+- [ ] Scope (if used) accurately identifies the area
+- [ ] Description uses imperative mood
+- [ ] Description is concise and specific
+- [ ] Issue number included (if applicable)
+- [ ] No trailing punctuation
+
+## Related Documentation
+
+- `branch-naming-conventions.md` - Branch naming (types align)
+- `naming-conventions.md` - General naming patterns
+- `../../.github/pull_request_template.md` - PR body template


### PR DESCRIPTION
## Summary
- Adds `docs/interfaces/pr-naming-conventions.md` standardizing Conventional Commits format for PR titles and commit messages
- Updates `naming-conventions.md` to reference the new standard
- Updates `branch-naming-conventions.md` related docs section
- Adds new doc to `docs/README.md` index

## Context
Formalizes the Conventional Commits pattern already emerging in recent commits (e.g., `refactor(docker):`, `feat(testing):`). Aligns PR titles with branch naming conventions so the full workflow is consistent:

```
Branch:  feature/123-add-voting
PR:      feat(voting): add vote counting (#123)
Commit:  feat(voting): add vote counting (#123)
```

## Testing
- [x] Documentation only, no code changes

## Linked Issue
N/A - process improvement

## AI tooling used
Claude Code (Opus 4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)