### PR TITLE
feat(web): Add environment badge to header

### DIFF
--- a/kube/app/templates/deployment.yaml
+++ b/kube/app/templates/deployment.yaml
@@ -119,5 +119,7 @@ spec:
           env:
             - name: VITE_API_URL
               value: {{ .Values.frontend.apiUrl | default (printf "http://%s:8080" (include "app.fullname" .)) | quote }}
+            - name: TC_ENVIRONMENT
+              value: {{ .Values.frontend.environment | default "" | quote }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -122,6 +122,9 @@ frontend:
   # API base URL injected at container start via docker-entrypoint.sh.
   # Defaults to the API service's internal DNS name if empty.
   apiUrl: ""
+  # Environment label shown as a badge in the UI header.
+  # Empty string = production (badge hidden). Values: demo, staging, development.
+  environment: ""
   service:
     type: ClusterIP
     port: 5173

--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -12,13 +12,18 @@ case "$VITE_API_URL" in
   *) echo "ERROR: VITE_API_URL must start with http:// or https://" >&2; exit 1 ;;
 esac
 
+# Optional environment label for non-production badge (empty = production/hidden)
+TC_ENVIRONMENT="${TC_ENVIRONMENT:-}"
+
 # Use quoted heredoc to prevent shell expansion, then substitute the placeholder
 cat > /usr/share/nginx/html/config.js <<'TEMPLATE'
 window.__TC_ENV__ = {
-  VITE_API_URL: "__VITE_API_URL__"
+  VITE_API_URL: "__VITE_API_URL__",
+  TC_ENVIRONMENT: "__TC_ENVIRONMENT__"
 };
 TEMPLATE
 
 sed -i "s|__VITE_API_URL__|${VITE_API_URL}|" /usr/share/nginx/html/config.js
+sed -i "s|__TC_ENVIRONMENT__|${TC_ENVIRONMENT}|" /usr/share/nginx/html/config.js
 
 exec nginx -g 'daemon off;'

--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -44,3 +44,39 @@ describe('getApiBaseUrl', () => {
     expect(getApiBaseUrl()).toBe('https://buildtime.example.com');
   });
 });
+
+describe('getEnvironment', () => {
+  const ORIGINAL_TC_ENV = window.__TC_ENV__;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete window.__TC_ENV__;
+  });
+
+  afterEach(() => {
+    window.__TC_ENV__ = ORIGINAL_TC_ENV;
+  });
+
+  test('returns environment from runtime config', async () => {
+    window.__TC_ENV__ = { TC_ENVIRONMENT: 'demo' };
+    const { getEnvironment } = await import('./config');
+    expect(getEnvironment()).toBe('demo');
+  });
+
+  test('defaults to "production" when runtime config is not set', async () => {
+    const { getEnvironment } = await import('./config');
+    expect(getEnvironment()).toBe('production');
+  });
+
+  test('defaults to "production" when TC_ENVIRONMENT is empty string', async () => {
+    window.__TC_ENV__ = { TC_ENVIRONMENT: '' };
+    const { getEnvironment } = await import('./config');
+    expect(getEnvironment()).toBe('production');
+  });
+
+  test('returns staging environment', async () => {
+    window.__TC_ENV__ = { TC_ENVIRONMENT: 'staging' };
+    const { getEnvironment } = await import('./config');
+    expect(getEnvironment()).toBe('staging');
+  });
+});

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -8,12 +8,21 @@
 
 interface RuntimeConfig {
   VITE_API_URL?: string;
+  TC_ENVIRONMENT?: string;
 }
 
 declare global {
   interface Window {
     __TC_ENV__?: RuntimeConfig;
   }
+}
+
+export function getEnvironment(): string {
+  const env = window.__TC_ENV__?.TC_ENVIRONMENT;
+  if (!env) {
+    return 'production';
+  }
+  return env;
 }
 
 export function getApiBaseUrl(): string {

--- a/web/src/pages/Layout.tsx
+++ b/web/src/pages/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from '@tanstack/react-router';
 import {
   ActionIcon,
   AppShell,
+  Badge,
   Burger,
   Group,
   Image,
@@ -13,6 +14,26 @@ import {
 import { useDisclosure } from '@mantine/hooks';
 import logo from '@/logo.png';
 import { Navbar } from '../components/Navbar/Navbar';
+import { getEnvironment } from '../config';
+
+const ENV_BADGE_CONFIG: Record<string, { color: string; label: string }> = {
+  demo: { color: 'blue', label: 'DEMO' },
+  staging: { color: 'orange', label: 'STAGING' },
+  development: { color: 'green', label: 'DEV' },
+};
+
+function EnvironmentBadge() {
+  const env = getEnvironment();
+  if (env === 'production') {
+    return null;
+  }
+  const config = ENV_BADGE_CONFIG[env] ?? { color: 'red', label: 'UNKNOWN ENV' };
+  return (
+    <Badge color={config.color} variant="filled" size="sm">
+      {config.label}
+    </Badge>
+  );
+}
 
 export function Layout() {
   const [opened, { toggle }] = useDisclosure();
@@ -34,6 +55,7 @@ export function Layout() {
           <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
           <Image src={logo} alt="TinyCongress logo" h={32} w="auto" />
           <Text fw={700}>TinyCongress</Text>
+          <EnvironmentBadge />
           <ActionIcon
             variant="subtle"
             onClick={toggleColorScheme}


### PR DESCRIPTION
## Summary
- Adds a colored pill badge next to "TinyCongress" in the header for non-production environments (demo=blue, staging=orange, dev=green, unknown=red). Hidden in production by default.
- Plumbs `TC_ENVIRONMENT` from Helm values (`frontend.environment`) through `docker-entrypoint.sh` runtime config into the browser via `window.__TC_ENV__`.
- Exports `getEnvironment()` from `config.ts` with unit tests covering runtime config, empty string, and unset defaults.

## Test plan
- [x] `just lint-frontend` — passes clean
- [x] `just typecheck` — no TS errors
- [x] Unit tests pass (4 new tests for `getEnvironment()`, 45 total)
- [ ] `just dev-frontend` — visually confirm no badge appears (production default)
- [ ] In browser console: `window.__TC_ENV__ = { TC_ENVIRONMENT: 'demo' }` then refresh — blue "DEMO" badge appears next to logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)