### PR TITLE
fix(web): Unify API base URL config for REST and GraphQL clients

### DIFF
--- a/kube/app/templates/deployment.yaml
+++ b/kube/app/templates/deployment.yaml
@@ -127,7 +127,7 @@ spec:
           ports:
             - containerPort: {{ .Values.frontend.service.port }}
           env:
-            - name: VITE_GRAPHQL_URL
-              value: {{ .Values.frontend.graphqlUrl | default (printf "http://%s:8080/graphql" (include "app.fullname" .)) | quote }}
+            - name: VITE_API_URL
+              value: {{ .Values.frontend.apiUrl | default (printf "http://%s:8080" (include "app.fullname" .)) | quote }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -122,8 +122,8 @@ frontend:
     repository: tc/frontend-dev
     tag: latest
     pullPolicy: IfNotPresent
-  # Override GraphQL endpoint (defaults to the API service DNS name).
-  graphqlUrl: ""
+  # Override API base URL (defaults to the API service DNS name).
+  apiUrl: ""
   service:
     type: ClusterIP
     port: 5173

--- a/web/src/api/graphqlClient.ts
+++ b/web/src/api/graphqlClient.ts
@@ -3,22 +3,11 @@ interface GraphQLResponse<T> {
   errors?: { message: string }[];
 }
 
-const defaultGraphqlUrl = 'http://localhost:8080/graphql';
+const API_BASE_URL: string =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:8080';
 
 export function getGraphqlUrl(): string {
-  const envUrl = import.meta.env.VITE_GRAPHQL_URL as string | undefined;
-  if (envUrl) {
-    return envUrl;
-  }
-
-  if (typeof window !== 'undefined') {
-    const url = new URL(window.location.origin);
-    url.port = '8080';
-    url.pathname = '/graphql';
-    return url.toString();
-  }
-
-  return defaultGraphqlUrl;
+  return `${API_BASE_URL}/graphql`;
 }
 
 export async function graphqlRequest<TData>(


### PR DESCRIPTION
## Summary
- **Problem:** The `/about` page fails to load build info when the frontend pod is port-forwarded to localhost. The GraphQL client used `VITE_GRAPHQL_URL` set to `http://tc:8080/graphql` (in-cluster service name), which the browser can't resolve outside the cluster.
- **Fix:** Both REST and GraphQL clients now share `VITE_API_URL` with a `http://localhost:8080` fallback, eliminating the separate `VITE_GRAPHQL_URL` env var.
- **K8s deployment** updated to pass `VITE_API_URL` (base URL) instead of `VITE_GRAPHQL_URL` (full GraphQL path).

## Test plan
- [x] All 35 frontend unit tests pass (`just test-frontend`)
- [ ] Deploy to KinD cluster and verify `/about` page loads build info
- [ ] Verify port-forwarded frontend resolves GraphQL endpoint to `localhost:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)