### PR TITLE
fix(web): pass username through DeviceProvider to verify links

### DIFF
--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -32,7 +32,7 @@ interface NavbarProps {
 }
 
 export function Navbar({ onNavigate }: NavbarProps) {
-  const { deviceKid, privateKey, clearDevice } = useDevice();
+  const { deviceKid, privateKey, username, clearDevice } = useDevice();
   const navigate = useNavigate();
   const currentPath = useRouterState({
     select: (state) => state.location.pathname,
@@ -107,7 +107,7 @@ export function Navbar({ onNavigate }: NavbarProps) {
               </Badge>
             ) : (
               (() => {
-                const url = buildVerifierUrl('');
+                const url = buildVerifierUrl(username ?? '');
                 if (url) {
                   return (
                     <Badge

--- a/web/src/pages/Login.page.test.tsx
+++ b/web/src/pages/Login.page.test.tsx
@@ -132,7 +132,8 @@ describe('LoginPage', () => {
     // Should store device credentials (non-extractable CryptoKey)
     expect(mockSetDevice).toHaveBeenCalledWith(
       'kid-device',
-      expect.objectContaining({ type: 'private' }) as CryptoKey
+      expect.objectContaining({ type: 'private' }) as CryptoKey,
+      'alice'
     );
   });
 

--- a/web/src/pages/Login.page.tsx
+++ b/web/src/pages/Login.page.tsx
@@ -101,7 +101,7 @@ export function LoginPage() {
       // time) would see stale context and redirect back to /login.
       // See https://github.com/TanStack/router/issues/2072
       flushSync(() => {
-        setDevice(response.device_kid, deviceKeyPair.privateKey);
+        setDevice(response.device_kid, deviceKeyPair.privateKey, username.trim());
       });
 
       // Navigate to rooms after successful login

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -38,7 +38,7 @@ interface PollPageProps {
 }
 
 export function PollPage({ roomId, pollId }: PollPageProps) {
-  const { deviceKid, privateKey, isLoading: deviceLoading } = useDevice();
+  const { deviceKid, privateKey, username, isLoading: deviceLoading } = useDevice();
   const { crypto } = useCrypto();
 
   const detailQuery = usePollDetail(roomId, pollId);
@@ -190,7 +190,7 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
               <Alert icon={<IconShieldOff size={16} />} color="yellow">
                 You need to verify your identity to vote in this room.
                 {(() => {
-                  const url = buildVerifierUrl('');
+                  const url = buildVerifierUrl(username ?? '');
                   if (url) {
                     return (
                       <Button component="a" href={url} size="xs" variant="light" mt="xs">

--- a/web/src/pages/Settings.page.tsx
+++ b/web/src/pages/Settings.page.tsx
@@ -11,7 +11,7 @@ import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
 
 export function SettingsPage() {
-  const { deviceKid, privateKey } = useDevice();
+  const { deviceKid, privateKey, username } = useDevice();
   const { crypto } = useCrypto();
 
   const devicesQuery = useListDevices(deviceKid, privateKey, crypto);
@@ -112,7 +112,7 @@ export function SettingsPage() {
                 </Text>
               </Group>
               {(() => {
-                const url = buildVerifierUrl('');
+                const url = buildVerifierUrl(username ?? '');
                 if (url) {
                   return (
                     <Button component="a" href={url} variant="light" size="sm">

--- a/web/src/pages/Signup.page.test.tsx
+++ b/web/src/pages/Signup.page.test.tsx
@@ -99,7 +99,7 @@ describe('SignupPage', () => {
     );
 
     // Should store device credentials (non-extractable CryptoKey)
-    expect(mockSetDevice).toHaveBeenCalledWith('dev-456', mockCryptoKey);
+    expect(mockSetDevice).toHaveBeenCalledWith('dev-456', mockCryptoKey, 'alice');
 
     expect(await screen.findByText(/What's next/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /browse rooms/i })).toHaveAttribute('href', '/rooms');

--- a/web/src/pages/Signup.page.tsx
+++ b/web/src/pages/Signup.page.tsx
@@ -70,7 +70,7 @@ export function SignupPage() {
       });
 
       // Store device credentials in session context (CryptoKey is non-extractable)
-      setDevice(response.device_kid, deviceKeyPair.privateKey);
+      setDevice(response.device_kid, deviceKeyPair.privateKey, username.trim());
 
       setCreatedAccount(response);
     } catch {

--- a/web/src/pages/VerifyCallback.page.tsx
+++ b/web/src/pages/VerifyCallback.page.tsx
@@ -9,6 +9,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { Alert, Button, Stack, Text, Title } from '@mantine/core';
 import { buildVerifierUrl } from '@/features/verification';
+import { useDevice } from '@/providers/DeviceProvider';
 
 interface VerifyCallbackSearch {
   verification?: string;
@@ -20,6 +21,7 @@ export function VerifyCallbackPage() {
   const search: VerifyCallbackSearch = useSearch({ strict: false });
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { username } = useDevice();
 
   const isSuccess = search.verification === 'success';
   const isError = search.verification === 'error';
@@ -64,7 +66,7 @@ export function VerifyCallbackPage() {
           </Alert>
           <Button
             onClick={() => {
-              const url = buildVerifierUrl('');
+              const url = buildVerifierUrl(username ?? '');
               if (url) {
                 window.location.href = url;
               }

--- a/web/src/providers/DeviceProvider.tsx
+++ b/web/src/providers/DeviceProvider.tsx
@@ -28,6 +28,7 @@ const CURRENT_KEY = 'current';
 interface StoredDevice {
   kid: string;
   privateKey: CryptoKey;
+  username?: string;
 }
 
 interface DeviceContextValue {
@@ -35,10 +36,12 @@ interface DeviceContextValue {
   deviceKid: string | null;
   /** Non-extractable CryptoKey for signing, or null if not authenticated */
   privateKey: CryptoKey | null;
+  /** Current username, or null if not authenticated */
+  username: string | null;
   /** True while loading credentials from IndexedDB on mount */
   isLoading: boolean;
   /** Store device credentials after signup/login */
-  setDevice: (kid: string, key: CryptoKey) => void;
+  setDevice: (kid: string, key: CryptoKey, username: string) => void;
   /** Clear device credentials (logout) */
   clearDevice: () => void;
 }
@@ -49,6 +52,7 @@ const noop = () => {};
 const DeviceContext = createContext<DeviceContextValue>({
   deviceKid: null,
   privateKey: null,
+  username: null,
   isLoading: true,
   setDevice: noop,
   clearDevice: noop,
@@ -89,6 +93,7 @@ interface DeviceProviderProps {
 export function DeviceProvider({ children }: DeviceProviderProps) {
   const [deviceKid, setDeviceKid] = useState<string | null>(null);
   const [privateKey, setPrivateKey] = useState<CryptoKey | null>(null);
+  const [username, setUsername] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // Load from IndexedDB on mount
@@ -98,6 +103,7 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
         if (stored) {
           setDeviceKid(stored.kid);
           setPrivateKey(stored.privateKey);
+          setUsername(stored.username ?? null);
         }
       })
       .catch((err: unknown) => {
@@ -110,10 +116,11 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
       });
   }, []);
 
-  const setDeviceFn = useCallback((kid: string, key: CryptoKey) => {
+  const setDeviceFn = useCallback((kid: string, key: CryptoKey, name: string) => {
     setDeviceKid(kid);
     setPrivateKey(key);
-    saveDevice({ kid, privateKey: key }).catch((err: unknown) => {
+    setUsername(name);
+    saveDevice({ kid, privateKey: key, username: name }).catch((err: unknown) => {
       // eslint-disable-next-line no-console
       console.warn('Failed to save device to IndexedDB:', err);
     });
@@ -122,6 +129,7 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
   const clearDeviceFn = useCallback(() => {
     setDeviceKid(null);
     setPrivateKey(null);
+    setUsername(null);
     deleteDevice().catch((err: unknown) => {
       // eslint-disable-next-line no-console
       console.warn('Failed to delete device from IndexedDB:', err);
@@ -132,11 +140,12 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
     () => ({
       deviceKid,
       privateKey,
+      username,
       isLoading,
       setDevice: setDeviceFn,
       clearDevice: clearDeviceFn,
     }),
-    [deviceKid, privateKey, isLoading, setDeviceFn, clearDeviceFn]
+    [deviceKid, privateKey, username, isLoading, setDeviceFn, clearDeviceFn]
   );
 
   return <DeviceContext.Provider value={value}>{children}</DeviceContext.Provider>;


### PR DESCRIPTION
## Summary

Closes #492

- Added `username` field to `DeviceProvider` (persisted in IDB alongside device credentials)
- Signup and login now pass the trimmed username when calling `setDevice`
- All `buildVerifierUrl` call sites (navbar, poll page, settings, verify callback) read from device context instead of passing empty string

## Test plan

- [x] `just lint-frontend` passes
- [x] `just test-frontend` — 103/103 tests pass (updated setDevice assertions in signup + login tests)
- [ ] Manual: after signup, verify links in navbar badge, poll alert, settings, and verify callback all include the correct username

🤖 Generated with [Claude Code](https://claude.com/claude-code)