### PR TITLE
docs: document syntheticBackupKey and anti-enumeration strategy

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -98,6 +98,20 @@ The envelope is validated at parse time (`BackupEnvelope::parse`). Weak KDF para
 
 **Not yet built:** Account recovery (helpers approve recovery via signed envelopes). Concept described in [signed-envelope-spec.md](interfaces/signed-envelope-spec.md) but no code exists.
 
+#### Anti-enumeration: synthetic backups
+
+`GET /auth/backup/{username}` returns `200 OK` for every username — real or fake. For unknown users (or users without a backup), the server generates a **synthetic backup** that is indistinguishable from a real one until ChaCha20-Poly1305 decryption fails, which looks identical to a wrong-password attempt.
+
+Synthetic backups are derived deterministically using HMAC-SHA256 keyed by a server-side secret (`TC_SYNTHETIC_BACKUP_KEY`, minimum 32 bytes). This ensures:
+
+- **Same username → same response** — prevents probing via response diffing across requests.
+- **Valid envelope structure** — passes `BackupEnvelope::parse()` so the client cannot distinguish real from synthetic at the format level.
+- **Unpredictable without the key** — external observers cannot precompute expected responses for a given username.
+
+The HMAC key must remain stable for the lifetime of a deployment. If it changes, synthetic responses change, allowing an attacker to distinguish real backups (which don't change) from synthetic ones (which would).
+
+See `service/src/identity/http/backup.rs` for the implementation.
+
 ### Key Identifier (KID)
 
 A stable, short identifier derived from a public key.

--- a/docs/interfaces/environment-variables.md
+++ b/docs/interfaces/environment-variables.md
@@ -55,6 +55,14 @@ TC_CORS__ALLOWED_ORIGINS=https://app.example.com
 TC_CORS__ALLOWED_ORIGINS=*
 ```
 
+### Identity & Security
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TC_SYNTHETIC_BACKUP_KEY` | Yes | - | HMAC key for generating synthetic backup envelopes (anti-enumeration). Minimum 32 bytes. Must remain stable for the lifetime of a deployment — changing it alters synthetic responses, which can leak which usernames are real. |
+
+**Security note:** This key prevents username enumeration via the backup endpoint. Generate with `openssl rand -base64 48` or equivalent. In Kubernetes, set via `syntheticBackupKey` in Helm values or a sealed secret.
+
 ### Security Headers Configuration
 
 | Variable | Required | Default | Description |
@@ -252,6 +260,7 @@ database:
 | `cors.allowedOrigins` | `""` | `cors.allowed_origins` in ConfigMap |
 | `graphql.playgroundEnabled` | `false` | `graphql.playground_enabled` in ConfigMap |
 | `swagger.enabled` | `false` | `swagger.enabled` in ConfigMap |
+| `syntheticBackupKey` | `""` | `synthetic-backup-key` in app Secret (required) |
 
 ## Local Development
 


### PR DESCRIPTION
## Summary
- Add anti-enumeration subsection to `docs/domain-model.md` explaining how synthetic backups prevent username enumeration and why the HMAC key must remain stable
- Add `TC_SYNTHETIC_BACKUP_KEY` entry to `docs/interfaces/environment-variables.md` with security notes and Helm values reference

## Test plan
- [ ] Docs render correctly in GitHub markdown preview
- [ ] No broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>