### PR TITLE
test: Add GraphQL schema snapshot testing

### DIFF
--- a/service/tests/graphql_schema_snapshot_tests.rs
+++ b/service/tests/graphql_schema_snapshot_tests.rs
@@ -1,0 +1,17 @@
+//! GraphQL schema snapshot tests.
+//!
+//! These tests ensure the GraphQL API contract doesn't change unintentionally.
+//! Run `cargo insta review` to inspect and approve intentional changes.
+
+use async_graphql::{EmptySubscription, Schema};
+use tinycongress_api::build_info::BuildInfoProvider;
+use tinycongress_api::graphql::{MutationRoot, QueryRoot};
+
+#[test]
+fn graphql_schema() {
+    let schema = Schema::build(QueryRoot, MutationRoot, EmptySubscription)
+        .data(BuildInfoProvider::from_env())
+        .finish();
+
+    insta::assert_snapshot!(schema.sdl());
+}

--- a/service/tests/snapshots/graphql_schema_snapshot_tests__graphql_schema.snap
+++ b/service/tests/snapshots/graphql_schema_snapshot_tests__graphql_schema.snap
@@ -1,0 +1,44 @@
+---
+source: service/tests/graphql_schema_snapshot_tests.rs
+assertion_line: 16
+expression: schema.sdl()
+---
+"""
+Build metadata exposed via GraphQL, REST, and logs.
+"""
+type BuildInfo {
+	version: String!
+	gitSha: String!
+	buildTime: String!
+	message: String
+}
+
+type MutationRoot {
+	"""
+	Placeholder mutation - returns the input string
+	
+	This exists because GraphQL requires at least one mutation.
+	Replace with actual mutations as features are implemented.
+	"""
+	echo(message: String!): String!
+}
+
+type QueryRoot {
+	"""
+	Returns build metadata for the running service
+	"""
+	buildInfo: BuildInfo!
+}
+
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+schema {
+	query: QueryRoot
+	mutation: MutationRoot
+}


### PR DESCRIPTION
## Summary

- Adds SDL-format GraphQL schema snapshot testing using insta
- Guards against unintentional API contract changes
- Mirrors the existing OpenAPI snapshot approach from #211

## Test plan

- [x] `cargo test --test graphql_schema_snapshot_tests` passes
- [ ] Verify schema changes cause test failure (modify schema, run test, see diff)
- [ ] Verify `cargo insta review` workflow for approving changes

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)