### PR TITLE
fix(ci): prevent broken E2E tests from reaching master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,6 +593,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     needs:
+      - detect-changes
       - build-images
       - scan-images
       - lint
@@ -603,9 +604,13 @@ jobs:
       - codegen-check
       - sqlx-check
       - security-audit
-    # Run when all dependencies succeeded or were skipped (path-filtered).
-    # Block only on failure or cancellation.
+    # always() is required so this job evaluates its `if` even when
+    # path-filtered dependencies are skipped.  Without it, GitHub Actions
+    # silently skips this job whenever any `needs` job is skipped, which
+    # allowed broken E2E tests to reach master undetected.
     if: >-
+      always() &&
+      (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true') &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     permissions:
@@ -783,7 +788,7 @@ jobs:
 
       - name: Build instrumented frontend for E2E tests
         working-directory: web
-        run: PLAYWRIGHT_COVERAGE=1 yarn build
+        run: VITE_API_URL=http://localhost:8080 PLAYWRIGHT_COVERAGE=1 yarn build
 
       - name: Analyze bundle size
         if: always()

--- a/web/tests/e2e/login.spec.ts
+++ b/web/tests/e2e/login.spec.ts
@@ -55,8 +55,12 @@ test('login flow recovers account and shows device list', async ({ page }) => {
   await page.getByRole('button', { name: /log in/i }).click();
 
   // Argon2id KDF with m_cost=65536 can take several seconds in the browser.
-  // After decryption, the login API call creates a device and navigates to /settings.
-  await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible({ timeout: 30_000 });
+  // After decryption, the login API call creates a device and navigates to /rooms.
+  await expect(page.getByRole('heading', { name: /rooms/i })).toBeVisible({ timeout: 30_000 });
+
+  // Navigate to settings to verify device list
+  await page.goto('/settings');
+  await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible();
   await expect(page.getByText(/Manage your devices/i)).toBeVisible();
 
   // Device list should load with two devices: the signup device + the login device
@@ -64,7 +68,7 @@ test('login flow recovers account and shows device list', async ({ page }) => {
   // Both devices show "Active" badge — verify at least one is visible
   await expect(page.getByText(/Active/i).first()).toBeVisible();
 
-  // Screenshot: settings with device list after login
+  // Screenshot: settings with device list
   await test.info().attach('login-settings', {
     body: await page.screenshot(),
     contentType: 'image/png',


### PR DESCRIPTION
## Summary

Three root causes allowed broken E2E tests to merge into master undetected:

1. **`integration-tests` skipped silently** — The job uses `needs:` with path-filtered jobs (`lint-web`, `build-storybook`, etc.) but doesn't use `always()`. When a dependency is skipped, GitHub Actions skips dependent jobs without evaluating the `if` condition. CI Gate only checks for `"failure"`, so `"skipped"` passes through.

   **Fix:** Add `always()` and an explicit path filter (`api || ui || ci` changes) to the `integration-tests` `if` condition, plus add `detect-changes` to `needs`.

2. **E2E build missing `VITE_API_URL`** — PR #478 added a throw when API URL is missing in production builds. The CI E2E build step (`yarn build`) is a production build but never set `VITE_API_URL`, so the app crashes on first API call.

   **Fix:** Set `VITE_API_URL=http://localhost:8080` during the build step.

3. **Login test expected wrong page** — PR #454 changed post-login navigation from `/settings` to `/rooms`, but the E2E test wasn't updated.

   **Fix:** Expect `/rooms` heading after login, then navigate to `/settings` for device list verification.

Fixes #477

## Test plan

- [ ] Integration tests actually run (not skipped) when `web/` or `service/` files change
- [ ] Integration tests correctly skip when only `kube/` or `docs/` files change
- [ ] E2E signup test passes (VITE_API_URL available)
- [ ] E2E login test passes (expects /rooms, then navigates to /settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)