### PR TITLE
chore(kube): add demo environment values and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
           directory: kube/
           config: .kube-linter.yaml
 
+      - name: Validate environment values
+        run: |
+          # Render the chart with each environment values file to catch drift.
+          # Image tags are stubbed — digests are provided by CD, not by values files.
+          for VALUES_FILE in kube/environments/*.yaml; do
+            ENV_NAME=$(basename "$VALUES_FILE" .yaml)
+            echo "::group::helm template ($ENV_NAME)"
+            helm template "tc-${ENV_NAME}" kube/app \
+              -f "$VALUES_FILE" \
+              --set image.tag=ci-stub \
+              --set frontend.image.tag=ci-stub \
+              --set postgres.image.tag=ci-stub
+            echo "::endgroup::"
+          done
+
   # ============================================================
   # JOB 0b: Lint web
   # ============================================================

--- a/kube/environments/demo.yaml
+++ b/kube/environments/demo.yaml
@@ -1,0 +1,64 @@
+# Demo environment values for the sauce cluster (ibcook.com).
+#
+# Validated in CI: `helm template tc-demo kube/app -f kube/environments/demo.yaml`
+# Applied by Flux via HelmRelease valuesFiles (homelab-gitops).
+#
+# Secrets (sim.openrouterApiKey) are NOT in this file — they're provided
+# via SOPS-encrypted valuesFrom in the HelmRelease.
+
+replicaCount: 1
+
+frontend:
+  environment: "demo"
+  replicaCount: 1
+  apiUrl: "https://tc-api-demo.ibcook.com"
+  service:
+    port: 80
+    targetPort: 8080
+
+cors:
+  allowedOrigins: "https://tiny-congress-demo.ibcook.com"
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+postgres:
+  persistence:
+    enabled: true
+
+# Auto-reset database when migrations change — acceptable for demo,
+# never for production.
+database:
+  autoResetOnMigrationFailure: true
+
+# HMAC key for synthetic backup envelopes. In-cluster, lookup() reuses
+# the existing Secret; this value is only used on first deploy or in CI.
+syntheticBackupKey: "demo-synthetic-backup-key-not-for-production"
+
+serviceAccount:
+  create: true
+
+# Bootstrap the sim verifier so the sim worker can endorse accounts.
+# Key derived from: SHA-256("tc-sim-verifier-root-key-v1") -> Ed25519 pubkey
+verifiers:
+  - name: "sim_verifier"
+    public_key: "ovySo2At7yyERm9siRnjP_txpqBLLRwIjDbH5qVAjG0"
+
+sim:
+  enabled: true
+  schedule: "*/30 * * * *"
+  apiUrl: "http://tc-demo.tiny-congress-demo.svc.cluster.local:8080"
+  openrouterModel: "meta-llama/llama-3.3-70b-instruct:free"
+  targetRooms: 5
+  votesPerPoll: 15
+  voterCount: 20
+  systemPrompt: >-
+    You are a civic engagement topic generator. Generate realistic local
+    governance topics suitable for community polling. Topics should be
+    specific, actionable, and relevant to a small city or town. Examples:
+    zoning changes, park improvements, transit priorities, budget allocation.


### PR DESCRIPTION
## Summary

- Add `kube/environments/demo.yaml` with demo-specific Helm values (ports, sim config, resources, verifiers)
- Add `helm template` validation step to `lint-kube` CI job — renders chart with each environment values file on every PR
- Prepares for homelab-gitops HelmRelease to use Flux `valuesFiles` instead of inline values

## Motivation

The demo HelmRelease in homelab-gitops contains both app config (ports, sim settings) and infra config (digests, DNS). When the chart changes (e.g., nginx-unprivileged switched to port 8080), nothing catches the drift between chart and values until Flux fails in the cluster.

By co-locating demo values with the chart, CI validates them together — `helm template` fails in the same PR that breaks compatibility.

## What stays in homelab-gitops

Only cluster-specific overrides:
- Image digests (set by CD pipeline)
- External DNS annotations (Cloudflare tunnel UUID)
- PVC references
- SOPS-encrypted secrets (OpenRouter API key)

## Test plan

- [ ] CI `lint-kube` job passes with new `helm template` step
- [ ] `helm template tc-demo kube/app -f kube/environments/demo.yaml` renders cleanly locally
- [ ] After merge: update homelab-gitops HelmRelease to add `valuesFiles` and remove migrated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)