### PR TITLE
refine: consolidate username validation in login and backup handlers

### DIFF
--- a/service/src/identity/http/backup.rs
+++ b/service/src/identity/http/backup.rs
@@ -17,6 +17,7 @@ use sha2::Sha256;
 use tc_crypto::Kid;
 
 use crate::identity::repo::{AccountRepoError, BackupRepoError, IdentityRepo};
+use crate::identity::service::validate_username;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -128,11 +129,8 @@ pub async fn get_backup(
     Path(username): Path<String>,
 ) -> impl IntoResponse {
     let username = username.trim();
-    if username.is_empty() {
-        return super::bad_request("Username cannot be empty");
-    }
-    if username.len() > crate::identity::service::MAX_USERNAME_LEN {
-        return super::bad_request("Username too long");
+    if let Err(e) = validate_username(username) {
+        return super::bad_request(&e.to_string());
     }
 
     // Always perform the account lookup.

--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use super::auth::MAX_TIMESTAMP_SKEW;
 use super::ErrorResponse;
 use crate::identity::repo::{AccountRepoError, DeviceKeyRepoError, IdentityRepo, NonceRepoError};
-use crate::identity::service::{CertificateSignature, DeviceName, DevicePubkey};
+use crate::identity::service::{validate_username, CertificateSignature, DeviceName, DevicePubkey};
 use tc_crypto::{verify_ed25519, Kid};
 
 /// Login request payload
@@ -110,11 +110,8 @@ pub async fn login(
 
     // Validate username
     let username = req.username.trim();
-    if username.is_empty() {
-        return super::bad_request("Username is required");
-    }
-    if username.len() > crate::identity::service::MAX_USERNAME_LEN {
-        return super::bad_request("Username too long");
+    if let Err(e) = validate_username(username) {
+        return super::bad_request(&e.to_string());
     }
 
     // Look up the account by username
@@ -395,7 +392,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body_bytes = to_bytes(response.into_body(), 1024).await.expect("body");
         let payload: serde_json::Value = serde_json::from_slice(&body_bytes).expect("json");
-        assert!(payload["error"].as_str().unwrap().contains("required"));
+        assert!(payload["error"].as_str().unwrap().contains("empty"));
     }
 
     #[tokio::test]

--- a/service/tests/login_tests.rs
+++ b/service/tests/login_tests.rs
@@ -648,8 +648,8 @@ async fn test_login_empty_username() {
         .expect("body");
     let body_str = String::from_utf8(body_bytes.to_vec()).expect("utf8");
     assert!(
-        body_str.contains("Username is required"),
-        "Expected username required error, got: {body_str}"
+        body_str.contains("cannot be empty"),
+        "Expected username empty error, got: {body_str}"
     );
 }
 


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Replaced duplicated partial username validation in login.rs and backup.rs with calls to the existing validate_username() function, eliminating two divergent code paths and extending coverage to include minimum-length, character, and reserved-name checks.

---
*Generated by [refine.sh](scripts/refine.sh)*