### PR TITLE
refine: enforce documented nonce length limit in auth extractor

### DIFF
--- a/service/src/identity/http/auth.rs
+++ b/service/src/identity/http/auth.rs
@@ -43,6 +43,13 @@ pub const MAX_TIMESTAMP_SKEW: i64 = 300;
 /// before signature verification.
 const MAX_BODY_SIZE: usize = 64 * 1024;
 
+/// Maximum length for the `X-Nonce` header value (bytes).
+///
+/// Nonces are opaque client-chosen strings used for replay prevention.
+/// 64 characters is generous for a UUID or random hex string while
+/// bounding the canonical message size before signature verification.
+const MAX_NONCE_LENGTH: usize = 64;
+
 /// Authenticated device extracted from signed request headers.
 ///
 /// Implements `FromRequest` — reads the full body, verifies the signature,
@@ -126,6 +133,10 @@ impl<S: Send + Sync> FromRequest<S> for AuthenticatedDevice {
             .and_then(|v| v.to_str().ok())
             .ok_or_else(|| auth_error("Missing X-Nonce header"))?
             .to_string();
+
+        if nonce.is_empty() || nonce.len() > MAX_NONCE_LENGTH {
+            return Err(auth_error("Nonce must be 1-64 characters"));
+        }
 
         // Parse KID
         let kid: Kid = kid_str
@@ -272,6 +283,21 @@ mod tests {
 
         let future = now + MAX_TIMESTAMP_SKEW + 1;
         assert!((now - future).abs() > MAX_TIMESTAMP_SKEW);
+    }
+
+    #[test]
+    fn test_nonce_length_limits() {
+        // Empty nonce should be rejected
+        assert!("".is_empty());
+
+        // Exactly at limit should be accepted
+        let at_limit = "a".repeat(MAX_NONCE_LENGTH);
+        assert_eq!(at_limit.len(), 64);
+        assert!(at_limit.len() <= MAX_NONCE_LENGTH);
+
+        // Over limit should be rejected
+        let over_limit = "a".repeat(MAX_NONCE_LENGTH + 1);
+        assert!(over_limit.len() > MAX_NONCE_LENGTH);
     }
 
     #[test]


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Enforce the documented 64-character max nonce length in the auth extractor, rejecting empty or oversized X-Nonce headers before they enter the canonical message or reach signature verification.

---
*Generated by [refine.sh](scripts/refine.sh)*