### PR TITLE
fix(ci): Migrate Cloudflare Pages deploy to wrangler-action v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1289,7 +1289,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=tiny-congress
+          command: pages deploy site --project-name=tiny-congress --branch=${{ github.head_ref || github.ref_name }}
 
       - name: Add PR comment with report links
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Replaces deprecated `cloudflare/pages-action@v1` with `cloudflare/wrangler-action@v3`
- `pages-action@v1` internally runs `npx wrangler@2`, which now returns **403 Forbidden** from the npm registry since Wrangler v2 has been removed
- Updates PR comment output references from `steps.deploy.outputs.url` to `steps.deploy.outputs.deployment-url` to match the new action's output schema

## Test plan
- [ ] CI deploy-cloudflare job completes successfully
- [ ] PR comment with report links renders correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)