### PR TITLE
fix(dev): Align dev Dockerfile with workspace layout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,21 @@
 # Logs
 *.log
 **/*.log
+
+# Rust build artifacts
+service/target/
+crates/*/target/
+
+# Frontend build artifacts and dependencies
+web/node_modules/
+web/dist/
+web/.vite/
+web/coverage/
+
+# Worktrees
+.worktrees/
+.claude/
+
+# Documentation and Kubernetes (no Dockerfile needs these)
+docs/
+kube/

--- a/justfile
+++ b/justfile
@@ -259,9 +259,9 @@ rust-version := ```
 # Start full development environment with Skaffold (hot reload, port forwarding)
 # Prerequisites: Docker, Skaffold, KinD cluster (just kind-create)
 dev: check-rust-version
-    @echo "Starting full-stack dev with Skaffold..."
+    @echo "Starting full-stack dev with Skaffold (targeting KinD cluster)..."
     @echo "Prerequisites: run 'just kind-create' first for KinD with shared cargo cache"
-    RUST_VERSION={{rust-version}} skaffold dev --port-forward --cleanup=false --skip-tests
+    RUST_VERSION={{rust-version}} skaffold dev --kube-context kind-kind --port-forward --cleanup=false --skip-tests
 
 # Build all container images (for current profile)
 build-images:

--- a/service/Dockerfile.dev
+++ b/service/Dockerfile.dev
@@ -6,7 +6,10 @@ FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION} AS chef
 WORKDIR /usr/src/app
 
 FROM chef AS planner
-COPY . .
+# Copy workspace root and all crates
+COPY Cargo.toml Cargo.lock ./
+COPY service ./service
+COPY crates ./crates
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
@@ -29,8 +32,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
     --mount=type=cache,target=/usr/src/app/target,id=cargo-target-dev \
     cargo chef cook --recipe-path recipe.json
 
-# Copy source and build with cache mounts
-COPY . .
+# Copy workspace root and all crates
+COPY Cargo.toml Cargo.lock ./
+COPY service ./service
+COPY crates ./crates
 
 ENV SQLX_OFFLINE=true
 
@@ -41,7 +46,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \
     cargo build --bin tinycongress-api && \
     cp target/debug/tinycongress-api /usr/local/bin/tinycongress-api
 
-RUN install -m 0755 bin/dev-entrypoint.sh /usr/local/bin/dev-entrypoint
+RUN install -m 0755 service/bin/dev-entrypoint.sh /usr/local/bin/dev-entrypoint
 
 # Default command: run the hot-reload dev entrypoint
 CMD ["/usr/local/bin/dev-entrypoint"]

--- a/service/bin/dev-entrypoint.sh
+++ b/service/bin/dev-entrypoint.sh
@@ -17,9 +17,10 @@ fi
 export RUST_LOG="${RUST_LOG:-info}"
 
 # Watch core Rust sources and migrations, re-running the API binary on change
+# Paths are relative to workspace root (/usr/src/app)
 exec cargo watch \
-  --watch src \
-  --watch migrations \
-  --watch Cargo.toml \
+  --watch service/src \
+  --watch service/migrations \
+  --watch service/Cargo.toml \
   --watch Cargo.lock \
   -x "run --bin tinycongress-api"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -13,9 +13,9 @@ build:
     - "linux/arm64"
   artifacts:
     - image: tc-api-dev
-      context: ./service/
+      context: .
       docker:
-        dockerfile: Dockerfile.dev
+        dockerfile: service/Dockerfile.dev
         buildArgs:
           BUILDKIT_INLINE_CACHE: "1"
           RUST_VERSION: "{{.RUST_VERSION}}"
@@ -24,11 +24,11 @@ build:
           - "tc-api-dev:cache"
       sync:
         manual:
-          - src: "src/**/*.rs"
+          - src: "service/src/**/*.rs"
             dest: /usr/src/app
-          - src: "migrations/**/*"
+          - src: "service/migrations/**/*"
             dest: /usr/src/app
-          - src: "Cargo.toml"
+          - src: "service/Cargo.toml"
             dest: /usr/src/app
           - src: "Cargo.lock"
             dest: /usr/src/app


### PR DESCRIPTION
## Summary

- Fix `just dev` failing with "failed to find a workspace root" — the dev Dockerfile context was `./service/` but `service/Cargo.toml` uses workspace inheritance and path dependencies to `crates/`
- Change tc-api-dev build context to repo root, matching the existing release Dockerfile pattern
- Expand `.dockerignore` to exclude build artifacts (`service/target/`, `web/node_modules/`, etc.) since more builds now use root context
- Pin `just dev` to `kind-kind` kube-context via `--kube-context` flag to prevent accidental deployment to non-KinD clusters

## Test plan

- [ ] Run `just dev` — all three images (tc-api-dev, postgres, tc-ui-dev) build successfully
- [ ] Verify the API container starts with cargo-watch running
- [ ] Confirm no "failed to find a workspace root" errors
- [ ] Verify file sync still works (edit a `.rs` file and confirm hot-reload triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)