### PR TITLE
refine: close username enumeration oracle in login endpoint

### DIFF
--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -91,7 +91,9 @@ fn validate_login_device(
     signed_payload.extend_from_slice(&req.timestamp.to_le_bytes());
 
     if verify_ed25519(root_pubkey_arr, &signed_payload, &cert_arr).is_err() {
-        return Err(super::bad_request("Invalid device certificate"));
+        // Return 401 with generic message — must be indistinguishable from
+        // AccountNotFound to prevent username enumeration.
+        return Err(super::unauthorized("Invalid credentials"));
     }
 
     let device_kid = device_pubkey.kid();
@@ -123,7 +125,9 @@ pub async fn login(
     // Look up the account by username
     let account = match repo.get_account_by_username(username).await {
         Ok(a) => a,
-        Err(AccountRepoError::NotFound) => return super::bad_request("Invalid credentials"),
+        // Return 401 with generic message — indistinguishable from
+        // InvalidCertificate to prevent username enumeration.
+        Err(AccountRepoError::NotFound) => return super::unauthorized("Invalid credentials"),
         Err(e) => {
             tracing::error!("Login account lookup failed: {e}");
             return super::internal_error();

--- a/service/src/identity/http/mod.rs
+++ b/service/src/identity/http/mod.rs
@@ -72,6 +72,16 @@ pub(crate) fn not_found(msg: &str) -> axum::response::Response {
         .into_response()
 }
 
+pub(crate) fn unauthorized(msg: &str) -> axum::response::Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(ErrorResponse {
+            error: msg.to_string(),
+        }),
+    )
+        .into_response()
+}
+
 pub(crate) fn internal_error() -> axum::response::Response {
     (
         StatusCode::INTERNAL_SERVER_ERROR,

--- a/service/tests/login_tests.rs
+++ b/service/tests/login_tests.rs
@@ -559,13 +559,15 @@ async fn test_login_old_cert_format_rejected() {
     .to_string();
 
     let response = app.oneshot(login_request(&body)).await.expect("response");
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Returns 401 with generic message to prevent username enumeration —
+    // indistinguishable from AccountNotFound.
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     let body_bytes = to_bytes(response.into_body(), 1024 * 1024)
         .await
         .expect("body");
     let body_str = String::from_utf8(body_bytes.to_vec()).expect("utf8");
-    assert!(body_str.contains("Invalid device certificate"));
+    assert!(body_str.contains("Invalid credentials"));
 }
 
 #[shared_runtime_test]
@@ -586,13 +588,15 @@ async fn test_login_wrong_root_key_rejected() {
     );
 
     let response = app.oneshot(login_request(&body)).await.expect("response");
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Returns 401 with generic message to prevent username enumeration —
+    // indistinguishable from AccountNotFound.
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     let body_bytes = to_bytes(response.into_body(), 1024 * 1024)
         .await
         .expect("body");
     let body_str = String::from_utf8(body_bytes.to_vec()).expect("utf8");
-    assert!(body_str.contains("Invalid device certificate"));
+    assert!(body_str.contains("Invalid credentials"));
 }
 
 // =========================================================================
@@ -611,7 +615,9 @@ async fn test_login_handler_account_not_found() {
     let body = login_json("nonexistent", &root, &device_pubkey, "Device", timestamp);
 
     let response = app.oneshot(login_request(&body)).await.expect("response");
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Returns 401 (not 400) to prevent username enumeration — same as
+    // InvalidCertificate so attackers can't distinguish the two cases.
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     let body_bytes = to_bytes(response.into_body(), 1024 * 1024)
         .await


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Close username enumeration oracle in login endpoint by returning identical 401 responses for AccountNotFound and InvalidCertificate, aligning with the backup endpoint's anti-enumeration design

---
*Generated by [refine.sh](scripts/refine.sh)*