### PR TITLE
fix(web): improve demo UX — about page, signup copy, poll errors

### DIFF
--- a/web/src/features/identity/components/SignupForm.tsx
+++ b/web/src/features/identity/components/SignupForm.tsx
@@ -66,7 +66,7 @@ export function SignupForm({
           <Title order={3}>What&apos;s next?</Title>
           <Text size="sm">
             {verifierUrl
-              ? 'Verify your identity to start voting in rooms.'
+              ? 'Verify your identity so we know you\u0027re a real person, not a bot. Verified users can vote in rooms.'
               : 'You\u0027re all set! Start exploring rooms and voting on polls.'}
           </Text>
           <Group mt="xs">

--- a/web/src/pages/About.page.tsx
+++ b/web/src/pages/About.page.tsx
@@ -14,9 +14,40 @@ export function AboutPage() {
         <Title order={2}>About TinyCongress</Title>
       </Group>
 
-      <Text c="dimmed" size="sm">
-        Build metadata for both the API (fetched via GraphQL) and the UI (baked in at build time),
-        so operators can verify exactly which revisions are running.
+      <Text size="sm">
+        TinyCongress is an experimental platform for structured group decision-making. Instead of
+        simple yes/no polls, participants vote across multiple dimensions — capturing the nuance of
+        how people actually think about complex issues.
+      </Text>
+
+      <Text size="sm">
+        Every account is backed by cryptographic identity. Your keys are generated in your browser
+        and never leave your device. The server is a witness, not a trusted authority.
+      </Text>
+
+      <Card shadow="sm" padding="lg" radius="md" withBorder>
+        <Stack gap="xs">
+          <Title order={5}>How it works</Title>
+          <Text size="sm" c="dimmed">
+            1. Create an account with a username and backup password
+          </Text>
+          <Text size="sm" c="dimmed">
+            2. Verify your identity to prove you&apos;re a real person
+          </Text>
+          <Text size="sm" c="dimmed">
+            3. Join a room and vote on multi-dimensional polls
+          </Text>
+          <Text size="sm" c="dimmed">
+            4. See how the community thinks — not just averages, but the shape of opinion
+          </Text>
+        </Stack>
+      </Card>
+
+      <Title order={4} mt="md">
+        Build Info
+      </Title>
+      <Text c="dimmed" size="xs">
+        Revision metadata for the API and UI.
       </Text>
 
       {isPending ? (

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -105,9 +105,12 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
   if (detailQuery.isError) {
     return (
       <Stack gap="md" maw={800} mx="auto" mt="xl">
-        <Alert icon={<IconAlertTriangle size={16} />} color="red">
-          Failed to load poll: {detailQuery.error.message}
+        <Alert icon={<IconAlertTriangle size={16} />} color="red" title="Poll not found">
+          This poll may have been removed or the link may be incorrect.
         </Alert>
+        <Button component={Link} to="/rooms" variant="light">
+          Browse Rooms
+        </Button>
       </Stack>
     );
   }


### PR DESCRIPTION
## Summary
- Rewrite About page: adds "what is this" explanation for non-technical visitors, moves build metadata below as a secondary section
- Add "why verify?" copy on signup success: "so we know you're a real person, not a bot"
- Replace raw API error on invalid poll with friendly "Poll not found" message + Browse Rooms link

All three address demo readiness checklist items (error dead-ends, "why verify?" copy, about page audience).

## Test plan
- [x] `just lint-frontend` passes
- [x] `just test-frontend` passes (103/103)
- [ ] Visit `/about` — should show platform explanation before build info
- [ ] Complete signup with verifier available — should see "why verify" copy
- [ ] Visit invalid poll URL — should see "Poll not found" with Browse Rooms link

🤖 Generated with [Claude Code](https://claude.com/claude-code)