### PR TITLE
fix(sim): use paid OpenRouter model to avoid free-tier rate limits

### DIFF
--- a/kube/environments/demo.yaml
+++ b/kube/environments/demo.yaml
@@ -53,7 +53,7 @@ sim:
   enabled: true
   schedule: "*/30 * * * *"
   apiUrl: "http://tc-demo.tiny-congress-demo.svc.cluster.local:8080"
-  openrouterModel: "meta-llama/llama-3.3-70b-instruct:free"
+  openrouterModel: "meta-llama/llama-3.3-70b-instruct"
   targetRooms: 5
   votesPerPoll: 15
   voterCount: 20

--- a/service/src/bin/sim.rs
+++ b/service/src/bin/sim.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), anyhow::Error> {
         target_rooms = config.target_rooms,
         votes_per_poll = config.votes_per_poll,
         voter_count = config.voter_count,
+        api_key_len = config.openrouter_api_key.len(),
         "sim config loaded"
     );
 


### PR DESCRIPTION
## Summary

- Remove `:free` suffix from `meta-llama/llama-3.3-70b-instruct` in demo config. The `:free` suffix routes through shared free-tier capacity regardless of API key presence, causing persistent 429 errors (`is_byok: false`).
- Log `api_key_len` at startup for easier debugging of auth issues.

Closes #440

## Test plan

- [ ] Verify Helm template renders correctly: `helm template tc-demo kube/app -f kube/environments/demo.yaml`
- [ ] After deploy, check sim logs for `api_key_len > 0` and successful LLM content generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)