### PR TITLE
fix(ci): skip source.yaml update when chart and images are unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,7 @@ jobs:
       postgres: ${{ steps.filter.outputs.postgres }}
       api: ${{ steps.filter.outputs.api }}
       ui: ${{ steps.filter.outputs.ui }}
+      chart: ${{ steps.filter.outputs.chart }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -392,6 +393,8 @@ jobs:
             ui:
               - 'web/**'
               - 'crates/tc-crypto/**'
+            chart:
+              - 'kube/app/**'
 
   # ============================================================
   # JOB 1: Build all container images in parallel
@@ -878,7 +881,7 @@ jobs:
   deploy-gitops:
     name: Update gitops image digests
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [integration-tests]
+    needs: [integration-tests, detect-changes]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -943,7 +946,10 @@ jobs:
           TC_SHA: ${{ github.sha }}
         run: |
           SOURCE="clusters/sauce/workloads/tiny-congress/source.yaml"
-          if [ "${{ steps.current.outputs.commit }}" = "${TC_SHA}" ]; then
+          CHART_CHANGED="${{ needs.detect-changes.outputs.chart }}"
+          if [ "$CHART_CHANGED" = "false" ] && [ -z "$CHANGED_DIGESTS" ]; then
+            echo "  source commit: no chart or image changes, skipping"
+          elif [ "${{ steps.current.outputs.commit }}" = "${TC_SHA}" ]; then
             echo "  source commit: unchanged, skipping"
           else
             echo "  source commit: ${{ steps.current.outputs.commit }} -> ${TC_SHA}"


### PR DESCRIPTION
## Summary

- Add `chart` path filter (`kube/app/**`) to `detect-changes` job
- Skip `source.yaml` commit pin when neither chart templates nor image digests changed
- Docs-only or scripts-only pushes now produce **zero gitops commits** (no Flux reconciliation)

Evidence from #437 (docs-only push) showing the problem — all digests were correctly skipped, but source.yaml still updated:
```
api: unchanged, skipping
ui: unchanged, skipping
pg: unchanged, skipping
source commit: 1afcb59f -> b9bfea64   ← unnecessary
```

## Test plan

- [ ] `actionlint` passes
- [ ] After merge: push a docs/scripts-only commit → verify "No digest changes detected" and no gitops commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)