### PR TITLE
fix(tests): prune orphaned testcontainers by owner PID

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ default:
 # =============================================================================
 
 # Run backend unit tests (auto-builds postgres image if needed for DB tests)
-test-backend: _ensure-test-postgres
+test-backend: _ensure-test-postgres prune-testcontainers
     cd service && cargo test
 
 # Run backend unit tests in watch mode (re-runs on file changes)
@@ -408,6 +408,23 @@ refine-remote *ARGS:
 # =============================================================================
 # Utility Commands
 # =============================================================================
+
+# Remove testcontainers whose owner process has exited (safe for parallel test runs)
+prune-testcontainers:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    STALE=""
+    while IFS= read -r cid; do
+        [ -z "$cid" ] && continue
+        pid=$(docker inspect "$cid" --format '{{{{index .Config.Labels "tc-owner-pid"}}' 2>/dev/null || true)
+        if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+            STALE="$STALE $cid"
+        fi
+    done < <(docker ps -aq --filter "label=tc-owner-pid")
+    if [ -n "$STALE" ]; then
+        echo "Pruning orphaned testcontainers (dead owner PIDs)..."
+        docker rm -f $STALE
+    fi
 
 # Clean build artifacts
 clean: _clean-wasm

--- a/service/tests/common/mod.rs
+++ b/service/tests/common/mod.rs
@@ -207,7 +207,11 @@ pub mod test_db {
                     .rsplit_once(':')
                     .unwrap_or((&image_full, "latest"));
 
-                // Start postgres container with custom image that includes pgmq
+                // Start postgres container with custom image that includes pgmq.
+                // Label with the current PID so `just prune-testcontainers` can
+                // identify and remove orphans from crashed runs without clobbering
+                // containers owned by other live test processes.
+                let owner_pid = std::process::id().to_string();
                 let container = GenericImage::new(image_name, image_tag)
                     .with_exposed_port(5432.into())
                     .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
@@ -216,6 +220,7 @@ pub mod test_db {
                     .with_env_var("POSTGRES_USER", "postgres")
                     .with_env_var("POSTGRES_PASSWORD", "postgres")
                     .with_env_var("POSTGRES_DB", "tiny-congress")
+                    .with_label("tc-owner-pid", owner_pid)
                     .start()
                     .await
                     .expect("Failed to start postgres container");


### PR DESCRIPTION
## Summary

- Labels each testcontainer with `tc-owner-pid=<PID>` at startup
- Adds `just prune-testcontainers` that only removes containers whose owner PID is dead — safe for parallel test runs
- Wires `prune-testcontainers` as a pre-step on `test-backend` for automatic cleanup before each run

## Background

testcontainers-rs has no Ryuk reaper (unlike the Java library). Cleanup depends entirely on `ContainerAsync::drop()`. Because our container lives in a `static OnceCell`, drop never fires — not on clean exit, not on crash. This caused 638 orphaned containers accumulating silently and pegging the Docker VM at ~900% CPU.

The PID-label approach is parallel-safe: `kill -0 $pid` distinguishes a dead owner (prune) from a live parallel test process (leave alone).

## Test plan

- [ ] Run `just test-backend`, confirm tests pass and prune runs cleanly with no containers to remove
- [ ] Verify `docker inspect <container> --format '{{index .Config.Labels "tc-owner-pid"}}'` shows the PID during a test run
- [ ] Kill a test run mid-flight, run `just prune-testcontainers`, confirm orphan is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)