### PR TITLE
fix(web): prevent slider dimension labels from clipping

### DIFF
--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -300,7 +300,7 @@ function VoteSlider({
           {dimension.description}
         </Text>
       ) : null}
-      <div style={{ paddingBottom: 8 }}>
+      <div style={{ paddingBottom: 8, paddingLeft: 8, paddingRight: 8 }}>
         <Slider
           value={value}
           onChange={onChange}
@@ -320,7 +320,12 @@ function VoteSlider({
             { value: dimension.min_value, label: dimension.min_label ?? 'Low' },
             { value: dimension.max_value, label: dimension.max_label ?? 'High' },
           ]}
-          styles={{ markLabel: { fontSize: 'var(--mantine-font-size-xs)' } }}
+          styles={{
+            markLabel: {
+              fontSize: 'var(--mantine-font-size-xs)',
+              whiteSpace: 'nowrap',
+            },
+          }}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add horizontal padding (8px) to slider wrapper div so min/max mark labels aren't cut off at container edges
- Add `whiteSpace: nowrap` to mark label styles to prevent label text from wrapping to a second line
- Fixes the clipping visible on dimension labels like "Not a concern" / "Big concern", especially on mobile viewports

Closes #493

## Test plan
- [ ] Open a poll page with long dimension labels (e.g. Immigration Stance or Healthcare Spending)
- [ ] Verify min/max labels are fully visible on desktop and mobile widths
- [ ] Verify slider thumb still drags the full range without layout issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)