### PR TITLE
fix: prevent GitHub Pages deployment race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,6 +733,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration-tests, storybook-build]
     if: always() && needs.integration-tests.result != 'cancelled'
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -8,6 +8,9 @@ jobs:
   cleanup:
     name: Remove PR preview from GitHub Pages
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

- Add `concurrency` group to `deploy-pages` job in CI workflow
- Add same concurrency group to `cleanup` job in cleanup-pr-previews workflow
- Both jobs now share `gh-pages-deploy` group with `cancel-in-progress: false`

This serializes all pushes to the `gh-pages` branch, preventing race conditions when multiple CI runs attempt to push concurrently.

## Test plan

- [ ] Trigger multiple CI runs simultaneously (e.g., push commits in quick succession)
- [ ] Verify deploys queue rather than fail with "fetch first" errors
- [ ] Confirm PR cleanup still works when PRs are closed

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)