### PR TITLE
refine: test add_device handler DuplicateKid and MaxDevicesReached paths

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -533,6 +533,66 @@ mod tests {
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
+    #[tokio::test]
+    async fn test_add_device_duplicate_kid_returns_conflict() {
+        use axum::extract::Extension;
+        use axum::response::IntoResponse;
+
+        let (req, account) = make_valid_components();
+        let repo = mock_with_account(account.clone());
+        repo.set_create_device_key_error(DeviceKeyRepoError::DuplicateKid);
+        let repo = std::sync::Arc::new(repo);
+
+        let body = axum::body::Bytes::from(
+            serde_json::json!({
+                "pubkey": req.pubkey,
+                "name": req.name,
+                "certificate": req.certificate,
+            })
+            .to_string(),
+        );
+        let auth = AuthenticatedDevice::for_test(account.id, Kid::derive(&[0xAAu8; 32]), body);
+
+        let response = add_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_add_device_max_devices_returns_unprocessable() {
+        use axum::extract::Extension;
+        use axum::response::IntoResponse;
+
+        let (req, account) = make_valid_components();
+        let repo = mock_with_account(account.clone());
+        repo.set_create_device_key_error(DeviceKeyRepoError::MaxDevicesReached);
+        let repo = std::sync::Arc::new(repo);
+
+        let body = axum::body::Bytes::from(
+            serde_json::json!({
+                "pubkey": req.pubkey,
+                "name": req.name,
+                "certificate": req.certificate,
+            })
+            .to_string(),
+        );
+        let auth = AuthenticatedDevice::for_test(account.id, Kid::derive(&[0xAAu8; 32]), body);
+
+        let response = add_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
     // ── revoke_device error paths ────────────────────────────────────────────
 
     /// Build an `AuthenticatedDevice` and a repo where `get_owned_device` succeeds


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added missing tests for add_device handler's DuplicateKid (409) and MaxDevicesReached (422) error paths, which were untested while the equivalent branches in revoke_device and rename_device were fully covered

---
*Generated by [refine.sh](scripts/refine.sh)*