### PR TITLE
fix(docker): correct PG_VERSION metadata to 18.3

### DIFF
--- a/dockerfiles/Dockerfile.postgres
+++ b/dockerfiles/Dockerfile.postgres
@@ -25,7 +25,7 @@ COPY --from=builder / /
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV LANG=en_US.utf8
 ENV PG_MAJOR=18
-ENV PG_VERSION=18.2
+ENV PG_VERSION=18.3
 ENV PGDATA=/var/lib/postgresql/18/docker
 VOLUME /var/lib/postgresql
 # Database name default (non-sensitive)


### PR DESCRIPTION
## Summary
- Fixes cosmetic metadata mismatch introduced in #495 — `PG_VERSION` was set to `18.2` but the actual image is `postgres:18-alpine` which ships 18.3

## Test plan
- [x] One-line change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)