### PR TITLE
fix(ci): gate lint/check jobs on path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   # ============================================================
   lint:
     name: Lint Rust formatting
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,6 +47,8 @@ jobs:
   # ============================================================
   lint-kube:
     name: Lint Kubernetes manifests
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.chart == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -76,6 +80,8 @@ jobs:
   # ============================================================
   lint-web:
     name: Lint web
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -136,6 +142,8 @@ jobs:
   # ============================================================
   build-storybook:
     name: Build Storybook
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -172,6 +180,8 @@ jobs:
   # ============================================================
   build-docs:
     name: Build documentation
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -216,6 +226,8 @@ jobs:
   # ============================================================
   codegen-check:
     name: Check codegen
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -260,6 +272,8 @@ jobs:
   # ============================================================
   security-audit:
     name: Security & Dependency Audit
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -307,7 +321,8 @@ jobs:
   sqlx-check:
     name: Check SQLx snapshots
     runs-on: ubuntu-latest
-    needs: [build-images]
+    needs: [build-images, detect-changes]
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ci == 'true'
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/tiny-congress
     steps:
@@ -377,6 +392,7 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       ui: ${{ steps.filter.outputs.ui }}
       chart: ${{ steps.filter.outputs.chart }}
+      ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -395,6 +411,10 @@ jobs:
               - 'crates/tc-crypto/**'
             chart:
               - 'kube/app/**'
+            ci:
+              - '.github/workflows/**'
+              - 'skaffold.yaml'
+              - 'justfile'
 
   # ============================================================
   # JOB 1: Build all container images in parallel
@@ -516,7 +536,7 @@ jobs:
   scan-images:
     name: Scan ${{ matrix.image }}
     runs-on: ubuntu-latest
-    needs: [build-images]
+    needs: [build-images, detect-changes]
     strategy:
       fail-fast: false
       matrix:
@@ -525,13 +545,26 @@ jobs:
           - tc-ui-release
           - postgres
     steps:
+      - name: Check if scan needed
+        id: should-scan
+        run: |
+          case "${{ matrix.image }}" in
+            tc-api-release) changed="${{ needs.detect-changes.outputs.api }}" ;;
+            tc-ui-release)  changed="${{ needs.detect-changes.outputs.ui }}" ;;
+            postgres)       changed="${{ needs.detect-changes.outputs.postgres }}" ;;
+            *)              changed="true" ;;
+          esac
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
+        if: steps.should-scan.outputs.changed != 'false'
         uses: actions/checkout@v6
         with:
           sparse-checkout: .trivyignore
           sparse-checkout-cone-mode: false
 
       - name: Login to GHCR
+        if: steps.should-scan.outputs.changed != 'false'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -539,6 +572,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
+        if: steps.should-scan.outputs.changed != 'false'
         uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ github.sha }}
@@ -565,6 +599,11 @@ jobs:
       - codegen-check
       - sqlx-check
       - security-audit
+    # Run when all dependencies succeeded or were skipped (path-filtered).
+    # Block only on failure or cancellation.
+    if: >-
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     permissions:
       contents: read
       packages: read
@@ -880,7 +919,11 @@ jobs:
   # ============================================================
   deploy-gitops:
     name: Update gitops image digests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >-
+      always() &&
+      github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     needs: [integration-tests, detect-changes]
     runs-on: ubuntu-latest
     permissions:
@@ -998,7 +1041,10 @@ jobs:
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     needs: [integration-tests, build-storybook, build-docs]
-    if: always() && needs.integration-tests.result != 'cancelled'
+    if: >-
+      always() &&
+      !contains(needs.*.result, 'cancelled') &&
+      needs.integration-tests.result != 'failure'
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
## Summary
- Gate 8 CI jobs on `detect-changes` path filters so they skip when their inputs haven't changed
- Add `ci` filter (workflow files, skaffold.yaml, justfile) that forces all jobs to run when CI infra changes
- Gate `scan-images` on path filters (skip Trivy scan for retagged identical images)
- Update `integration-tests`, `deploy-gitops`, `deploy-cloudflare` to tolerate skipped dependencies via `!contains(needs.*.result, 'failure')`

**Gated jobs:** `lint` (Rust), `lint-kube`, `lint-web`, `build-storybook`, `build-docs`, `codegen-check`, `security-audit`, `sqlx-check`, `scan-images`

**Always-run jobs:** `static-analysis` (cross-cutting typo/lint checks), `integration-tests` (e2e safety net)

On a docs-only commit, this avoids ~15 minutes of parallel Rust compilation, Node installs, security scans, and Trivy vulnerability scanning.

## Test plan
- [ ] actionlint passes (verified locally)
- [ ] CI passes on this PR (the CI change itself triggers the `ci` filter, so all jobs run)
- [ ] After merge, a docs-only push should show most jobs as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>