### PR TITLE
fix: add missing MAX_TIMESTAMP_SKEW import in login tests

### DIFF
--- a/service/src/identity/http/login.rs
+++ b/service/src/identity/http/login.rs
@@ -206,6 +206,7 @@ pub async fn login(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::http::auth::MAX_TIMESTAMP_SKEW;
     use crate::identity::repo::{
         mock::MockIdentityRepo, AccountRecord, DeviceKeyRepoError, NonceRepoError,
     };


### PR DESCRIPTION
## Summary

- Master is broken: `cargo test` fails with `cannot find value MAX_TIMESTAMP_SKEW in this scope` at `login.rs:541`
- The test module uses `use super::*` but the parent module's `use super::auth::MAX_TIMESTAMP_SKEW` is a private re-import, so it's not re-exported by the glob
- Add an explicit `use crate::identity::http::auth::MAX_TIMESTAMP_SKEW` in the test module

## Test plan

- [x] `cargo check --tests` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)