### PR TITLE
fix(helm): auto-generate synthetic backup key on first install

### DIFF
--- a/kube/app/templates/secret.yaml
+++ b/kube/app/templates/secret.yaml
@@ -13,12 +13,20 @@ stringData:
 
 ---
 
+{{- $appSecretName := printf "%s-app" (include "app.fullname" .) }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $appSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "app.fullname" . }}-app
+  name: {{ $appSecretName }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
 type: Opaque
-stringData:
-  synthetic-backup-key: {{ .Values.syntheticBackupKey | quote }}
+data:
+  {{- if and $existingSecret (index $existingSecret.data "synthetic-backup-key") }}
+  synthetic-backup-key: {{ index $existingSecret.data "synthetic-backup-key" }}
+  {{- else if .Values.syntheticBackupKey }}
+  synthetic-backup-key: {{ .Values.syntheticBackupKey | b64enc }}
+  {{- else }}
+  synthetic-backup-key: {{ randAlphaNum 64 | b64enc }}
+  {{- end }}


### PR DESCRIPTION
## Summary

- Auto-generate `TC_SYNTHETIC_BACKUP_KEY` on first Helm install using `randAlphaNum 64`
- Preserve existing key across upgrades via Helm `lookup`
- Still allows explicit override via `.Values.syntheticBackupKey`

This unblocks the homelab-gitops deployment, which has been stuck in an infinite upgrade/rollback loop because the `tc-demo-app` secret was never provisioned.

## What changed

`kube/app/templates/secret.yaml` — the app secret now uses a 3-tier fallback:
1. **Existing cluster secret** (via `lookup`) — preserves across upgrades
2. **Explicit values override** — `syntheticBackupKey` in values.yaml
3. **Random generation** — `randAlphaNum 64` on fresh install

Switched from `stringData` to `data` with `b64enc` to avoid double-encoding when reusing the base64 value returned by `lookup`.

## Test plan

- [ ] `helm template` renders without error (lookup returns empty in dry-run, falls through to randAlphaNum)
- [ ] Deploy to cluster: verify secret created with 64-char random key, and preserved across `flux reconcile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)