### PR TITLE
refine: test device name too-long boundary in validate_add_device_request

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -376,6 +376,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_add_device_request_name_too_long() {
+        let (mut req, account) = make_valid_components();
+        req.name = "a".repeat(129); // exceeds 128-char DeviceName limit
+        let repo = MockIdentityRepo::new();
+        let err = validate_add_device_request(&repo, account.id, &req)
+            .await
+            .err()
+            .expect("expected error");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn test_validate_add_device_request_invalid_cert_length() {
         let (mut req, account) = make_valid_components();
         req.certificate = encode_base64url(&[0u8; 32]); // 32 bytes, not 64


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added missing too-long device name boundary test to validate_add_device_request, mirroring the equivalent test added to validate_login_device in PR #442.

---
*Generated by [refine.sh](scripts/refine.sh)*