### PR TITLE
fix(ux): replace blank loading screens with centered spinner

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,16 +13,16 @@ import { mantineTheme } from './theme/mantineTheme';
 export default function App() {
   return (
     <ErrorBoundary context="Application">
-      <CryptoProvider>
-        <DeviceProvider>
-          <QueryProvider>
-            <MantineProvider theme={mantineTheme} defaultColorScheme="dark">
-              <Notifications />
+      <MantineProvider theme={mantineTheme} defaultColorScheme="dark">
+        <Notifications />
+        <CryptoProvider>
+          <DeviceProvider>
+            <QueryProvider>
               <Router />
-            </MantineProvider>
-          </QueryProvider>
-        </DeviceProvider>
-      </CryptoProvider>
+            </QueryProvider>
+          </DeviceProvider>
+        </CryptoProvider>
+      </MantineProvider>
     </ErrorBoundary>
   );
 }

--- a/web/src/Router.tsx
+++ b/web/src/Router.tsx
@@ -8,7 +8,7 @@ import {
   RouterProvider,
   useParams,
 } from '@tanstack/react-router';
-import { Button, Group, Stack, Text, Title } from '@mantine/core';
+import { Button, Center, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { AuthRequiredOutlet } from './components/AuthRequiredOutlet';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AboutPage } from './pages/About.page';
@@ -156,7 +156,11 @@ export function Router() {
   const { deviceKid, isLoading } = useDevice();
 
   if (isLoading) {
-    return null;
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Loader size="sm" />
+      </Center>
+    );
   }
 
   return (

--- a/web/src/providers/CryptoProvider.tsx
+++ b/web/src/providers/CryptoProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { Center, Loader } from '@mantine/core';
 
 /**
  * Interface for the crypto module functions exposed by WASM
@@ -86,7 +87,11 @@ export function CryptoProvider({ children }: CryptoProviderProps) {
   // Don't render children until WASM is loaded
   // This ensures crypto is always available when useCryptoRequired is called
   if (state.isLoading) {
-    return null;
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Loader size="sm" />
+      </Center>
+    );
   }
 
   if (state.error) {


### PR DESCRIPTION
## Summary

- Move `MantineProvider` above `CryptoProvider` and `DeviceProvider` in the tree so Mantine styles and components are available during both loading phases
- `CryptoProvider`: renders `<Center><Loader /></Center>` instead of `null` while WASM initializes
- `Router`: renders `<Center><Loader /></Center>` instead of `null` while IndexedDB rehydrates the device session

Previously every page load started with a blank screen (white in light mode, dark in dark mode) for the duration of WASM + IndexedDB startup. This was particularly jarring on first visit and looked broken on mobile.

## Test plan

- [ ] Fresh page load shows a centered spinner briefly before the app renders
- [ ] No visual flash or blank screen
- [ ] Dark mode respected during loading (spinner uses theme color)
- [ ] `just test-frontend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)