### PR TITLE
refine: consolidate root pubkey decode into shared http helper

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -181,14 +181,7 @@ async fn validate_add_device_request(
         }
     };
 
-    let Ok(root_pubkey_bytes) = decode_base64url(&account.root_pubkey) else {
-        tracing::error!("Corrupted root pubkey for account {account_id}");
-        return Err(super::internal_error());
-    };
-    let Ok(root_pubkey_arr): Result<[u8; 32], _> = root_pubkey_bytes.as_slice().try_into() else {
-        tracing::error!("Corrupted root pubkey length for account {account_id}");
-        return Err(super::internal_error());
-    };
+    let root_pubkey_arr = super::decode_account_root_pubkey(&account)?;
 
     if verify_ed25519(&root_pubkey_arr, device_pubkey.as_bytes(), &cert_arr).is_err() {
         return Err(super::bad_request("Invalid device certificate"));

--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -135,13 +135,9 @@ pub async fn login(
     };
 
     // Decode root public key from the stored account
-    let Ok(root_pubkey_bytes) = decode_base64url(&account.root_pubkey) else {
-        tracing::error!("Corrupted root pubkey for account {}", account.id);
-        return super::internal_error();
-    };
-    let Ok(root_pubkey_arr): Result<[u8; 32], _> = root_pubkey_bytes.as_slice().try_into() else {
-        tracing::error!("Corrupted root pubkey length for account {}", account.id);
-        return super::internal_error();
+    let root_pubkey_arr = match super::decode_account_root_pubkey(&account) {
+        Ok(arr) => arr,
+        Err(resp) => return resp,
     };
 
     // Validate device fields and verify the timestamp-bound certificate

--- a/service/src/identity/http/mod.rs
+++ b/service/src/identity/http/mod.rs
@@ -18,7 +18,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::service::{IdentityService, SignupError, SignupRequest};
-use tc_crypto::Kid;
+use crate::identity::repo::AccountRecord;
+use tc_crypto::{decode_base64url, Kid};
 
 /// Signup response
 #[derive(Debug, Serialize, Deserialize)]
@@ -90,6 +91,26 @@ pub(crate) fn internal_error() -> axum::response::Response {
         }),
     )
         .into_response()
+}
+
+/// Decode the stored base64url root public key from an account record into raw bytes.
+///
+/// Both the login and add-device flows look up the root pubkey from the account record
+/// to verify a certificate. This helper consolidates the decode-and-check so both
+/// callers handle corruption identically.
+#[allow(clippy::result_large_err)]
+pub(crate) fn decode_account_root_pubkey(
+    account: &AccountRecord,
+) -> Result<[u8; 32], axum::response::Response> {
+    let Ok(bytes) = decode_base64url(&account.root_pubkey) else {
+        tracing::error!("Corrupted root pubkey for account {}", account.id);
+        return Err(internal_error());
+    };
+    let Ok(arr): Result<[u8; 32], _> = bytes.as_slice().try_into() else {
+        tracing::error!("Corrupted root pubkey length for account {}", account.id);
+        return Err(internal_error());
+    };
+    Ok(arr)
 }
 
 /// Handle signup request — delegates validation and persistence to [`IdentityService`].
@@ -301,5 +322,38 @@ mod tests {
         assert!(body_str.contains("Internal server error"));
         assert!(!body_str.contains("secret_password"));
         assert!(!body_str.contains("db-host"));
+    }
+
+    // ── Helper: decode_account_root_pubkey ─────────────────────────────────
+
+    fn test_account_record(root_pubkey: &str) -> AccountRecord {
+        AccountRecord {
+            id: Uuid::nil(),
+            username: "testuser".to_string(),
+            root_pubkey: root_pubkey.to_string(),
+            root_kid: Kid::derive(&[0u8; 32]),
+        }
+    }
+
+    #[test]
+    fn test_decode_account_root_pubkey_valid() {
+        use tc_crypto::encode_base64url;
+        let bytes = [1u8; 32];
+        let account = test_account_record(&encode_base64url(&bytes));
+        assert_eq!(decode_account_root_pubkey(&account).unwrap(), bytes);
+    }
+
+    #[test]
+    fn test_decode_account_root_pubkey_invalid_base64() {
+        let account = test_account_record("!!!not-base64!!!");
+        assert!(decode_account_root_pubkey(&account).is_err());
+    }
+
+    #[test]
+    fn test_decode_account_root_pubkey_wrong_length() {
+        use tc_crypto::encode_base64url;
+        let short = encode_base64url(&[1u8; 16]); // 16 bytes, not 32
+        let account = test_account_record(&short);
+        assert!(decode_account_root_pubkey(&account).is_err());
     }
 }


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Extracted duplicated root pubkey decode logic from login.rs and devices.rs into a single shared helper decode_account_root_pubkey() in http/mod.rs, eliminating the two-path drift risk for a security-relevant operation.

---
*Generated by [refine.sh](scripts/refine.sh)*