### PR TITLE
fix(service): Replace unsafe set_var with direct EnvFilter configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,10 +3508,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # GraphQL
 async-graphql = "7.0"

--- a/service/README.md
+++ b/service/README.md
@@ -38,7 +38,7 @@ createdb tiny-congress
 
 2. Set environment variables:
 ```bash
-export DATABASE_URL=postgres://username:password@localhost/tiny-congress
+export TC_DATABASE__URL=postgres://username:password@localhost/tiny-congress
 ```
 
 3. Run the server:
@@ -49,7 +49,7 @@ cargo run
 The server will:
 - Connect to PostgreSQL with retry logic (handles startup race conditions)
 - Run database migrations automatically
-- Start listening on port 8080 (or `PORT` env var)
+- Start listening on port 8080 (or `TC_SERVER__PORT` env var)
 
 ### Development with Skaffold
 
@@ -98,12 +98,20 @@ Access the GraphQL Playground at `http://localhost:8080/graphql` for interactive
 
 ## Environment Variables
 
+Configuration is loaded via [Figment](https://docs.rs/figment/) with `TC_`-prefixed env vars (double underscore `__` separates nesting levels). Env vars override `config.yaml` values.
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgres://postgres:postgres@localhost:5432/tiny-congress` |
-| `PORT` | Server port | `8080` |
-| `RUST_LOG` | Log level | `info` |
-| `MIGRATIONS_DIR` | Custom migrations directory | `./migrations` |
+| `TC_DATABASE__URL` | PostgreSQL connection string (required) | — |
+| `TC_DATABASE__MAX_CONNECTIONS` | Connection pool size | `10` |
+| `TC_DATABASE__MIGRATIONS_DIR` | Custom migrations directory | none |
+| `TC_SERVER__PORT` | Server port | `8080` |
+| `TC_SERVER__HOST` | Bind address | `0.0.0.0` |
+| `TC_LOGGING__LEVEL` | tracing filter directive (e.g. `debug`, `info`, `warn`) | `info` |
+| `TC_CORS__ALLOWED_ORIGINS` | Comma-separated origins or `*` | none |
+| `TC_GRAPHQL__PLAYGROUND_ENABLED` | Enable GraphQL Playground at `/graphql` | `false` |
+| `TC_SWAGGER__ENABLED` | Enable Swagger UI at `/swagger-ui` | `false` |
+| `TC_SECURITY_HEADERS__ENABLED` | Enable security response headers | `true` |
 | `APP_VERSION` | Application version for build info | `dev` |
 | `GIT_SHA` | Git commit SHA for build info | `unknown` |
 | `BUILD_TIME` | Build timestamp (RFC3339) | `unknown` |

--- a/service/bin/dev-entrypoint.sh
+++ b/service/bin/dev-entrypoint.sh
@@ -14,7 +14,7 @@ if ! command -v cargo-watch >/dev/null 2>&1; then
   exec tinycongress-api
 fi
 
-export RUST_LOG="${RUST_LOG:-info}"
+export TC_LOGGING__LEVEL="${TC_LOGGING__LEVEL:-info}"
 
 # Watch core Rust sources and migrations, re-running the API binary on change
 # Paths are relative to workspace root (/usr/src/app)

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -42,8 +42,13 @@ async fn main() -> Result<(), anyhow::Error> {
     let config = Config::load().map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // Set up logging from config
-    std::env::set_var("RUST_LOG", &config.logging.level);
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_new(&config.logging.level).map_err(|e| {
+                anyhow::anyhow!("invalid log level '{}': {e}", config.logging.level)
+            })?,
+        )
+        .init();
 
     // Init banner so container logs clearly show startup
     tracing::info!(


### PR DESCRIPTION
## Summary

- Replace `std::env::set_var("RUST_LOG", ...)` in `main.rs` with direct `tracing_subscriber::EnvFilter` construction — `set_var` is unsound in multi-threaded runtimes (UB per Rust 1.66+ docs)
- Enable `env-filter` feature on `tracing-subscriber` in `Cargo.toml`
- Update `dev-entrypoint.sh` to use `TC_LOGGING__LEVEL` instead of `RUST_LOG`
- Fix stale env var documentation in `service/README.md` — replace `DATABASE_URL`, `PORT`, `RUST_LOG`, `MIGRATIONS_DIR` with the actual `TC_`-prefixed figment variables

## Test plan

- [x] `just lint-backend` passes (clippy + fmt)
- [x] `just test-backend` passes (all 145 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)