### PR TITLE
fix(ci): Update Cloudflare Pages deploy to use SVG logo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,14 +842,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
-            web/src/logo.png
+            web/src/logo-dark.svg
             web/src/favicon.ico
           sparse-checkout-cone-mode: false
 
       - name: Create site directory
         run: |
           mkdir -p site
-          cp web/src/logo.png site/logo.png
+          cp web/src/logo-dark.svg site/logo.svg
           cp web/src/favicon.ico site/favicon.ico
 
       - name: Download coverage report
@@ -1185,7 +1185,7 @@ jobs:
           <body>
             <header class="header">
               <div class="header-top">
-                <img src="logo.png" alt="Tiny Congress" class="logo">
+                <img src="logo.svg" alt="Tiny Congress" class="logo">
                 <h1>Tiny Congress</h1>
                 <span class="coverage-badge">
                   📊 ${COVERAGE_PCT}% coverage


### PR DESCRIPTION
## Summary
- PR #281 replaced `web/src/logo.png` with SVG variants (`logo-dark.svg`, `logo-light.svg`) but the Cloudflare Pages deploy job still referenced the old PNG path
- Updates sparse checkout, copy command, and landing page HTML to use `logo-dark.svg`

## Test plan
- [ ] Verify the "Deploy to Cloudflare Pages" job passes on this branch's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)