### PR TITLE
fix(ci): pass PLAYWRIGHT_API_URL to smoke test workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -70,10 +70,19 @@ jobs:
           echo "Target not reachable after 30 attempts"
           exit 1
 
+      - name: Derive API URL from target
+        id: api
+        run: |
+          BASE="${{ steps.target.outputs.url }}"
+          # https://tiny-congress-demo.ibcook.com → https://tc-api-demo.ibcook.com
+          API_URL=$(echo "$BASE" | sed 's|https://tiny-congress-demo\.|https://tc-api-demo.|')/graphql
+          echo "url=$API_URL" >> "$GITHUB_OUTPUT"
+
       - name: Run Playwright tests
         working-directory: web
         env:
           PLAYWRIGHT_BASE_URL: ${{ steps.target.outputs.url }}
+          PLAYWRIGHT_API_URL: ${{ steps.api.outputs.url }}
           PLAYWRIGHT_SKIP_WEB_SERVER: "true"
         run: yarn playwright:test --project ${{ matrix.project }}
 


### PR DESCRIPTION
## Summary
- Derive `PLAYWRIGHT_API_URL` from the target base URL in the smoke test workflow
- The about.smoke test makes a direct GraphQL API call and was defaulting to `localhost:8080`, which always fails in CI
- Other tests (signup, login, rooms) go through the frontend which gets the API URL from `config.js` — those may also benefit from having the env var available

This should fix the 100% failure rate on all 5 browser projects in the smoke test workflow.

## Test plan
- [ ] Trigger `workflow_dispatch` on the PR branch and verify tests pass
- [ ] Verify the derived API URL is correct: `https://tc-api-demo.ibcook.com/graphql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)