### PR TITLE
refactor(test): Use fake timers in ThreadedConversation tests

### DIFF
--- a/web/src/components/ThreadedConversation/ThreadedConversation.test.tsx
+++ b/web/src/components/ThreadedConversation/ThreadedConversation.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, userEvent } from '@test-utils';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { ThreadedConversation, type ConversationBranch, type Thread } from './ThreadedConversation';
 
 const baseTimestamp = new Date('2024-01-01T00:00:00Z');


### PR DESCRIPTION
## Summary
- Aligns ThreadedConversation tests with documented timer testing patterns from `frontend-test-patterns.md`
- Replaces real-time `waitFor` (up to 3 seconds) with deterministic `vi.useFakeTimers()` and `vi.advanceTimersByTime()`
- Tests now run instantly instead of waiting for real time to elapse

## Test plan
- [x] `just test-frontend` passes locally
- [x] ThreadedConversation tests run deterministically

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)