### PR TITLE
refine: enforce username max-length at login and backup endpoints

### DIFF
--- a/service/src/identity/http/backup.rs
+++ b/service/src/identity/http/backup.rs
@@ -131,6 +131,9 @@ pub async fn get_backup(
     if username.is_empty() {
         return super::bad_request("Username cannot be empty");
     }
+    if username.len() > crate::identity::service::MAX_USERNAME_LEN {
+        return super::bad_request("Username too long");
+    }
 
     // Always perform the account lookup.
     let account_result = repo.get_account_by_username(username).await;
@@ -269,6 +272,20 @@ mod tests {
             .uri(format!("/auth/backup/{username}"))
             .body(Body::empty())
             .expect("request builder")
+    }
+
+    #[tokio::test]
+    async fn test_get_backup_too_long_username_returns_bad_request() {
+        let repo = MockIdentityRepo::new();
+        let app = test_router(repo);
+
+        let username = "a".repeat(65);
+        let response = app
+            .oneshot(backup_request(&username))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     /// Anti-enumeration: unknown username must return 200, not 404.

--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -113,6 +113,9 @@ pub async fn login(
     if username.is_empty() {
         return super::bad_request("Username is required");
     }
+    if username.len() > crate::identity::service::MAX_USERNAME_LEN {
+        return super::bad_request("Username too long");
+    }
 
     // Look up the account by username
     let account = match repo.get_account_by_username(username).await {
@@ -199,10 +202,18 @@ pub async fn login(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::StatusCode;
+    use crate::identity::repo::mock::MockIdentityRepo;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+        routing::post,
+        Router,
+    };
     use ed25519_dalek::{Signer, SigningKey};
     use rand::rngs::OsRng;
+    use std::sync::Arc;
     use tc_crypto::encode_base64url;
+    use tower::ServiceExt;
 
     /// Build a valid login request and matching root pubkey.
     ///
@@ -331,5 +342,50 @@ mod tests {
             .err()
             .expect("expected validation error");
         assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ── Handler-level tests ─────────────────────────────────────────────────
+
+    fn test_login_router(repo: MockIdentityRepo) -> Router {
+        Router::new()
+            .route("/auth/login", post(login))
+            .layer(axum::extract::Extension(
+                Arc::new(repo) as Arc<dyn crate::identity::repo::IdentityRepo>
+            ))
+    }
+
+    #[tokio::test]
+    async fn test_login_too_long_username_returns_bad_request() {
+        let repo = MockIdentityRepo::new();
+        let app = test_login_router(repo);
+
+        let long_username = "a".repeat(65);
+        let body = serde_json::json!({
+            "username": long_username,
+            "timestamp": chrono::Utc::now().timestamp(),
+            "device": {
+                "pubkey": encode_base64url(&[0u8; 32]),
+                "name": "test",
+                "certificate": encode_base64url(&[0u8; 64])
+            }
+        })
+        .to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .expect("request builder"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body_bytes = to_bytes(response.into_body(), 1024).await.expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body_bytes).expect("json");
+        assert!(payload["error"].as_str().unwrap().contains("too long"));
     }
 }

--- a/service/src/identity/service.rs
+++ b/service/src/identity/service.rs
@@ -66,6 +66,12 @@ pub enum SignupError {
 
 // ─── Validation helpers ──────────────────────────────────────────────────────
 
+/// Maximum byte length of a valid username.
+///
+/// Used both in signup validation and at the login/backup endpoints to reject
+/// obviously invalid input before hitting the database.
+pub const MAX_USERNAME_LEN: usize = 64;
+
 const RESERVED_USERNAMES: &[&str] = &[
     "admin",
     "administrator",
@@ -113,7 +119,7 @@ pub fn validate_username(username: &str) -> Result<(), UsernameError> {
     if username.len() < 3 {
         return Err(UsernameError::TooShort);
     }
-    if username.len() > 64 {
+    if username.len() > MAX_USERNAME_LEN {
         return Err(UsernameError::TooLong);
     }
     if !username


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added MAX_USERNAME_LEN constant and enforced 64-byte username ceiling at the login and backup endpoints, which previously passed unbounded usernames directly to the database.

---
*Generated by [refine.sh](scripts/refine.sh)*