### PR TITLE
refine: test list_devices handler success and DB error paths

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -680,6 +680,60 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    // ── list_devices ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_list_devices_success_returns_ok_with_records() {
+        use axum::response::IntoResponse;
+        use axum::{body::to_bytes, extract::Extension};
+
+        let account_id = Uuid::new_v4();
+        let record = make_device_record(account_id);
+        let kid = record.device_kid.clone();
+
+        let repo = std::sync::Arc::new(MockIdentityRepo::new());
+        repo.set_list_device_keys_result(Ok(vec![record]));
+
+        let auth = AuthenticatedDevice::for_test(account_id, kid, axum::body::Bytes::new());
+
+        let response = list_devices(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024).await.expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(payload["devices"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_devices_db_error_returns_internal() {
+        use axum::extract::Extension;
+        use axum::response::IntoResponse;
+
+        let account_id = Uuid::new_v4();
+        let auth_kid = Kid::derive(&[0xAAu8; 32]);
+
+        let repo = std::sync::Arc::new(MockIdentityRepo::new());
+        repo.set_list_device_keys_result(Err(DeviceKeyRepoError::Database(sqlx::Error::Protocol(
+            "db error".to_string(),
+        ))));
+
+        let auth = AuthenticatedDevice::for_test(account_id, auth_kid, axum::body::Bytes::new());
+
+        let response = list_devices(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }
 
 /// Verify a device exists and belongs to the given account.

--- a/service/src/identity/repo/identity.rs
+++ b/service/src/identity/repo/identity.rs
@@ -376,6 +376,8 @@ pub mod mock {
         pub create_device_key_error: Mutex<Option<DeviceKeyRepoError>>,
         pub get_device_key_by_kid_result:
             Mutex<Option<Result<DeviceKeyRecord, DeviceKeyRepoError>>>,
+        pub list_device_keys_result:
+            Mutex<Option<Result<Vec<DeviceKeyRecord>, DeviceKeyRepoError>>>,
         pub get_backup_by_kid_result: Mutex<Option<Result<BackupRecord, BackupRepoError>>>,
         pub nonce_result: Mutex<Option<Result<(), NonceRepoError>>>,
         pub revoke_device_key_result: Mutex<Option<Result<(), DeviceKeyRepoError>>>,
@@ -391,6 +393,7 @@ pub mod mock {
                 account_by_id_result: Mutex::new(None),
                 create_device_key_error: Mutex::new(None),
                 get_device_key_by_kid_result: Mutex::new(None),
+                list_device_keys_result: Mutex::new(None),
                 get_backup_by_kid_result: Mutex::new(None),
                 nonce_result: Mutex::new(None),
                 revoke_device_key_result: Mutex::new(None),
@@ -453,6 +456,18 @@ pub mod mock {
                 .get_device_key_by_kid_result
                 .lock()
                 .expect("lock poisoned") = Some(result);
+        }
+
+        /// Set the result that [`IdentityRepo::list_device_keys_by_account`] will return.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the internal mutex is poisoned.
+        pub fn set_list_device_keys_result(
+            &self,
+            result: Result<Vec<DeviceKeyRecord>, DeviceKeyRepoError>,
+        ) {
+            *self.list_device_keys_result.lock().expect("lock poisoned") = Some(result);
         }
 
         /// Set the result that [`IdentityRepo::get_backup_by_kid`] will return.
@@ -588,7 +603,11 @@ pub mod mock {
             &self,
             _account_id: Uuid,
         ) -> Result<Vec<DeviceKeyRecord>, DeviceKeyRepoError> {
-            Ok(vec![])
+            self.list_device_keys_result
+                .lock()
+                .expect("lock poisoned")
+                .take()
+                .unwrap_or(Ok(vec![]))
         }
 
         async fn get_device_key_by_kid(


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added configurable mock result for list_device_keys_by_account and tests covering the list_devices handler's success path and DB error path.

---
*Generated by [refine.sh](scripts/refine.sh)*