### PR TITLE
feat(web): Dark mode default with color scheme toggle

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
     <ErrorBoundary context="Application">
       <CryptoProvider>
         <QueryProvider>
-          <MantineProvider theme={mantineTheme}>
+          <MantineProvider theme={mantineTheme} defaultColorScheme="dark">
             <Router />
           </MantineProvider>
         </QueryProvider>

--- a/web/src/pages/Layout.tsx
+++ b/web/src/pages/Layout.tsx
@@ -1,10 +1,26 @@
+import { IconMoon, IconSun } from '@tabler/icons-react';
 import { Outlet } from '@tanstack/react-router';
-import { AppShell, Burger, Group, Image, Text } from '@mantine/core';
+import {
+  ActionIcon,
+  AppShell,
+  Burger,
+  Group,
+  Image,
+  Text,
+  useComputedColorScheme,
+  useMantineColorScheme,
+} from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { Navbar } from '../components/Navbar/Navbar';
 
 export function Layout() {
   const [opened, { toggle }] = useDisclosure();
+  const { setColorScheme } = useMantineColorScheme();
+  const colorScheme = useComputedColorScheme();
+
+  const toggleColorScheme = () => {
+    setColorScheme(colorScheme === 'dark' ? 'light' : 'dark');
+  };
 
   return (
     <AppShell
@@ -17,6 +33,15 @@ export function Layout() {
           <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
           <Image src="/src/logo.png" alt="TinyCongress logo" h={32} w="auto" />
           <Text fw={700}>TinyCongress</Text>
+          <ActionIcon
+            variant="subtle"
+            onClick={toggleColorScheme}
+            ml="auto"
+            size="lg"
+            aria-label="Toggle color scheme"
+          >
+            {colorScheme === 'dark' ? <IconSun size={20} /> : <IconMoon size={20} />}
+          </ActionIcon>
         </Group>
       </AppShell.Header>
       <AppShell.Navbar>


### PR DESCRIPTION
## Summary
- Makes dark mode the default color scheme for new visitors
- Adds a sun/moon toggle button in the header bar (right-aligned) to switch between dark and light mode
- Mantine persists the user's choice in `localStorage` automatically

## Changes
- `web/src/App.tsx`: Added `defaultColorScheme="dark"` to `MantineProvider`
- `web/src/pages/Layout.tsx`: Added `ActionIcon` toggle using `useMantineColorScheme()` and `useComputedColorScheme()` hooks with Tabler sun/moon icons

## Test plan
- [x] Verified dark mode loads by default on localhost
- [x] Verified toggle switches to light mode (moon icon)
- [x] Verified toggle switches back to dark mode (sun icon)
- [x] `just lint-frontend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)