### PR TITLE
feat(web): runtime env injection and SPA routing for frontend

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -8,6 +8,12 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
+    # Static assets — return 404 if missing (never fall through to SPA)
+    location ~* \.(?:css|js|json|map|jpg|jpeg|png|gif|ico|svg|webp|avif|woff2?|ttf|eot)$ {
+        try_files $uri =404;
+    }
+
+    # SPA routing — serve index.html for navigation routes only
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/web/src/pages/Layout.tsx
+++ b/web/src/pages/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from '@tanstack/react-router';
 import { AppShell, Burger, Group, Image, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import logo from '@/logo.png';
 import { Navbar } from '../components/Navbar/Navbar';
 
 export function Layout() {
@@ -15,7 +16,7 @@ export function Layout() {
       <AppShell.Header>
         <Group h="100%" px="md" gap="sm">
           <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
-          <Image src="/src/logo.png" alt="TinyCongress logo" h={32} w="auto" />
+          <Image src={logo} alt="TinyCongress logo" h={32} w="auto" />
           <Text fw={700}>TinyCongress</Text>
         </Group>
       </AppShell.Header>


### PR DESCRIPTION
## Summary
- Replace build-time `import.meta.env.VITE_API_URL` with runtime config (`window.__TC_ENV__`) generated by docker-entrypoint.sh at container start, making the frontend image environment-agnostic
- Add nginx SPA routing (`try_files`) so deep links like `/members/123` work in production
- Add static asset location block so missing files return 404 instead of index.html
- Fix logo.png serving in production by importing it as an ES module (Vite bundles it with content hash) instead of referencing `/src/logo.png` which only exists in dev

## Test plan
- [ ] `just lint-frontend` passes
- [ ] `just typecheck` passes
- [ ] `just test-frontend` passes
- [ ] Build frontend Docker image and verify `config.js` is generated from env vars
- [ ] Verify SPA deep links serve index.html
- [ ] Verify `/logo.png` or other missing static assets return 404, not HTML
- [ ] Verify logo renders correctly in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)