### PR TITLE
Add service annotations and postgres persistence to Helm values

### DIFF
--- a/kube/app/templates/postgres.yaml
+++ b/kube/app/templates/postgres.yaml
@@ -51,4 +51,9 @@ spec:
           periodSeconds: 5
       volumes:
       - name: postgres-data
+        {{- if .Values.postgres.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.postgres.persistence.existingClaim | default (printf "%s-postgres" (include "app.fullname" .)) }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}

--- a/kube/app/templates/service.yaml
+++ b/kube/app/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "app.fullname" . }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -24,6 +28,10 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
+  {{- with .Values.frontend.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.frontend.service.type | default "ClusterIP" }}
   ports:

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -62,6 +62,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 8080
+  # Annotations to add to the API service (e.g., external-dns, load-balancer config)
+  annotations: {}
 
 startupProbe:
   httpGet:
@@ -129,6 +131,8 @@ frontend:
     type: ClusterIP
     port: 5173
     targetPort: 5173
+    # Annotations to add to the frontend service (e.g., external-dns, load-balancer config)
+    annotations: {}
 
 postgres:
   image:
@@ -136,6 +140,11 @@ postgres:
     tag: "17"
     pullPolicy: IfNotPresent
     digest: ""
+  persistence:
+    # Enable to use a PersistentVolumeClaim instead of emptyDir
+    enabled: false
+    # Name of an existing PVC to use. If empty, defaults to "<fullname>-postgres"
+    existingClaim: ""
 
 # Cargo build cache for dev mode (hostPath volume)
 # Shares build cache with local dev via KinD extraMounts


### PR DESCRIPTION
## Summary

- Add `service.annotations` and `frontend.service.annotations` values to the Helm chart so external-dns (and other) annotations can be set through the values interface instead of postRenderers kustomize patches
- Add `postgres.persistence.enabled` and `postgres.persistence.existingClaim` values to support PVC-backed postgres storage, replacing the fragile JSON patch that swaps emptyDir by volume array index
- All defaults preserve existing behavior (no annotations, emptyDir volumes) — fully backward-compatible

## Motivation

The `tiny-congress-demo` HelmRelease in the gitops repo uses three `postRenderers` patches to work around missing values in this chart. One of those patches uses a JSON patch by array index (`/spec/template/spec/volumes/0`), which is brittle — any reordering of the volumes array would silently break it. Moving these into the chart's values interface makes the configuration self-documenting and eliminates the postRenderers entirely.

## Test plan

- [ ] `helm template` with defaults renders unchanged output (emptyDir, no annotations)
- [ ] `helm template` with `service.annotations` renders annotations on the API Service
- [ ] `helm template` with `frontend.service.annotations` renders annotations on the frontend Service
- [ ] `helm template` with `postgres.persistence.enabled=true` + `existingClaim` renders PVC volume
- [ ] `helm template` with `postgres.persistence.enabled=true` and no `existingClaim` renders auto-generated PVC name
- [ ] After merging, update gitops repo to replace `postRenderers` with values overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)