### PR TITLE
ci: use in-cluster BuildKit with Zot pull-through cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://buildkit.buildkit.svc.cluster.local:1234
+          endpoint: tcp://buildkitd.buildkit.svc.cluster.local:1234
 
       - name: Login to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- **Remote BuildKit driver** replaces the ephemeral DinD buildx builder. The persistent BuildKit daemon (`buildkit.buildkit.svc.cluster.local:1234`) has a 50Gi Ceph-backed layer cache that survives across all jobs. Every unchanged layer is a cache hit — no more re-pulling `rust:1.83` on every run.
- **Zot registry cache** replaces GHCR as the explicit build cache destination. Cache import/export stays entirely in-cluster (no external roundtrip, no GHCR rate limits).
- **Zot pull-through mirrors** are configured server-side in `buildkitd.toml` (homelab-gitops). `FROM ubuntu:22.04` is automatically routed through Zot on first fetch; subsequent jobs hit Zot's local copy. No workflow changes needed for base image pulls.

## What changed

`build-images` job only:
1. `docker/setup-buildx-action@v3` now sets `driver: remote` + `endpoint: tcp://buildkit.buildkit.svc.cluster.local:1234`
2. `cache-from`/`cache-to` point to `zot.zot.svc.cluster.local:5000/cache/<image>:cache` instead of GHCR

All other jobs are unchanged. The DinD daemon is still available for `docker run` in integration tests.

## Infra side (homelab-gitops, already deployed)

- `buildkit/configmap.yaml`: new `buildkitd.toml` with Zot mirrors for `docker.io` and `ghcr.io`
- `buildkit/statefulset.yaml`: mounts config and passes `--config` flag
- `zot/helmrelease.yaml`: adds `catthehacker/**` to GHCR onDemand sync

## Test plan

- [ ] `build-images` completes successfully on `arc-runner-set`
- [ ] Second run (warm) is measurably faster than first run (cold) — layer cache hit
- [ ] `integration-tests` job unaffected (still uses DinD for `docker run`)
- [ ] No regressions on `ubuntu-latest` jobs (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)