### PR TITLE
feat(sim): track OpenRouter token usage per call and session rollup

### DIFF
--- a/service/src/bin/sim.rs
+++ b/service/src/bin/sim.rs
@@ -13,7 +13,7 @@ use tinycongress_api::sim::{
     config::SimConfig,
     content::{count_active_rooms, insert_sim_content},
     identity::SimAccount,
-    llm::generate_content,
+    llm::{generate_content, Usage},
     votes::cast_simulated_votes,
 };
 
@@ -122,7 +122,8 @@ async fn main() -> Result<(), anyhow::Error> {
     }
     tracing::info!("account signup complete");
 
-    // 7. Count active rooms via API
+    // 7. Count active rooms via API; track token usage across all LLM calls this session
+    let mut session_usage = Usage::default();
     let active_rooms = count_active_rooms(&client).await?;
     tracing::info!(
         active_rooms,
@@ -135,7 +136,8 @@ async fn main() -> Result<(), anyhow::Error> {
         let rooms_needed = config.target_rooms - active_rooms;
         tracing::info!(rooms_needed, "generating new content via LLM...");
 
-        let content = generate_content(&http, &config, rooms_needed).await?;
+        let (content, usage) = generate_content(&http, &config, rooms_needed).await?;
+        session_usage += usage;
         tracing::info!(
             rooms_generated = content.rooms.len(),
             "LLM content received"
@@ -163,6 +165,12 @@ async fn main() -> Result<(), anyhow::Error> {
     let vote_count = cast_simulated_votes(&client, &accounts, config.votes_per_poll).await?;
     tracing::info!(votes_cast = vote_count, "vote simulation complete");
 
+    tracing::info!(
+        prompt_tokens = session_usage.prompt_tokens,
+        completion_tokens = session_usage.completion_tokens,
+        total_tokens = session_usage.total_tokens,
+        "llm_session_summary"
+    );
     tracing::info!("tc-sim run complete");
     Ok(())
 }

--- a/service/src/sim/llm.rs
+++ b/service/src/sim/llm.rs
@@ -1,5 +1,7 @@
 //! LLM response types and `OpenRouter` client for generating sim content.
 
+use std::ops::AddAssign;
+
 use serde::{Deserialize, Serialize};
 
 use super::config::SimConfig;
@@ -39,6 +41,22 @@ pub struct SimDimension {
     pub max: f32,
 }
 
+/// Token usage from a single `OpenRouter` API call.
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+impl AddAssign for Usage {
+    fn add_assign(&mut self, rhs: Self) {
+        self.prompt_tokens += rhs.prompt_tokens;
+        self.completion_tokens += rhs.completion_tokens;
+        self.total_tokens += rhs.total_tokens;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // OpenRouter API types (private)
 // ---------------------------------------------------------------------------
@@ -66,6 +84,7 @@ struct ResponseFormat {
 #[derive(Debug, Deserialize)]
 struct ChatResponse {
     choices: Vec<Choice>,
+    usage: Option<Usage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -127,6 +146,8 @@ pub fn build_messages(config: &SimConfig, rooms_needed: usize) -> Vec<ChatMessag
 
 /// Call the `OpenRouter` API to generate sim content.
 ///
+/// Returns the generated content and token usage for this call.
+///
 /// # Errors
 ///
 /// Returns an error if the HTTP request fails, the response cannot be parsed,
@@ -135,7 +156,7 @@ pub async fn generate_content(
     client: &reqwest::Client,
     config: &SimConfig,
     rooms_needed: usize,
-) -> Result<SimContent, anyhow::Error> {
+) -> Result<(SimContent, Usage), anyhow::Error> {
     let messages = build_messages(config, rooms_needed);
 
     let request = ChatRequest {
@@ -165,6 +186,15 @@ pub async fn generate_content(
 
     let chat_response: ChatResponse = response.json().await?;
 
+    let usage = chat_response.usage.unwrap_or_default();
+    tracing::info!(
+        model = %config.openrouter_model,
+        prompt_tokens = usage.prompt_tokens,
+        completion_tokens = usage.completion_tokens,
+        total_tokens = usage.total_tokens,
+        "llm_call"
+    );
+
     let first_choice = chat_response
         .choices
         .into_iter()
@@ -173,7 +203,7 @@ pub async fn generate_content(
 
     let content: SimContent = serde_json::from_str(&first_choice.message.content)?;
 
-    Ok(content)
+    Ok((content, usage))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `Usage` struct (`Copy + Default + AddAssign`) to capture `prompt_tokens`, `completion_tokens`, `total_tokens` from OpenRouter responses
- `generate_content` now returns `(SimContent, Usage)` and logs a `llm_call` span with token counts after each API call
- `sim.rs` accumulates usage via `+=` and logs a `llm_session_summary` span at the end of every run (zero counts when no LLM calls were made)

## Test plan
- [ ] All 64 sim unit tests pass
- [ ] `cargo build --bin sim` compiles clean
- [ ] Clippy clean (doc_markdown backtick fix included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)