### PR TITLE
feat: auto-recover from migration ordering mismatch

### DIFF
--- a/kube/app/templates/configmap.yaml
+++ b/kube/app/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
       port: {{ .Values.database.port }}
       name: {{ .Values.database.name | quote }}
       max_connections: {{ .Values.database.maxConnections | default 10 }}
+      auto_reset_on_migration_failure: {{ .Values.database.autoResetOnMigrationFailure | default false }}
     server:
       port: {{ .Values.service.port | default 8080 }}
     logging:

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -167,6 +167,9 @@ database:
   password: postgres
   # Maximum connections in pool
   maxConnections: 10
+  # Auto-reset database on migration version mismatch.
+  # Only safe for ephemeral databases (e.g. demo environment).
+  autoResetOnMigrationFailure: false
 
 # Logging configuration
 logging:

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -78,6 +78,13 @@ pub struct DatabaseConfig {
 
     /// Optional custom migrations directory path.
     pub migrations_dir: Option<String>,
+
+    /// When true, automatically drop and recreate the database if migrations
+    /// fail due to version mismatch (e.g. a different image was deployed
+    /// against an existing DB). Only safe for ephemeral databases like the
+    /// demo environment. Default: false.
+    #[serde(default)]
+    pub auto_reset_on_migration_failure: bool,
 }
 
 impl DatabaseConfig {
@@ -91,6 +98,20 @@ impl DatabaseConfig {
             .host(&self.host)
             .port(self.port)
             .database(&self.name)
+            .username(&self.user)
+            .password(&self.password)
+    }
+
+    /// Build `PgConnectOptions` targeting the `postgres` system database.
+    ///
+    /// Used for administrative operations (DROP/CREATE DATABASE) that cannot
+    /// run against the application database itself.
+    #[must_use]
+    pub fn system_connect_options(&self) -> sqlx_postgres::PgConnectOptions {
+        sqlx_postgres::PgConnectOptions::new()
+            .host(&self.host)
+            .port(self.port)
+            .database("postgres")
             .username(&self.user)
             .password(&self.password)
     }
@@ -316,6 +337,7 @@ impl Default for Config {
                 password: String::new(),
                 max_connections: default_max_connections(),
                 migrations_dir: None,
+                auto_reset_on_migration_failure: false,
             },
             server: ServerConfig {
                 port: default_port(),
@@ -505,6 +527,7 @@ mod tests {
             password: "s3cret".into(),
             max_connections: 10,
             migrations_dir: None,
+            auto_reset_on_migration_failure: false,
         };
         let opts = config.connect_options();
         // PgConnectOptions exposes getters for host, port, and database
@@ -524,6 +547,7 @@ mod tests {
             password: "p@ss:word/ok?".into(),
             max_connections: 10,
             migrations_dir: None,
+            auto_reset_on_migration_failure: false,
         };
         let opts = config.connect_options();
         // PgConnectOptions handles special chars without URL encoding issues.

--- a/service/src/db.rs
+++ b/service/src/db.rs
@@ -1,6 +1,7 @@
 use crate::config::DatabaseConfig;
-use sqlx_core::migrate::Migrator;
-use sqlx_postgres::{PgPool, PgPoolOptions};
+use sqlx::Connection;
+use sqlx_core::migrate::{MigrateError, Migrator};
+use sqlx_postgres::{PgConnection, PgPool, PgPoolOptions};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -13,16 +14,46 @@ use tracing::{info, warn};
 /// budget (600s), so the process crashes fast enough for K8s to restart the
 /// pod without Helm timing out.
 ///
+/// When `auto_reset_on_migration_failure` is enabled and migrations fail due
+/// to a version mismatch (not an SQL execution error), the database is dropped
+/// and recreated, then migrations are retried exactly once.
+///
 /// # Errors
 /// Returns an error if the connection cannot be established within the retry
 /// deadline, or if migrations fail after a successful connection.
 pub async fn setup_database(config: &DatabaseConfig) -> Result<PgPool, anyhow::Error> {
+    let pool = connect_with_retry(config).await?;
+    let migrator = resolve_migrator(config).await?;
+
+    match migrator.run(&pool).await {
+        Ok(()) => {
+            info!("Migrations applied");
+            Ok(pool)
+        }
+        Err(err) if config.auto_reset_on_migration_failure && is_resettable_error(&err) => {
+            warn!(
+                error = %err,
+                "Migration failed with resettable error; resetting database"
+            );
+            pool.close().await;
+            reset_database(config).await?;
+            let pool = connect_with_retry(config).await?;
+            migrator.run(&pool).await?;
+            info!("Migrations applied after database reset");
+            Ok(pool)
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Connect to Postgres with exponential backoff, retrying for up to 120 s.
+async fn connect_with_retry(config: &DatabaseConfig) -> Result<PgPool, anyhow::Error> {
     let retry_deadline = Duration::from_secs(120);
     let max_interval = Duration::from_secs(5);
     let mut delay = Duration::from_millis(500);
     let start = Instant::now();
 
-    let pool = loop {
+    loop {
         info!("Attempting to connect to Postgres...");
 
         match PgPoolOptions::new()
@@ -31,7 +62,7 @@ pub async fn setup_database(config: &DatabaseConfig) -> Result<PgPool, anyhow::E
             .connect_with(config.connect_options())
             .await
         {
-            Ok(pool) => break pool,
+            Ok(pool) => return Ok(pool),
             Err(err) => {
                 if start.elapsed() >= retry_deadline {
                     warn!(error = %err, "Postgres not ready; retries exhausted after {:?}", retry_deadline);
@@ -42,13 +73,16 @@ pub async fn setup_database(config: &DatabaseConfig) -> Result<PgPool, anyhow::E
                 delay = (delay.saturating_mul(2)).min(max_interval);
             }
         }
-    };
+    }
+}
 
-    // Resolve the migrations directory in a way that works in release images too.
-    // Preference order:
-    //  1. config.migrations_dir (from config file or TC_DATABASE__MIGRATIONS_DIR env)
-    //  2. ./migrations relative to the running binary
-    //  3. The compile-time manifest directory for local `cargo run`
+/// Resolve the migrations directory, trying multiple candidate paths.
+///
+/// Preference order:
+///  1. `config.migrations_dir` (from config file or `TC_DATABASE__MIGRATIONS_DIR` env)
+///  2. `./migrations` relative to the running binary
+///  3. The compile-time manifest directory for local `cargo run`
+async fn resolve_migrator(config: &DatabaseConfig) -> Result<Migrator, anyhow::Error> {
     let candidate_dirs = [
         config.migrations_dir.as_ref().map(PathBuf::from),
         Some(PathBuf::from("./migrations")),
@@ -59,14 +93,12 @@ pub async fn setup_database(config: &DatabaseConfig) -> Result<PgPool, anyhow::E
     ];
 
     let mut last_error = None;
-    let mut migrator = None;
 
     for dir in candidate_dirs.into_iter().flatten() {
         match Migrator::new(Path::new(&dir)).await {
             Ok(found) => {
                 info!("Using migrations from {}", dir.display());
-                migrator = Some(found);
-                break;
+                return Ok(found);
             }
             Err(err) => {
                 last_error = Some((dir, err));
@@ -74,14 +106,67 @@ pub async fn setup_database(config: &DatabaseConfig) -> Result<PgPool, anyhow::E
         }
     }
 
-    let migrator = migrator.ok_or_else(|| match last_error {
-        Some((dir, err)) => {
-            anyhow::anyhow!("failed to load migrations from {}: {}", dir.display(), err)
-        }
-        None => anyhow::anyhow!("failed to resolve migrations directory"),
-    })?;
+    match last_error {
+        Some((dir, err)) => Err(anyhow::anyhow!(
+            "failed to load migrations from {}: {}",
+            dir.display(),
+            err
+        )),
+        None => Err(anyhow::anyhow!("failed to resolve migrations directory")),
+    }
+}
 
-    migrator.run(&pool).await?;
-    info!("Migrations applied");
-    Ok(pool)
+/// Returns true for migration errors caused by version history divergence,
+/// which are fixed by a fresh database. Returns false for SQL execution
+/// errors which would recur on a clean DB.
+///
+/// `MigrateError` is `#[non_exhaustive]`, so the wildcard arm is required.
+const fn is_resettable_error(err: &MigrateError) -> bool {
+    matches!(
+        err,
+        MigrateError::VersionMissing(_) | MigrateError::VersionMismatch(_) | MigrateError::Dirty(_)
+    )
+}
+
+/// Drop and recreate the application database.
+///
+/// Connects to the `postgres` system database, terminates existing connections
+/// to the app database, then drops and recreates it. All operations are logged
+/// at `warn!` level since this is a destructive recovery path.
+async fn reset_database(config: &DatabaseConfig) -> Result<(), anyhow::Error> {
+    let db_name = &config.name;
+    warn!(database = %db_name, "Resetting database: terminating connections");
+
+    let mut conn: PgConnection = PgConnection::connect_with(&config.system_connect_options())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to connect to system database: {e}"))?;
+
+    // Terminate all other connections to the target database.
+    sqlx::query(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()"
+    )
+    .bind(db_name)
+    .execute(&mut conn)
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to terminate connections to {db_name}: {e}"))?;
+
+    // Database identifiers cannot be parameterized — use quoting to prevent
+    // injection. The name comes from our own config, not user input.
+    let drop_sql = format!("DROP DATABASE IF EXISTS \"{db_name}\"");
+    let create_sql = format!("CREATE DATABASE \"{db_name}\"");
+
+    warn!(database = %db_name, "Dropping database");
+    sqlx::query(&drop_sql)
+        .execute(&mut conn)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to drop database {db_name}: {e}"))?;
+
+    warn!(database = %db_name, "Creating database");
+    sqlx::query(&create_sql)
+        .execute(&mut conn)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create database {db_name}: {e}"))?;
+
+    warn!(database = %db_name, "Database reset complete");
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Add opt-in `auto_reset_on_migration_failure` config flag (`TC_DATABASE__AUTO_RESET_ON_MIGRATION_FAILURE`) that drops and recreates the database when migrations fail due to version mismatch
- Refactor `setup_database()` into `connect_with_retry`, `resolve_migrator`, `is_resettable_error`, and `reset_database` helpers
- Wire the flag through Helm values and configmap so the demo HelmRelease can enable it

Closes #427

## Test plan
- [x] `cargo build -p tinycongress-api` succeeds
- [x] `just lint-backend` passes
- [x] `just test-backend` passes — existing tests unaffected (flag defaults to `false`)
- [ ] Manual verification: demo HelmRelease sets `database.autoResetOnMigrationFailure: true` (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)