### PR TITLE
refine: use [u8; 64] for ValidatedAddDevice cert_bytes

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -141,7 +141,7 @@ pub async fn add_device(
 struct ValidatedAddDevice {
     device_kid: Kid,
     device_name: DeviceName,
-    cert_bytes: Vec<u8>,
+    cert_bytes: [u8; 64],
 }
 
 /// Validate and verify the add-device request inputs.
@@ -199,7 +199,7 @@ async fn validate_add_device_request(
     Ok(ValidatedAddDevice {
         device_kid,
         device_name,
-        cert_bytes,
+        cert_bytes: cert_arr,
     })
 }
 


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Changed ValidatedAddDevice.cert_bytes from Vec<u8> to [u8; 64] in devices.rs, consistent with ValidatedLogin.cert_bytes in login.rs, encoding the Ed25519 signature size invariant in the type

---
*Generated by [refine.sh](scripts/refine.sh)*