### PR TITLE
chore(justfile): remove dead verify-ci recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,11 +59,6 @@ test-skaffold:
     @echo "Building images and running unit tests via Skaffold..."
     skaffold build --file-output artifacts.json && skaffold test --build-artifacts artifacts.json
 
-# Verify full test suite via Skaffold (CI mode - RECOMMENDED approach per AGENTS.md)
-verify-ci:
-    @echo "Running full CI verification (Skaffold, unit tests, integration tests, E2E)..."
-    skaffold verify -p ci
-
 # Check backend formatting
 lint-backend-fmt:
     cd service && cargo fmt --all -- --check


### PR DESCRIPTION
## Summary
- Remove `verify-ci` recipe — it calls `skaffold verify -p ci` but `skaffold.yaml` has no `verify` stanza, so the command would always fail

After this + PR #325 (declutter), the only cluster test entry point is `test-ci` (`skaffold build` + `skaffold test`).

## Context
PR #2 of the justfile cleanup series:
1. #325 — Declutter (hide internal recipes, remove dead ones)
2. **This PR** — Remove dead `verify-ci`
3. Rename for consistency
4. Update header/setup

## Test plan
- [x] `just --list` parses, `verify-ci` no longer appears
- [x] No references to `verify-ci` found anywhere in docs or CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)