### PR TITLE
fix(ci): fix dufs upload reliability and always upload reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1074,8 +1074,7 @@ jobs:
     needs: [integration-tests, build-storybook, build-docs]
     if: >-
       always() &&
-      !contains(needs.*.result, 'cancelled') &&
-      needs.integration-tests.result != 'failure'
+      !contains(needs.*.result, 'cancelled')
     permissions:
       contents: read
       pull-requests: write
@@ -1537,22 +1536,21 @@ jobs:
         run: |
           set -euo pipefail
           DEST="${{ github.sha }}"
+          BASE="https://reports-upload.ibcook.com"
 
-          # Upload all site files via WebDAV PUT
-          find site -type f | while read -r file; do
-            rel="${file#site/}"
-            curl -sf -u "ci:${DUFS_PASSWORD}" \
-              -T "$file" \
-              "https://reports-upload.ibcook.com/${DEST}/${rel}"
-          done
+          upload_dir() {
+            local target="$1"
+            while IFS= read -r -d '' file; do
+              rel="${file#site/}"
+              echo "Uploading ${rel} → ${target}/${rel}"
+              curl --fail-with-body --retry 2 -u "ci:${DUFS_PASSWORD}" \
+                -T "$file" \
+                "${BASE}/${target}/${rel}"
+            done < <(find site -type f -print0)
+          }
 
-          # Also upload as "latest" for quick access
-          find site -type f | while read -r file; do
-            rel="${file#site/}"
-            curl -sf -u "ci:${DUFS_PASSWORD}" \
-              -T "$file" \
-              "https://reports-upload.ibcook.com/latest/${rel}"
-          done
+          upload_dir "$DEST"
+          upload_dir "latest"
 
           {
             echo "### 📋 CI Reports"


### PR DESCRIPTION
## Summary
- Remove the `integration-tests.result != 'failure'` gate on the upload job — reports should upload especially when tests fail
- Fix broken pipe from `find | while` with `pipefail` — switch to process substitution (`find -print0` + `read -d ''`)
- Use `--fail-with-body` instead of `-sf` for error visibility, add `--retry 2` for transient failures

Follows up on #473 where the upload step failed with exit code 22 and broken pipe.

## Test plan
- [ ] CI passes
- [ ] Upload job runs and succeeds
- [ ] Reports accessible at `https://reports.ibcook.com/<sha>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)