### PR TITLE
[DX] Add pre-commit hook for lint-staged

### DIFF
--- a/docs/playbooks/local-dev-setup.md
+++ b/docs/playbooks/local-dev-setup.md
@@ -263,6 +263,31 @@ cargo run --release
 
 Or use `mold` linker (Linux) / `zld` (macOS).
 
+## Git Hooks
+
+The repository uses [Husky](https://typicode.github.io/husky/) to run pre-commit checks. Hooks are installed automatically when you run `yarn install` in the `web/` directory (via the `prepare` script).
+
+### Pre-commit Hook
+
+Located at `.husky/pre-commit`, this hook runs automatically before each commit:
+
+**Frontend files (`*.ts`, `*.tsx`, `*.css`):**
+- Runs `lint-staged` which applies ESLint fixes, Prettier formatting, and Stylelint fixes to staged files
+
+**Backend files (`*.rs`):**
+- Runs `cargo fmt --check` to verify formatting
+- Runs `cargo clippy` to check for common mistakes
+
+### Bypassing Hooks
+
+If you need to commit without running hooks (e.g., WIP commits, emergency fixes):
+
+```bash
+git commit --no-verify -m "WIP: work in progress"
+```
+
+Use sparingly—CI will still enforce these checks.
+
 ## See also
 
 - `docs/interfaces/environment-variables.md` - All env vars


### PR DESCRIPTION
## Summary

- Documents the pre-commit hook setup in `docs/playbooks/local-dev-setup.md`
- Explains how Husky hooks are auto-installed via `yarn install`
- Documents both frontend (lint-staged) and backend (cargo fmt/clippy) checks
- Provides bypass instructions using `--no-verify`

Note: The pre-commit hook itself was already added to `master` - this PR adds the missing documentation as specified in the acceptance criteria.

## Test plan

- [ ] Verify documentation renders correctly
- [ ] Confirm lint and tests pass

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)