### PR TITLE
fix(ci): Use /users/ GHCR API path for deploy-gitops job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,6 +780,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Checkout gitops repo
         uses: actions/checkout@v6
@@ -796,7 +797,7 @@ jobs:
           SHA="${{ github.sha }}"
           for IMAGE in tc-api-release tc-ui-release postgres; do
             DIGEST=$(gh api \
-              "/orgs/icook/packages/container/tiny-congress%2F${IMAGE}/versions" \
+              "/users/icook/packages/container/tiny-congress%2F${IMAGE}/versions" \
               --jq ".[] | select(.metadata.container.tags[] == \"${SHA}\") | .name")
             echo "${IMAGE}=${DIGEST}" >> "$GITHUB_OUTPUT"
             echo "  ${IMAGE}: ${DIGEST}"


### PR DESCRIPTION
## Summary

- Fix GHCR API 404 in `deploy-gitops` job by switching `/orgs/icook/` to `/users/icook/` (icook is a user account, not an org)
- Add `packages: read` permission to ensure the `GITHUB_TOKEN` can query GHCR package versions

Fixes the CI failure introduced by #274.

## Test plan

- [ ] CI workflow YAML passes validation
- [ ] `deploy-gitops` job resolves image digests without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)