### PR TITLE
refine: test revoke_device and rename_device repo error paths

### DIFF
--- a/service/src/identity/http/auth.rs
+++ b/service/src/identity/http/auth.rs
@@ -72,6 +72,19 @@ impl AuthenticatedDevice {
         serde_json::from_slice(&self.body_bytes)
             .map_err(|e| super::bad_request(&format!("Invalid JSON body: {e}")))
     }
+
+    /// Construct an `AuthenticatedDevice` for use in unit tests.
+    ///
+    /// Skips all authentication checks. For testing handler logic after
+    /// authentication has conceptually succeeded.
+    #[cfg(test)]
+    pub fn for_test(account_id: Uuid, device_kid: Kid, body: Bytes) -> Self {
+        Self {
+            account_id,
+            device_kid,
+            body_bytes: body,
+        }
+    }
 }
 
 /// Validate a nonce value from the X-Nonce header.

--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -481,6 +481,142 @@ mod tests {
             .expect("expected error");
         assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
+
+    // ── revoke_device error paths ────────────────────────────────────────────
+
+    /// Build an `AuthenticatedDevice` and a repo where `get_owned_device` succeeds
+    /// (so we reach the `revoke_device_key` call), then inject an error there.
+    fn setup_revoke_preconditions(
+        account_id: Uuid,
+        target_kid: &Kid,
+    ) -> (std::sync::Arc<MockIdentityRepo>, AuthenticatedDevice) {
+        // auth device has a different KID so the "cannot revoke self" check passes
+        let auth_kid = Kid::derive(&[0xAAu8; 32]);
+        let record = make_device_record(account_id);
+
+        let repo = std::sync::Arc::new(MockIdentityRepo::new());
+        // `get_owned_device` calls `get_device_key_by_kid` — return a record owned by this account
+        repo.set_get_device_key_by_kid_result(Ok(record));
+
+        let auth = AuthenticatedDevice::for_test(account_id, auth_kid, axum::body::Bytes::new());
+        let _ = target_kid; // used by caller for the Path argument
+        (repo, auth)
+    }
+
+    #[tokio::test]
+    async fn test_revoke_device_already_revoked_returns_conflict() {
+        use axum::response::IntoResponse;
+        use axum::{body::to_bytes, extract::Extension, extract::Path};
+
+        let account_id = Uuid::new_v4();
+        let target_kid = Kid::derive(&[0xBBu8; 32]);
+        let (repo, auth) = setup_revoke_preconditions(account_id, &target_kid);
+        repo.set_revoke_device_key_result(Err(DeviceKeyRepoError::AlreadyRevoked));
+
+        let response = revoke_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            Path(target_kid.as_str().to_string()),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = to_bytes(response.into_body(), 1024).await.expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(payload["error"].as_str().unwrap(), "Device already revoked");
+    }
+
+    #[tokio::test]
+    async fn test_revoke_device_db_error_returns_internal() {
+        use axum::response::IntoResponse;
+        use axum::{extract::Extension, extract::Path};
+
+        let account_id = Uuid::new_v4();
+        let target_kid = Kid::derive(&[0xBBu8; 32]);
+        let (repo, auth) = setup_revoke_preconditions(account_id, &target_kid);
+        repo.set_revoke_device_key_result(Err(DeviceKeyRepoError::Database(
+            sqlx::Error::Protocol("db error".to_string()),
+        )));
+
+        let response = revoke_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            Path(target_kid.as_str().to_string()),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // ── rename_device error paths ────────────────────────────────────────────
+
+    fn setup_rename_preconditions(
+        account_id: Uuid,
+        target_kid: &Kid,
+    ) -> (std::sync::Arc<MockIdentityRepo>, AuthenticatedDevice) {
+        let auth_kid = Kid::derive(&[0xAAu8; 32]);
+        let record = make_device_record(account_id);
+
+        let repo = std::sync::Arc::new(MockIdentityRepo::new());
+        repo.set_get_device_key_by_kid_result(Ok(record));
+
+        let body = axum::body::Bytes::from(r#"{"name":"Renamed Device"}"#);
+        let auth = AuthenticatedDevice::for_test(account_id, auth_kid, body);
+        let _ = target_kid;
+        (repo, auth)
+    }
+
+    #[tokio::test]
+    async fn test_rename_device_already_revoked_returns_conflict() {
+        use axum::response::IntoResponse;
+        use axum::{body::to_bytes, extract::Extension, extract::Path};
+
+        let account_id = Uuid::new_v4();
+        let target_kid = Kid::derive(&[0xCCu8; 32]);
+        let (repo, auth) = setup_rename_preconditions(account_id, &target_kid);
+        repo.set_rename_device_key_result(Err(DeviceKeyRepoError::AlreadyRevoked));
+
+        let response = rename_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            Path(target_kid.as_str().to_string()),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = to_bytes(response.into_body(), 1024).await.expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(
+            payload["error"].as_str().unwrap(),
+            "Cannot rename a revoked device"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rename_device_db_error_returns_internal() {
+        use axum::response::IntoResponse;
+        use axum::{extract::Extension, extract::Path};
+
+        let account_id = Uuid::new_v4();
+        let target_kid = Kid::derive(&[0xCCu8; 32]);
+        let (repo, auth) = setup_rename_preconditions(account_id, &target_kid);
+        repo.set_rename_device_key_result(Err(DeviceKeyRepoError::Database(
+            sqlx::Error::Protocol("db error".to_string()),
+        )));
+
+        let response = rename_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            Path(target_kid.as_str().to_string()),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }
 
 /// Verify a device exists and belongs to the given account.

--- a/service/src/identity/repo/identity.rs
+++ b/service/src/identity/repo/identity.rs
@@ -378,6 +378,8 @@ pub mod mock {
             Mutex<Option<Result<DeviceKeyRecord, DeviceKeyRepoError>>>,
         pub get_backup_by_kid_result: Mutex<Option<Result<BackupRecord, BackupRepoError>>>,
         pub nonce_result: Mutex<Option<Result<(), NonceRepoError>>>,
+        pub revoke_device_key_result: Mutex<Option<Result<(), DeviceKeyRepoError>>>,
+        pub rename_device_key_result: Mutex<Option<Result<(), DeviceKeyRepoError>>>,
     }
 
     impl MockIdentityRepo {
@@ -391,6 +393,8 @@ pub mod mock {
                 get_device_key_by_kid_result: Mutex::new(None),
                 get_backup_by_kid_result: Mutex::new(None),
                 nonce_result: Mutex::new(None),
+                revoke_device_key_result: Mutex::new(None),
+                rename_device_key_result: Mutex::new(None),
             }
         }
 
@@ -467,6 +471,24 @@ pub mod mock {
         /// Panics if the internal mutex is poisoned.
         pub fn set_nonce_result(&self, result: Result<(), NonceRepoError>) {
             *self.nonce_result.lock().expect("lock poisoned") = Some(result);
+        }
+
+        /// Set the result that [`IdentityRepo::revoke_device_key`] will return.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the internal mutex is poisoned.
+        pub fn set_revoke_device_key_result(&self, result: Result<(), DeviceKeyRepoError>) {
+            *self.revoke_device_key_result.lock().expect("lock poisoned") = Some(result);
+        }
+
+        /// Set the result that [`IdentityRepo::rename_device_key`] will return.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the internal mutex is poisoned.
+        pub fn set_rename_device_key_result(&self, result: Result<(), DeviceKeyRepoError>) {
+            *self.rename_device_key_result.lock().expect("lock poisoned") = Some(result);
         }
     }
 
@@ -581,7 +603,11 @@ pub mod mock {
         }
 
         async fn revoke_device_key(&self, _device_kid: &Kid) -> Result<(), DeviceKeyRepoError> {
-            Ok(())
+            self.revoke_device_key_result
+                .lock()
+                .expect("lock poisoned")
+                .take()
+                .unwrap_or(Ok(()))
         }
 
         async fn rename_device_key(
@@ -589,7 +615,11 @@ pub mod mock {
             _device_kid: &Kid,
             _new_name: &str,
         ) -> Result<(), DeviceKeyRepoError> {
-            Ok(())
+            self.rename_device_key_result
+                .lock()
+                .expect("lock poisoned")
+                .take()
+                .unwrap_or(Ok(()))
         }
 
         async fn touch_device_key(&self, _device_kid: &Kid) -> Result<(), DeviceKeyRepoError> {


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added tests for the AlreadyRevoked and DB-error branches of revoke_device (→ 409) and rename_device (→ 409/500), which were previously untestable because MockIdentityRepo always returned Ok(()) for those operations.

---
*Generated by [refine.sh](scripts/refine.sh)*