### PR TITLE
fix(refine): fix CI auto-fix push and add just fmt to prompt

### DIFF
--- a/scripts/refine-prompt.md
+++ b/scripts/refine-prompt.md
@@ -14,7 +14,8 @@ You are refining code in `{{FOCUS_PATH}}`.
 4. Do not add new dependencies.
 5. Do not modify files outside `{{FOCUS_PATH}}` unless the change requires
    updating a test file or a direct caller.
-6. Run `just lint` and `just test` before committing. If they fail, fix or abandon.
+6. Run `just fmt` to auto-fix formatting, then `just lint` and `just test` before committing. If lint or tests fail, fix or abandon.
+   `just test` runs unit tests only — do NOT run `just test-ci` or e2e tests (they require a full cluster that isn't available here). CI validates integration after the PR is created.
 
 ## Already in progress
 

--- a/scripts/refine.sh
+++ b/scripts/refine.sh
@@ -336,7 +336,7 @@ $failure_logs
     fi
 
     # Push the fix
-    git -C "$wt_path" push --quiet origin "$branch"
+    git -C "$wt_path" push --quiet origin "HEAD:$branch"
     log "Pushed CI fix ($new_commits commit(s)) to $branch"
 
     git -C "$REPO_ROOT" worktree remove "$wt_path" --force 2>/dev/null || true


### PR DESCRIPTION
## Summary
- **Fix detached HEAD push bug** in `fix_ci_failure()`: the original worktree held the branch checkout, so the fix worktree ended up on a detached HEAD. `git push origin "$branch"` pushed the stale local ref, not the fix commits. Changed to `git push origin "HEAD:$branch"`.
- **Add `just fmt` to refine prompt**: Claude was told to run `just lint` (read-only check) but not `just fmt` (auto-fix). This was the root cause of every open refine PR failing on "Lint Rust formatting".

## Test plan
- [x] Verified the 4 stale PRs (#395, #400, #412, #416) by pushing `cargo fmt` fixes — all should pass CI now
- [ ] Next refine loop run should produce PRs that pass formatting checks
- [ ] Next CI failure should trigger auto-fix that actually pushes commits

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)