### PR TITLE
refine: test nonce replay and database error paths in login handler

### DIFF
--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -202,7 +202,9 @@ pub async fn login(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::identity::repo::{mock::MockIdentityRepo, AccountRecord, DeviceKeyRepoError};
+    use crate::identity::repo::{
+        mock::MockIdentityRepo, AccountRecord, DeviceKeyRepoError, NonceRepoError,
+    };
     use axum::{
         body::{to_bytes, Body},
         http::{Request, StatusCode},
@@ -554,6 +556,75 @@ mod tests {
             account_id.to_string()
         );
         assert_eq!(payload["root_kid"].as_str().unwrap(), root_kid.as_str());
+    }
+
+    /// Nonce replay must return 400 — replaying a valid request within the
+    /// timestamp window is rejected before device key creation.
+    #[tokio::test]
+    async fn test_login_nonce_replay_returns_bad_request() {
+        let (req, root_pubkey) = make_valid_components();
+
+        let repo = MockIdentityRepo::new();
+        repo.set_account_by_username_result(Ok(AccountRecord {
+            id: Uuid::new_v4(),
+            username: req.username.clone(),
+            root_pubkey: encode_base64url(&root_pubkey),
+            root_kid: Kid::derive(&root_pubkey),
+        }));
+        repo.set_nonce_result(Err(NonceRepoError::Replay));
+        let app = test_login_router(repo);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header("content-type", "application/json")
+                    .body(Body::from(login_body(&req)))
+                    .expect("request builder"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body_bytes = to_bytes(response.into_body(), 1024).await.expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body_bytes).expect("json");
+        assert_eq!(
+            payload["error"].as_str().unwrap(),
+            "Request replay detected"
+        );
+    }
+
+    /// Nonce DB error must return 500 without leaking internal details.
+    #[tokio::test]
+    async fn test_login_nonce_database_error_returns_internal() {
+        let (req, root_pubkey) = make_valid_components();
+
+        let repo = MockIdentityRepo::new();
+        repo.set_account_by_username_result(Ok(AccountRecord {
+            id: Uuid::new_v4(),
+            username: req.username.clone(),
+            root_pubkey: encode_base64url(&root_pubkey),
+            root_kid: Kid::derive(&root_pubkey),
+        }));
+        repo.set_nonce_result(Err(NonceRepoError::Database(sqlx::Error::Protocol(
+            "db error".to_string(),
+        ))));
+        let app = test_login_router(repo);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header("content-type", "application/json")
+                    .body(Body::from(login_body(&req)))
+                    .expect("request builder"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/service/src/identity/repo/identity.rs
+++ b/service/src/identity/repo/identity.rs
@@ -377,6 +377,7 @@ pub mod mock {
         pub get_device_key_by_kid_result:
             Mutex<Option<Result<DeviceKeyRecord, DeviceKeyRepoError>>>,
         pub get_backup_by_kid_result: Mutex<Option<Result<BackupRecord, BackupRepoError>>>,
+        pub nonce_result: Mutex<Option<Result<(), NonceRepoError>>>,
     }
 
     impl MockIdentityRepo {
@@ -389,6 +390,7 @@ pub mod mock {
                 create_device_key_error: Mutex::new(None),
                 get_device_key_by_kid_result: Mutex::new(None),
                 get_backup_by_kid_result: Mutex::new(None),
+                nonce_result: Mutex::new(None),
             }
         }
 
@@ -456,6 +458,15 @@ pub mod mock {
         /// Panics if the internal mutex is poisoned.
         pub fn set_get_backup_by_kid_result(&self, result: Result<BackupRecord, BackupRepoError>) {
             *self.get_backup_by_kid_result.lock().expect("lock poisoned") = Some(result);
+        }
+
+        /// Set the result that [`IdentityRepo::check_and_record_nonce`] will return.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the internal mutex is poisoned.
+        pub fn set_nonce_result(&self, result: Result<(), NonceRepoError>) {
+            *self.nonce_result.lock().expect("lock poisoned") = Some(result);
         }
     }
 
@@ -586,7 +597,11 @@ pub mod mock {
         }
 
         async fn check_and_record_nonce(&self, _nonce_hash: &[u8]) -> Result<(), NonceRepoError> {
-            Ok(())
+            self.nonce_result
+                .lock()
+                .expect("lock poisoned")
+                .take()
+                .unwrap_or(Ok(()))
         }
 
         async fn cleanup_expired_nonces(&self, _max_age_secs: i64) -> Result<u64, NonceRepoError> {


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added tests for the nonce replay and database error branches in the login handler, and extended MockIdentityRepo with a configurable nonce result to make those paths testable.

---
*Generated by [refine.sh](scripts/refine.sh)*