### PR TITLE
fix(ui): Fix fetchJson silently dropping caller-provided headers

### DIFF
--- a/web/src/features/identity/api/client.ts
+++ b/web/src/features/identity/api/client.ts
@@ -23,12 +23,19 @@ interface ApiErrorResponse {
 
 // === API Functions ===
 
-async function fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
+export async function fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
   const url = `${getApiBaseUrl()}${path}`;
+
+  const merged = new Headers({ 'Content-Type': 'application/json' });
+  if (options?.headers) {
+    new Headers(options.headers).forEach((value, key) => {
+      merged.set(key, value);
+    });
+  }
 
   const response = await fetch(url, {
     ...options,
-    headers: { 'Content-Type': 'application/json' },
+    headers: merged,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- `fetchJson` was hard-overwriting `headers` after spreading `options`, silently dropping any caller-provided headers
- Now merges headers using the `Headers` API: `Content-Type: application/json` is the default, callers can add extra headers or override `Content-Type`
- Exported `fetchJson` for direct testability; added tests for header preservation and override

## Test plan
- [x] Existing tests pass (signup request, error handling)
- [x] New test: caller-provided headers preserved alongside default Content-Type
- [x] New test: caller can override Content-Type
- [x] `just lint-frontend` passes
- [x] `just fmt` clean

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)