### PR TITLE
fix(kube): prevent demo_verifier crash when API unavailable at startup

### DIFF
--- a/kube/app/templates/deployment-demo-verifier.yaml
+++ b/kube/app/templates/deployment-demo-verifier.yaml
@@ -41,7 +41,7 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: 8090
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/service/src/bin/demo_verifier.rs
+++ b/service/src/bin/demo_verifier.rs
@@ -7,6 +7,7 @@
     clippy::unwrap_used
 )]
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -60,6 +61,7 @@ struct AppState {
     client: SimClient,
     verifier: SimAccount,
     allowed_callback: String,
+    ready: AtomicBool,
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +86,14 @@ struct VerifyResponse {
 
 async fn health() -> StatusCode {
     StatusCode::OK
+}
+
+async fn ready(State(state): State<Arc<AppState>>) -> StatusCode {
+    if state.ready.load(Ordering::Relaxed) {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
 }
 
 async fn index_page() -> Html<String> {
@@ -559,33 +569,57 @@ async fn main() -> Result<(), anyhow::Error> {
         "demo verifier identity (ensure TC_VERIFIERS includes this public key)"
     );
 
-    // 4. Login to register device key
-    let login_body = verifier.build_login_json();
-    let resp = client.login(&login_body).await?;
-    let login_status = resp.status();
-    if login_status.as_u16() == 201 {
-        tracing::info!("demo verifier device key registered via login");
-    } else if login_status.as_u16() == 409 {
-        tracing::debug!("demo verifier device key already registered");
-    } else {
-        let body = resp.text().await.unwrap_or_default();
-        tracing::warn!(
-            status = %login_status,
-            body = %body,
-            "demo verifier login failed (account may not be bootstrapped yet)"
-        );
-    }
-
-    // 5. Build and start axum server
+    // 4. Build app state and start server — login happens in background
     let state = Arc::new(AppState {
         client,
         verifier,
         allowed_callback: config.allowed_callback,
+        ready: AtomicBool::new(false),
+    });
+
+    // Spawn background login retry so the server starts immediately
+    let bg_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let delays = [1, 2, 5, 10, 30];
+        for (attempt, &delay) in delays.iter().enumerate() {
+            let login_body = bg_state.verifier.build_login_json();
+            match bg_state.client.login(&login_body).await {
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    if status == 201 {
+                        tracing::info!("demo verifier device key registered via login");
+                        bg_state.ready.store(true, Ordering::Relaxed);
+                    } else if status == 409 {
+                        tracing::debug!("demo verifier device key already registered");
+                        bg_state.ready.store(true, Ordering::Relaxed);
+                    } else {
+                        let body = resp.text().await.unwrap_or_default();
+                        tracing::warn!(
+                            status,
+                            body = %body,
+                            "demo verifier login returned unexpected status"
+                        );
+                    }
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        delay_secs = delay,
+                        error = %e,
+                        "could not reach API for login — retrying"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+                }
+            }
+        }
+        tracing::error!("demo verifier login failed after all retries — verify requests will fail until API is reachable");
     });
 
     let app = Router::new()
         .route("/", get(index_page))
         .route("/health", get(health))
+        .route("/ready", get(ready))
         .route("/api/verify", post(verify))
         .layer(CorsLayer::permissive())
         .with_state(state);


### PR DESCRIPTION
## Summary
- The `demo_verifier` binary exits fatally if the TC API is unreachable during startup login. During Helm upgrades, both pods roll simultaneously — the verifier crash-loops, times out at 10m, and forces a rollback.
- Moves the login call to a background retry loop (1s, 2s, 5s, 10s, 30s backoff) so the HTTP server starts immediately.
- Adds a `/ready` endpoint gated on successful login. Liveness probe stays on `/health` (always 200), readiness probe now uses `/ready` (503 until login succeeds). Kubernetes won't route traffic to the verifier until the API is up and login completes.

## Test plan
- [ ] CI passes (clippy, fmt, tests)
- [ ] Deploy to demo cluster — verify HelmRelease reconciles successfully
- [ ] Confirm demo-verifier pod starts, passes liveness, and becomes ready after API is up
- [ ] Verify `/api/verify` endpoint works after readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)