### PR TITLE
fix(security): Resolve trivy and cargo-deny vulnerability failures

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -18,3 +18,23 @@ CVE-2025-58183
 # Affects: gosu in postgres:18 base image (Go 1.24.6)
 # Fixed in: Go 1.24.11, 1.25.5
 CVE-2025-61729
+
+# crypto/tls: Unexpected session resumption
+# Affects: gosu in postgres:18 base image (Go 1.24.6)
+# Fixed in: Go 1.24.13, 1.25.7, 1.26.0-rc.3
+CVE-2025-68121
+
+# net/url: Memory exhaustion in query parameter parsing
+# Affects: gosu in postgres:18 base image (Go 1.24.6)
+# Fixed in: Go 1.24.12, 1.25.6
+CVE-2025-61726
+
+# archive/zip: Excessive CPU consumption when building directory names
+# Affects: gosu in postgres:18 base image (Go 1.24.6)
+# Fixed in: Go 1.24.12, 1.25.6
+CVE-2025-61728
+
+# crypto/tls: TLS 1.3 handshake multiple message vulnerability
+# Affects: gosu in postgres:18 base image (Go 1.24.6)
+# Fixed in: Go 1.24.12, 1.25.6
+CVE-2025-61730

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -37,7 +37,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
 FROM debian:bookworm-slim
 
 RUN apt-get update \
-  && apt-get install -y ca-certificates libpq5 libssl3 \
+  && apt-get install -y --no-install-recommends ca-certificates libpq5 libssl3 \
+  && apt-get upgrade -y libpq5 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/app/target/release/tinycongress-api /usr/local/bin/


### PR DESCRIPTION
## Summary
- **bytes crate** (RUSTSEC-2026-0007): Updated `bytes` 1.11.0 → 1.11.1 to fix integer overflow in `BytesMut::reserve`
- **tc-api-release image** (CVE-2026-2004/2005/2006): Added `apt-get upgrade -y libpq5` in Dockerfile runtime stage to pick up patched `15.16-0+deb12u1`
- **postgres image** (CVE-2025-68121, CVE-2025-61726, CVE-2025-61728, CVE-2025-61730): Added 4 new gosu Go stdlib CVEs to `.trivyignore` — gosu only runs at container startup to drop privileges, consistent with existing ignore entries

## Test plan
- [ ] CI security-audit job passes (cargo-deny no longer flags bytes)
- [ ] CI scan-postgres job passes (new CVEs in .trivyignore)
- [ ] CI scan-tc-api-release job passes (libpq5 upgraded to fixed version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)