### PR TITLE
refine: add CertificateSignature newtype, consolidate cert decode

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 use super::auth::AuthenticatedDevice;
 use super::ErrorResponse;
 use crate::identity::repo::{AccountRepoError, DeviceKeyRecord, DeviceKeyRepoError, IdentityRepo};
-use crate::identity::service::{DeviceName, DevicePubkey};
-use tc_crypto::{decode_base64url, verify_ed25519, Kid};
+use crate::identity::service::{CertificateSignature, DeviceName, DevicePubkey};
+use tc_crypto::{verify_ed25519, Kid};
 
 /// Device info returned in API responses (omits certificate and raw pubkey)
 #[derive(Debug, Serialize)]
@@ -104,7 +104,7 @@ pub async fn add_device(
             &validated.device_kid,
             &req.pubkey,
             validated.device_name.as_str(),
-            &validated.cert_bytes,
+            validated.cert.as_bytes(),
         )
         .await
     {
@@ -141,7 +141,7 @@ pub async fn add_device(
 struct ValidatedAddDevice {
     device_kid: Kid,
     device_name: DeviceName,
-    cert_bytes: [u8; 64],
+    cert: CertificateSignature,
 }
 
 /// Validate and verify the add-device request inputs.
@@ -157,16 +157,8 @@ async fn validate_add_device_request(
     let device_name =
         DeviceName::parse(&req.name).map_err(|e| super::bad_request(&e.to_string()))?;
 
-    let Ok(cert_bytes) = decode_base64url(&req.certificate) else {
-        return Err(super::bad_request(
-            "Invalid base64url encoding for certificate",
-        ));
-    };
-    let Ok(cert_arr): Result<[u8; 64], _> = cert_bytes.as_slice().try_into() else {
-        return Err(super::bad_request(
-            "certificate must be 64 bytes (Ed25519 signature)",
-        ));
-    };
+    let cert_sig = CertificateSignature::from_base64url(&req.certificate)
+        .map_err(|e| super::bad_request(&e.to_string()))?;
 
     // Look up the account to get the root pubkey for certificate verification
     let account = match repo.get_account_by_id(account_id).await {
@@ -183,7 +175,13 @@ async fn validate_add_device_request(
 
     let root_pubkey_arr = super::decode_account_root_pubkey(&account)?;
 
-    if verify_ed25519(&root_pubkey_arr, device_pubkey.as_bytes(), &cert_arr).is_err() {
+    if verify_ed25519(
+        &root_pubkey_arr,
+        device_pubkey.as_bytes(),
+        cert_sig.as_bytes(),
+    )
+    .is_err()
+    {
         return Err(super::bad_request("Invalid device certificate"));
     }
 
@@ -192,7 +190,7 @@ async fn validate_add_device_request(
     Ok(ValidatedAddDevice {
         device_kid,
         device_name,
-        cert_bytes: cert_arr,
+        cert: cert_sig,
     })
 }
 

--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 use super::auth::MAX_TIMESTAMP_SKEW;
 use super::ErrorResponse;
 use crate::identity::repo::{AccountRepoError, DeviceKeyRepoError, IdentityRepo, NonceRepoError};
-use crate::identity::service::{DeviceName, DevicePubkey};
-use tc_crypto::{decode_base64url, verify_ed25519, Kid};
+use crate::identity::service::{CertificateSignature, DeviceName, DevicePubkey};
+use tc_crypto::{verify_ed25519, Kid};
 
 /// Login request payload
 #[derive(Debug, Deserialize)]
@@ -56,7 +56,7 @@ pub struct LoginResponse {
 struct ValidatedLogin {
     device_kid: Kid,
     device_name: DeviceName,
-    cert_bytes: [u8; 64],
+    cert: CertificateSignature,
 }
 
 /// Validate and verify the login request inputs.
@@ -74,23 +74,15 @@ fn validate_login_device(
     let device_name =
         DeviceName::parse(&req.device.name).map_err(|e| super::bad_request(&e.to_string()))?;
 
-    let Ok(cert_bytes) = decode_base64url(&req.device.certificate) else {
-        return Err(super::bad_request(
-            "Invalid base64url encoding for device.certificate",
-        ));
-    };
-    let Ok(cert_arr): Result<[u8; 64], _> = cert_bytes.as_slice().try_into() else {
-        return Err(super::bad_request(
-            "device.certificate must be 64 bytes (Ed25519 signature)",
-        ));
-    };
+    let cert_sig = CertificateSignature::from_base64url(&req.device.certificate)
+        .map_err(|e| super::bad_request(&e.to_string()))?;
 
     // The certificate must sign device_pubkey || timestamp (LE i64 bytes)
     let mut signed_payload = Vec::with_capacity(40);
     signed_payload.extend_from_slice(device_pubkey.as_bytes());
     signed_payload.extend_from_slice(&req.timestamp.to_le_bytes());
 
-    if verify_ed25519(root_pubkey_arr, &signed_payload, &cert_arr).is_err() {
+    if verify_ed25519(root_pubkey_arr, &signed_payload, cert_sig.as_bytes()).is_err() {
         // Return 401 with generic message — must be indistinguishable from
         // AccountNotFound to prevent username enumeration.
         return Err(super::unauthorized("Invalid credentials"));
@@ -101,7 +93,7 @@ fn validate_login_device(
     Ok(ValidatedLogin {
         device_kid,
         device_name,
-        cert_bytes: cert_arr,
+        cert: cert_sig,
     })
 }
 
@@ -149,7 +141,7 @@ pub async fn login(
     // Record nonce to prevent replay within the timestamp window.
     // Nonce cleanup is handled by the background sweep in main.rs
     // (spawn_nonce_cleanup), using MAX_TIMESTAMP_SKEW as the TTL.
-    let nonce_hash: [u8; 32] = Sha256::digest(validated.cert_bytes).into();
+    let nonce_hash: [u8; 32] = Sha256::digest(validated.cert.as_bytes()).into();
     if let Err(e) = repo.check_and_record_nonce(&nonce_hash).await {
         return match e {
             NonceRepoError::Replay => super::bad_request("Request replay detected"),
@@ -171,7 +163,7 @@ pub async fn login(
             &validated.device_kid,
             &req.device.pubkey,
             validated.device_name.as_str(),
-            &validated.cert_bytes,
+            validated.cert.as_bytes(),
         )
         .await
     {

--- a/service/src/identity/service.rs
+++ b/service/src/identity/service.rs
@@ -241,6 +241,53 @@ impl DevicePubkey {
     }
 }
 
+// ─── CertificateSignature type ──────────────────────────────────────────────
+
+/// A validated Ed25519 certificate signature (exactly 64 bytes).
+///
+/// Can only be constructed through [`CertificateSignature::from_base64url`], which
+/// decodes and validates the byte length.
+#[derive(Debug, Clone)]
+pub struct CertificateSignature([u8; 64]);
+
+/// Error type for certificate signature validation failures.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CertificateSignatureError {
+    InvalidEncoding,
+    InvalidLength,
+}
+
+impl std::fmt::Display for CertificateSignatureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidEncoding => write!(f, "Invalid base64url encoding for certificate"),
+            Self::InvalidLength => write!(f, "certificate must be 64 bytes (Ed25519 signature)"),
+        }
+    }
+}
+
+impl CertificateSignature {
+    /// Decode and validate a base64url-encoded Ed25519 signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CertificateSignatureError`] if decoding fails or length is not 64.
+    pub fn from_base64url(encoded: &str) -> Result<Self, CertificateSignatureError> {
+        let bytes =
+            decode_base64url(encoded).map_err(|_| CertificateSignatureError::InvalidEncoding)?;
+        let arr: [u8; 64] = bytes
+            .try_into()
+            .map_err(|_| CertificateSignatureError::InvalidLength)?;
+        Ok(Self(arr))
+    }
+
+    /// Return the raw 64-byte signature.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
 // ─── Service trait and implementation ────────────────────────────────────────
 
 /// Orchestrates identity operations: validation + atomic persistence.
@@ -355,14 +402,8 @@ impl IdentityService for DefaultIdentityService {
             .map_err(|e| SignupError::Validation(e.to_string()))?;
 
         // Decode and verify certificate
-        let certificate_bytes = decode_base64url(&req.device.certificate).map_err(|_| {
-            SignupError::Validation("Invalid base64url encoding for device.certificate".to_string())
-        })?;
-        let cert_arr: [u8; 64] = certificate_bytes.as_slice().try_into().map_err(|_| {
-            SignupError::Validation(
-                "device.certificate must be 64 bytes (Ed25519 signature)".to_string(),
-            )
-        })?;
+        let cert_sig = CertificateSignature::from_base64url(&req.device.certificate)
+            .map_err(|e| SignupError::Validation(e.to_string()))?;
 
         // Verify the certificate: root key must have signed the device public key.
         // The signed message is the raw 32-byte device pubkey. This is sufficient because
@@ -370,8 +411,12 @@ impl IdentityService for DefaultIdentityService {
         // cannot be replayed for a different device. If a future "rotate device key"
         // feature reuses key material, the message format must be extended (e.g. with
         // account binding or a nonce).
-        verify_ed25519(&root_pubkey_arr, device_pubkey.as_bytes(), &cert_arr)
-            .map_err(|_| SignupError::Validation("Invalid device certificate".to_string()))?;
+        verify_ed25519(
+            &root_pubkey_arr,
+            device_pubkey.as_bytes(),
+            cert_sig.as_bytes(),
+        )
+        .map_err(|_| SignupError::Validation("Invalid device certificate".to_string()))?;
 
         // Build validated signup data and delegate to repo
         let validated = ValidatedSignup {
@@ -384,7 +429,7 @@ impl IdentityService for DefaultIdentityService {
             device_pubkey: req.device.pubkey.clone(),
             device_kid,
             device_name: device_name.as_str().to_string(),
-            certificate: certificate_bytes,
+            certificate: cert_sig.as_bytes().to_vec(),
         };
 
         self.repo


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added CertificateSignature([u8; 64]) newtype to eliminate duplicated base64url-decode + 64-byte length check that was copied across signup, add-device, and login call sites.

---
*Generated by [refine.sh](scripts/refine.sh)*