### PR TITLE
refine: test rename_device rejects empty device name

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -733,6 +733,46 @@ mod tests {
 
     // ── rename_device error paths ────────────────────────────────────────────
 
+    /// Empty device name must be rejected before any repo call.
+    ///
+    /// The handler validates the name via `DeviceName::parse` immediately after
+    /// parsing the KID. An empty name (or whitespace-only) must return 400 so
+    /// that callers get a clear error rather than silently storing a blank name.
+    #[tokio::test]
+    async fn test_rename_device_empty_name_returns_bad_request() {
+        use axum::response::IntoResponse;
+        use axum::{body::to_bytes, extract::Extension, extract::Path};
+
+        let account_id = Uuid::new_v4();
+        let auth_kid = Kid::derive(&[0xAAu8; 32]);
+        let target_kid = Kid::derive(&[0xCCu8; 32]);
+
+        // Empty name — DeviceName::parse must reject this before any repo call.
+        let repo = std::sync::Arc::new(MockIdentityRepo::new());
+        let body = axum::body::Bytes::from(r#"{"name":""}"#);
+        let auth = AuthenticatedDevice::for_test(account_id, auth_kid, body);
+
+        let response = rename_device(
+            Extension(repo as std::sync::Arc<dyn crate::identity::repo::IdentityRepo>),
+            Path(target_kid.as_str().to_string()),
+            auth,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), 1024).await.expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap()
+                .to_lowercase()
+                .contains("empty"),
+            "error message should mention empty name"
+        );
+    }
+
     #[tokio::test]
     async fn test_rename_device_invalid_kid_format_returns_bad_request() {
         use axum::response::IntoResponse;


### PR DESCRIPTION
Automated refinement of `service/src/identity/`

Added missing test for rename_device handler rejecting empty device names at the HTTP boundary — the DeviceName::parse validation path existed but was completely untested, leaving the guard unverifiable by CI.

---
*Generated by [refine.sh](scripts/refine.sh)*