### PR TITLE
fix(reputation): read RETURNING id from verifier account upsert

### DIFF
--- a/service/src/reputation/bootstrap.rs
+++ b/service/src/reputation/bootstrap.rs
@@ -59,22 +59,22 @@ async fn ensure_verifier_account(
         return Ok(id);
     }
 
-    // Create new account
+    // Create new account, returning the actual id (existing or newly inserted)
     let id = Uuid::new_v4();
-    sqlx::query(
+    let returned_id: (Uuid,) = sqlx::query_as(
         r"INSERT INTO accounts (id, username, root_pubkey, root_kid)
           VALUES ($1, $2, $3, $4)
-          ON CONFLICT (username) DO UPDATE SET username = EXCLUDED.username
+          ON CONFLICT (username) DO UPDATE SET root_pubkey = EXCLUDED.root_pubkey, root_kid = EXCLUDED.root_kid
           RETURNING id",
     )
     .bind(id)
     .bind(name)
     .bind(public_key)
     .bind(kid.as_str())
-    .execute(pool)
+    .fetch_one(pool)
     .await?;
 
-    Ok(id)
+    Ok(returned_id.0)
 }
 
 /// Ensure the account has an `authorized_verifier` endorsement (genesis, NULL issuer).


### PR DESCRIPTION
## Summary
- `ensure_verifier_account` used `.execute()` instead of `.fetch_one()`, silently discarding the `RETURNING id` result
- On username conflict the function returned a locally-generated UUID never inserted into the DB
- `ensure_authorized_verifier_endorsement` then FK-violated on that phantom UUID, crashing the process on every startup (344 restarts in 24h observed via Grafana)

## Fix
Switch to `.fetch_one()` and use the actual returned `id`. Also tightened the `ON CONFLICT` update to keep keys in sync rather than a no-op self-assignment.

## Test Plan
- [ ] Deploy and verify pod restarts drop to 0
- [ ] Confirm verifier bootstrap logs show success on startup

Fixes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)