### PR TITLE
docs: add ADR-008 and ADR-009 for verifier and sim architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,8 @@ Architecture Decision Records explaining why we chose specific approaches:
 | [005-mantine-first-styling.md](decisions/005-mantine-first-styling.md) | Mantine-first styling approach |
 | [006-wasm-crypto-sharing.md](decisions/006-wasm-crypto-sharing.md) | Shared crypto code via WASM |
 | [007-rest-endpoint-generation.md](decisions/007-rest-endpoint-generation.md) | REST endpoint generation strategy (Proposed) |
+| [008-account-based-verifiers.md](decisions/008-account-based-verifiers.md) | Verifiers as regular accounts with config bootstrap |
+| [009-sim-as-api-client.md](decisions/009-sim-as-api-client.md) | Simulation worker as pure HTTP API client |
 
 ## Checklists
 

--- a/docs/decisions/008-account-based-verifiers.md
+++ b/docs/decisions/008-account-based-verifiers.md
@@ -1,0 +1,55 @@
+# ADR-008: Account-Based Verifiers with Config Bootstrap
+
+## Status
+Accepted
+
+## Context
+TinyCongress needs a way for external identity verifiers (e.g., ID.me) to endorse user accounts for voting eligibility. The initial implementation used a dedicated `verifier_accounts` table with API-key authentication — verifiers were a separate entity class with their own auth mechanism.
+
+This created several problems:
+- Two authentication systems to maintain (device-key signing for users, Bearer tokens for verifiers)
+- Verifier accounts couldn't be managed through the same identity infrastructure as regular accounts
+- The API-key approach didn't align with TinyCongress's trust model where all authentication is based on Ed25519 key pairs
+- No way for the sim worker to act as a verifier without a separate credential type
+
+## Decision
+Verifiers are regular accounts authenticated via the same device-key signing protocol as all other users. A verifier is simply an account that holds an `authorized_verifier` endorsement (with `issuer_id = NULL` for platform-bootstrapped verifiers).
+
+**Bootstrap mechanism:** The API server reads `TC_VERIFIERS` (a JSON array of `{name, public_key}` entries) at startup and idempotently creates accounts + genesis endorsements. This runs on every startup with `ON CONFLICT DO NOTHING` semantics.
+
+**Authentication flow:** Verifiers sign requests to `POST /verifiers/endorsements` using the same `X-Device-Kid` / `X-Signature` / `X-Timestamp` / `X-Nonce` headers as any authenticated user. The endpoint checks that the caller has the `authorized_verifier` endorsement before allowing the operation.
+
+**Login:** Since bootstrap only creates the account with a root key (no device key), the verifier must call `POST /auth/login` to register a device key before making authenticated requests. The login certificate is `root_key.sign(device_pubkey || timestamp_le_i64_bytes)`.
+
+## Consequences
+
+### Positive
+- Single authentication system — device-key signing for everything
+- Verifiers are first-class accounts that can be audited, revoked, and managed like any other account
+- The endorsement trail is clear: `issuer_id` on endorsements traces back to a real account
+- Genesis endorsements (NULL issuer) are distinguishable from earned endorsements
+- The sim worker can act as a verifier using the same `SimAccount` identity infrastructure
+
+### Negative
+- Bootstrap config must be coordinated between the API server (`TC_VERIFIERS`) and any client that needs to act as that verifier (e.g., the sim worker must derive the same key pair)
+- Verifier accounts consume a row in the accounts table (negligible cost, but they're mixed in with real users)
+
+### Neutral
+- The `verifier_accounts` table and API-key columns were removed in migration 10
+- External verifiers (like ID.me) still use their own OAuth flow for identity verification but create endorsements through the same `POST /verifiers/endorsements` endpoint
+
+## Alternatives considered
+
+### API-key authentication (original approach)
+- Verifiers authenticated with `Authorization: Bearer <api-key>`
+- Rejected: violated the principle of a single auth mechanism, required maintaining a parallel credential system, and didn't produce auditable issuer trails on endorsements
+
+### Service-to-service tokens (JWT/mTLS)
+- Machine-to-machine auth using short-lived tokens or mutual TLS
+- Rejected: over-engineered for the current scale, adds infrastructure complexity (token issuer, certificate management), and still requires a separate auth path
+
+## References
+- PR #381, #384: Generalized verifier API implementation
+- `service/src/reputation/bootstrap.rs`: Bootstrap logic
+- `service/src/reputation/http/mod.rs`: Endorsement endpoint with `AuthenticatedDevice`
+- `docs/interfaces/environment-variables.md`: `TC_VERIFIERS` configuration

--- a/docs/decisions/009-sim-as-api-client.md
+++ b/docs/decisions/009-sim-as-api-client.md
@@ -1,0 +1,66 @@
+# ADR-009: Simulation Worker as Pure HTTP API Client
+
+## Status
+Accepted
+
+## Context
+The demo environment needs synthetic content (rooms, polls, votes) to showcase TinyCongress. The original "seed" module accessed the database directly — it shared the `PgPool` and ran SQL inserts to populate rooms and cast votes.
+
+This approach had problems:
+- Bypassed all HTTP-layer validation, auth middleware, and business logic
+- Created a coupling between the seeder and the database schema — migration changes broke the seeder
+- Couldn't verify that the API actually worked end-to-end for the operations it was seeding
+- Violated the trust boundary: the seeder handled key material server-side to create accounts, which real clients never do
+
+## Decision
+The simulation worker (`sim` binary) is a pure HTTP API client. It interacts exclusively through the public REST API — the same endpoints real users and frontends hit. It has no database dependency and no access to `PgPool`.
+
+**Identity:** The sim derives deterministic Ed25519 key pairs from seed indices via `SHA-256("tc-sim-{key-type}-v1-{index}")`. The same index always produces the same keys, making runs reproducible and idempotent.
+
+**Account lifecycle:** `POST /auth/signup` (201 = new, 409 = exists, proceed). No login needed for voter accounts — device-key signing is per-request using the key registered at signup.
+
+**Verifier:** A separate deterministic identity (`SimAccount::verifier()`) logs in via `POST /auth/login` to register a device key, then signs `POST /verifiers/endorsements` requests to grant voting eligibility.
+
+**Content:** LLM-generated room topics via OpenRouter, inserted through `POST /rooms`, `POST /rooms/{id}/polls`, etc.
+
+**Votes:** Discovered via API (`GET /rooms` → `GET /rooms/{id}/polls` → `GET /rooms/{id}/polls/{id}/results`), cast through `POST /rooms/{id}/polls/{id}/vote`.
+
+## Consequences
+
+### Positive
+- Dogfoods the API — every sim run is an implicit integration test
+- Enforces the trust boundary: all crypto happens client-side, matching the real user flow
+- No database coupling — the sim works against any TinyCongress API instance
+- Can run from anywhere (laptop, CronJob, CI) with just a URL and API keys
+- Idempotent: re-running with the same config produces the same accounts and skips existing content (409/upsert semantics)
+
+### Negative
+- More API calls than direct DB inserts (O(rooms × polls) for discovery, one call per vote)
+- Depends on the API being up — can't seed an empty database without a running server
+- Error diagnosis is harder: failures surface as HTTP status codes, not SQL errors
+
+### Neutral
+- The `seed` module and binary were deleted entirely — no migration path, clean replacement
+- The sim binary ships in the same Docker image as the API (`COPY --from=builder .../sim`)
+- Configuration uses `SIM_*` env vars (not `TC_*`) to avoid collision with the API config
+
+## Alternatives considered
+
+### Direct database access (original approach)
+- Seeder shared `PgPool` with the API, ran SQL inserts directly
+- Rejected: bypassed validation and auth, created schema coupling, violated trust boundary, didn't verify the API worked
+
+### Hybrid approach (DB for accounts, API for content)
+- Create accounts directly in the database, but use the API for rooms/polls/votes
+- Rejected: still violates the trust boundary for account creation (server-side key handling), and the partial approach is harder to reason about than a clean boundary
+
+### GraphQL instead of REST
+- Use the GraphQL API for content operations
+- Rejected: the REST API covers all needed operations, GraphQL adds complexity (query construction, fragment management) without benefit for a machine client
+
+## References
+- PR #380: Sim module implementation
+- `service/src/sim/`: Module source
+- `service/src/bin/sim.rs`: Orchestration entry point
+- `docs/interfaces/environment-variables.md`: `SIM_*` configuration
+- ADR-008: Account-based verifiers (the sim's endorsement mechanism)


### PR DESCRIPTION
## Summary
- **ADR-008**: Documents the decision to make verifiers regular accounts with device-key signing, bootstrapped from `TC_VERIFIERS` config at startup (replaces API-key auth)
- **ADR-009**: Documents the decision to have the sim worker interact exclusively through the public REST API (replaces direct DB access)
- Updates docs/README.md ADR index

## Test plan
- [ ] ADRs follow the template format
- [ ] README index links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)