### PR TITLE
ci: pin chart source commit alongside image digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -808,6 +808,13 @@ jobs:
             .spec.values.postgres.image.digest = "${{ steps.digests.outputs.postgres }}"
           ' "$FILE"
 
+      - name: Pin chart source to matching commit
+        env:
+          TC_SHA: ${{ github.sha }}
+        run: |
+          SOURCE="clusters/sauce/workloads/tiny-congress/source.yaml"
+          yq -i '.spec.ref.commit = strenv(TC_SHA)' "$SOURCE"
+
       - name: Commit and push
         env:
           TC_SHA: ${{ github.sha }}
@@ -816,6 +823,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add clusters/sauce/workloads/tiny-congress/helmrelease-demo.yaml
+          git add clusters/sauce/workloads/tiny-congress/source.yaml
           # Only commit if there are actual changes
           if git diff --cached --quiet; then
             echo "No digest changes detected"


### PR DESCRIPTION
## Summary
- CD job now updates `source.yaml` to pin the GitRepository to the same commit that built the images
- Keeps chart templates and image digests in lockstep, preventing the drift that caused the 2026-02-28 deploy loop

Cherry-picked from #360 (traceability commit already merged separately).

## Test plan
- [ ] Merge and verify `deploy-gitops` job updates both `helmrelease-demo.yaml` and `source.yaml`
- [ ] Resume the HelmRelease and confirm a clean upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)