### PR TITLE
ci: suppress per-file curl output in dufs upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1526,9 +1526,11 @@ jobs:
             config=$(mktemp)
             local count=0
             local total_bytes=0
+            local first=true
             while IFS= read -r -d '' file; do
               rel="${file#site/}"
-              printf 'url = "%s/%s/%s"\nupload-file = "%s"\nuser = "ci:%s"\nsilent\nfail-with-body\nnext\n' \
+              if $first; then first=false; else printf 'next\n' >> "$config"; fi
+              printf 'url = "%s/%s/%s"\nupload-file = "%s"\nuser = "ci:%s"\nsilent\nfail-with-body\n' \
                 "$BASE" "$target" "$rel" "$file" "$DUFS_PASSWORD" >> "$config"
               count=$((count + 1))
               total_bytes=$((total_bytes + $(wc -c < "$file")))


### PR DESCRIPTION
## Summary
- Replace per-file `echo + curl progress` output with a single summary line per destination
- Reduces upload step log from ~2000 lines to 2 lines

## Test plan
- [ ] Upload step logs show `Uploaded N files to <dest>/` instead of one line per file

🤖 Generated with [Claude Code](https://claude.com/claude-code)