### PR TITLE
fix(ci): Gate deploy-gitops on integration-tests passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,7 +776,7 @@ jobs:
   deploy-gitops:
     name: Update gitops image digests
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [build-images]
+    needs: [integration-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Change `deploy-gitops` job from `needs: [build-images]` to `needs: [integration-tests]`
- Prevents pushing image digests to the gitops repo before the full test suite passes

Since `integration-tests` already depends on all other jobs (build-images, scan-images, lint, lint-web, storybook-build, codegen-check, sqlx-check, security-audit), this gates deployment on the entire CI pipeline.

Follow-up to #273 / #274.

## Test plan

- [ ] `deploy-gitops` job only starts after `integration-tests` completes successfully
- [ ] Re-run on master to also verify the deploy key fix (secret was set after the previous run was queued)

🤖 Generated with [Claude Code](https://claude.com/claude-code)