### PR TITLE
fix(service): Suppress unused warnings in shared test utilities

### DIFF
--- a/service/tests/common/mod.rs
+++ b/service/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 //! Common test utilities for integration tests.
 //!
 //! This module provides:


### PR DESCRIPTION
## Summary
- Adds `#![allow(unused)]` to `service/tests/common/mod.rs` to suppress ~31 compiler warnings across 6 integration test binaries
- Each test binary compiles the full shared `common` module but only uses a subset of utilities (factories, graphql helpers, migration helpers, app builder methods), causing `unused_imports`, `dead_code`, and related warnings
- The inner attribute propagates to all child modules (`factories/`, `graphql.rs`, `migration_helpers.rs`, `app_builder.rs`)

## Test plan
- [x] `just test-backend` passes with zero warnings
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)