### PR TITLE
refine: add direct unit test for validate_username empty case

### DIFF
--- a/service/src/identity/service.rs
+++ b/service/src/identity/service.rs
@@ -561,6 +561,11 @@ mod tests {
     // ── Username validation (direct function tests) ────────────────────────
 
     #[test]
+    fn test_validate_username_empty() {
+        assert_eq!(validate_username(""), Err(UsernameError::Empty));
+    }
+
+    #[test]
     fn test_validate_username_too_short() {
         assert_eq!(validate_username("ab"), Err(UsernameError::TooShort));
         assert_eq!(validate_username("a"), Err(UsernameError::TooShort));


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added direct unit test for validate_username('') → Err(UsernameError::Empty), closing the only untested variant in the direct test suite.

---
*Generated by [refine.sh](scripts/refine.sh)*