### PR TITLE
test: Add OpenAPI schema snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +727,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1425,6 +1443,19 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "insta"
+version = "1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b76866be74d68b1595eb8060cb9191dca9c021db2316558e52ddc5d55d41b66c"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
 
 [[package]]
 name = "itertools"
@@ -2607,6 +2638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3148,7 @@ dependencies = [
  "chrono",
  "figment",
  "hyper",
+ "insta",
  "once_cell",
  "serde",
  "serde-aux",
@@ -3903,6 +3941,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -56,6 +56,7 @@ once_cell = "1.19"
 tc-test-macros = { path = "../crates/test-macros", version = "0.1.0" }
 # Enable test-utils feature for integration tests
 tinycongress-api = { path = ".", version = "0.1.0", features = ["test-utils"] }
+insta = { version = "1.41", features = ["json"] }
 
 [[bin]]
 name = "export_schema"

--- a/service/tests/openapi_snapshot_tests.rs
+++ b/service/tests/openapi_snapshot_tests.rs
@@ -1,0 +1,13 @@
+//! OpenAPI schema snapshot tests.
+//!
+//! These tests ensure the REST API contract doesn't change unintentionally.
+//! Run `cargo insta review` to inspect and approve intentional changes.
+
+use tinycongress_api::rest::ApiDoc;
+use utoipa::OpenApi;
+
+#[test]
+fn openapi_schema() {
+    let schema = ApiDoc::openapi();
+    insta::assert_json_snapshot!(schema);
+}

--- a/service/tests/snapshots/openapi_snapshot_tests__openapi_schema.snap
+++ b/service/tests/snapshots/openapi_snapshot_tests__openapi_schema.snap
@@ -1,0 +1,154 @@
+---
+source: service/tests/openapi_snapshot_tests.rs
+assertion_line: 12
+expression: schema
+---
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "TinyCongress API",
+    "description": "REST API for TinyCongress",
+    "license": {
+      "name": "MIT"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/api/v1",
+      "description": "REST API v1"
+    }
+  ],
+  "paths": {
+    "/build-info": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get build information",
+        "description": "Returns metadata about the running service including version, git SHA, and build time.\n\n# Errors\n\nReturns `ProblemDetails` on internal server errors.",
+        "operationId": "get_build_info",
+        "responses": {
+          "200": {
+            "description": "Build information retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BuildInfo": {
+        "type": "object",
+        "description": "Build metadata exposed via GraphQL, REST, and logs.",
+        "required": [
+          "version",
+          "gitSha",
+          "buildTime"
+        ],
+        "properties": {
+          "buildTime": {
+            "type": "string"
+          },
+          "gitSha": {
+            "type": "string"
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "description": "RFC 7807 Problem Details error response.",
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail"
+        ],
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable explanation specific to this occurrence"
+          },
+          "extensions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ProblemExtensions",
+                "description": "Additional error details"
+              }
+            ]
+          },
+          "instance": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URI reference identifying the specific occurrence"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "description": "HTTP status code",
+            "minimum": 0
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable summary"
+          },
+          "type": {
+            "type": "string",
+            "description": "URI reference identifying the problem type"
+          }
+        }
+      },
+      "ProblemExtensions": {
+        "type": "object",
+        "description": "Extended error information mapping to GraphQL error codes.",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Error code matching GraphQL error codes"
+          },
+          "field": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Field that caused the error (for validation errors)"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `insta`-based snapshot test to catch unintended REST API contract drift
- Test compares current OpenAPI schema against a committed snapshot
- Fails with clear diff when schema changes, guiding developers to review and accept intentional changes

## Test plan
- [x] `just test-backend` passes
- [x] Snapshot generated and committed
- [ ] Verify CI passes

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)