### PR TITLE
refine: add direct unit tests for DeviceName::parse

### DIFF
--- a/service/src/identity/service.rs
+++ b/service/src/identity/service.rs
@@ -580,6 +580,42 @@ mod tests {
         assert_eq!(validate_username("ROOT"), Err(UsernameError::Reserved));
     }
 
+    // ── DeviceName validation (direct function tests) ─────────────────────
+
+    #[test]
+    fn test_device_name_empty() {
+        assert!(matches!(DeviceName::parse(""), Err(DeviceNameError::Empty)));
+    }
+
+    #[test]
+    fn test_device_name_whitespace_only() {
+        assert!(matches!(
+            DeviceName::parse("   "),
+            Err(DeviceNameError::Empty)
+        ));
+    }
+
+    #[test]
+    fn test_device_name_max_valid_length() {
+        let name = "a".repeat(128);
+        assert!(DeviceName::parse(&name).is_ok());
+    }
+
+    #[test]
+    fn test_device_name_too_long() {
+        let name = "a".repeat(129);
+        assert!(matches!(
+            DeviceName::parse(&name),
+            Err(DeviceNameError::TooLong)
+        ));
+    }
+
+    #[test]
+    fn test_device_name_trims_whitespace() {
+        let result = DeviceName::parse("  My Device  ").unwrap();
+        assert_eq!(result.as_str(), "My Device");
+    }
+
     // ── Service-level validation tests ─────────────────────────────────────
 
     #[tokio::test]


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added 5 direct unit tests for DeviceName::parse covering empty, whitespace-only, max-valid length, first-invalid length, and trimming — the TooLong error variant and trim behavior were previously completely untested

---
*Generated by [refine.sh](scripts/refine.sh)*