### PR TITLE
chore(justfile): declutter recipe list

### DIFF
--- a/docs/playbooks/backend-test-patterns.md
+++ b/docs/playbooks/backend-test-patterns.md
@@ -268,13 +268,7 @@ async fn test_build_info_query() {
 
 ### First-Time Setup
 
-Build the custom Postgres image with pgmq extension:
-
-```bash
-just build-test-postgres
-```
-
-This creates `tc-postgres:local` which tests use by default. The image is built automatically when running `just test-backend` if it doesn't exist.
+The custom Postgres image (`tc-postgres:local`) with the pgmq extension is built automatically on first test run. No manual step needed.
 
 ### How It Works
 
@@ -399,8 +393,8 @@ async fn test_pgmq_extension_available() {
 ### "Failed to start postgres container"
 
 1. Ensure Docker is running
-2. Build the test image: `just build-test-postgres`
-3. Check image exists: `docker images | grep tc-postgres`
+2. Check image exists: `docker images | grep tc-postgres`
+3. If missing, it will be built automatically on next `just test-backend` run
 
 ### "zombie connection" warnings
 

--- a/docs/playbooks/graphql-codegen.md
+++ b/docs/playbooks/graphql-codegen.md
@@ -34,7 +34,7 @@ The codegen pipeline has two stages:
 
    This runs both stages:
    - `just export-schema` - exports GraphQL SDL from Rust
-   - `just codegen-frontend` - generates TypeScript types
+   - `just codegen-graphql` - generates TypeScript types
 
 3. **Verify the generated types** in `web/src/api/generated/graphql.ts`
 
@@ -47,7 +47,7 @@ The codegen pipeline has two stages:
 ## Verification
 - [ ] `just codegen` produces no additional changes (idempotent)
 - [ ] `just lint-frontend` passes (generated code is formatted)
-- [ ] `just typecheck-frontend` passes
+- [ ] `just typecheck` passes
 - [ ] CI `codegen-check` job will verify this automatically
 
 ## CI enforcement

--- a/docs/playbooks/local-dev-setup.md
+++ b/docs/playbooks/local-dev-setup.md
@@ -142,10 +142,7 @@ just test            # Both
 Backend tests that need a database use [testcontainers](https://testcontainers.com/) to automatically
 spin up an isolated PostgreSQL container. No manual database setup required.
 
-**First-time setup:** Build the custom postgres image with pgmq extension:
-```bash
-just build-test-postgres
-```
+The custom postgres image (`tc-postgres:local`) with pgmq extension is built automatically on first test run.
 
 ### Watch Mode (Automatic Re-run on File Changes)
 

--- a/justfile
+++ b/justfile
@@ -91,7 +91,7 @@ build-wasm:
     cd crates/tc-crypto && wasm-pack build --target web --release --out-dir ../../web/src/wasm/tc-crypto
     @echo "✓ WASM built to web/src/wasm/tc-crypto/"
 
-# [internal] Build crypto-wasm for development (faster, debug symbols)
+# Internal: Build crypto-wasm for development (faster, debug symbols)
 _build-wasm-dev:
     @echo "Building tc-crypto WASM for development..."
     cd crates/tc-crypto && wasm-pack build --target web --dev --out-dir ../../web/src/wasm/tc-crypto
@@ -101,7 +101,7 @@ _build-wasm-dev:
 test-wasm:
     cargo test -p tc-crypto
 
-# [internal] Clean WASM build artifacts
+# Internal: Clean WASM build artifacts
 _clean-wasm:
     rm -rf crates/tc-crypto/pkg web/src/wasm/tc-crypto
     @echo "✓ WASM artifacts cleaned"
@@ -150,7 +150,7 @@ test-frontend-full: _build-wasm-dev
 test-frontend-e2e:
     cd web && yarn playwright:ci
 
-# [internal] Check frontend types
+# Internal: Check frontend types
 _typecheck-frontend:
     cd web && yarn typecheck
 
@@ -198,7 +198,7 @@ install-frontend:
 # Full-Stack Development (Requires Skaffold + Kubernetes Cluster)
 # =============================================================================
 
-# [internal] Check that local rustc version matches mise.toml (for shared cargo cache)
+# Internal: Check that local rustc version matches mise.toml (for shared cargo cache)
 _check-rust-version:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -256,7 +256,7 @@ build-images:
     @echo "Building container images..."
     skaffold build
 
-# [internal] Build images and output artifacts JSON (for reuse with test-ci)
+# Internal: Build images and output artifacts JSON (for reuse with test-ci)
 _build-images-artifacts:
     @echo "Building container images and writing artifacts..."
     skaffold build --file-output artifacts.json


### PR DESCRIPTION
## Summary
- Hide internal recipes behind `_` prefix so they don't appear in `just --list`: `build-wasm-dev`, `clean-wasm`, `typecheck-frontend`, `check-rust-version`, `build-images-artifacts`
- Remove dead recipes: `build-test-postgres` (superseded by `_ensure-test-postgres`), `test-skaffold` (duplicate of `test-ci`), `codegen-frontend` (legacy alias), `node-use` (stale nvm instructions)
- Fold `test-full` into `test-ci` — eliminates alias indirection
- Remove stale `node-use` reference from `setup` output

Public recipe count goes from ~60 to ~53. No behavior changes — all hidden/removed recipes were either unused, duplicates, or internal implementation details.

## Test plan
- [x] `just --list` parses cleanly, hidden recipes not shown
- [ ] `just test-ci` still works (depends on `_build-images-artifacts`)
- [ ] `just dev` still works (depends on `_check-rust-version`)
- [ ] `just test-frontend` still works (depends on `_build-wasm-dev`)
- [ ] `just clean` still works (depends on `_clean-wasm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)