### PR TITLE
chore(infra): Remove redundant PATH override in Dockerfile.dev

### DIFF
--- a/service/Dockerfile.dev
+++ b/service/Dockerfile.dev
@@ -43,7 +43,5 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
 
 RUN install -m 0755 bin/dev-entrypoint.sh /usr/local/bin/dev-entrypoint
 
-ENV PATH="/usr/local/cargo/bin:${PATH}"
-
 # Default command: run the hot-reload dev entrypoint
 CMD ["/usr/local/bin/dev-entrypoint"]


### PR DESCRIPTION
## Summary

Removes the explicit `ENV PATH="/usr/local/cargo/bin:${PATH}"` line from `service/Dockerfile.dev` as it's redundant.

### Investigation Findings

- The base image (`lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION}`) already sets `PATH=/usr/local/cargo/bin:...`
- This PATH correctly persists through the multi-stage build when inheriting from `chef`
- Verified by testing that `cargo` and `cargo-watch` commands remain available in the final image without the explicit ENV override

### Root Cause

The workaround was added in commit ccf8fec (PR #13) with message "Ensure cargo available in dev image". However, testing shows the base image already provides the correct PATH - the explicit override was unnecessary.

## Test Plan

- [ ] CI build completes successfully
- [ ] Dev container can run `cargo` commands at runtime (via dev-entrypoint.sh using cargo-watch)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)