### PR TITLE
fix(ci): detect OpenAPI codegen drift in CI and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,10 +181,10 @@ jobs:
           retention-days: 7
 
   # ============================================================
-  # JOB 0c: Verify GraphQL codegen is up-to-date
+  # JOB 0c: Verify codegen is up-to-date (GraphQL + OpenAPI)
   # ============================================================
   codegen-check:
-    name: Check GraphQL codegen
+    name: Check codegen
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -217,12 +217,12 @@ jobs:
 
       - name: Check for uncommitted changes
         run: |
-          if ! git diff --quiet web/schema.graphql web/src/api/generated/; then
-            echo "::error::GraphQL codegen is out of date. Run 'just codegen' and commit the changes."
-            git diff web/schema.graphql web/src/api/generated/
+          if ! git diff --quiet web/schema.graphql web/openapi.json web/src/api/generated/; then
+            echo "::error::Codegen is out of date. Run 'just codegen' and commit the changes."
+            git diff web/schema.graphql web/openapi.json web/src/api/generated/
             exit 1
           fi
-          echo "✓ GraphQL codegen is up to date"
+          echo "✓ Codegen is up to date"
 
   # ============================================================
   # JOB 0d: Security & Dependency Audit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -26,4 +26,13 @@ if git diff --cached --name-only | grep -q '\.rs$'; then
   fi
 fi
 
+# Guard: openapi.json changes require regenerated rest.ts
+if git diff --cached --name-only | grep -q 'web/openapi.json'; then
+  if ! git diff --cached --name-only | grep -q 'web/src/api/generated/rest.ts'; then
+    echo "web/openapi.json is staged but web/src/api/generated/rest.ts is not."
+    echo "Run 'just codegen' and stage the generated file."
+    exit 1
+  fi
+fi
+
 exit $frontend_status


### PR DESCRIPTION
## Summary

- Widen CI `codegen-check` job diff to include `web/openapi.json` (previously only checked `web/schema.graphql` and `web/src/api/generated/`)
- Add pre-commit hook guard: blocks committing `web/openapi.json` without also staging `web/src/api/generated/rest.ts`

Discovered while working on #381 — updating utoipa annotations regenerated `openapi.json` but the TypeScript REST client wasn't regenerated, causing CI to fail.

## Test plan
- [ ] Stage only `web/openapi.json` — pre-commit should block with message to run `just codegen`
- [ ] Stage both `web/openapi.json` and `web/src/api/generated/rest.ts` — hook passes
- [ ] CI `Check codegen` job catches stale `openapi.json` or `rest.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)