### PR TITLE
fix(ux): polish login page and mobile header

### DIFF
--- a/web/src/pages/Layout.tsx
+++ b/web/src/pages/Layout.tsx
@@ -66,7 +66,9 @@ export function Layout() {
             h={32}
             w="auto"
           />
-          <Text fw={700}>TinyCongress</Text>
+          <Text fw={700} visibleFrom="sm">
+            TinyCongress
+          </Text>
           <EnvironmentBadge />
           <ActionIcon
             variant="subtle"

--- a/web/src/pages/Login.page.tsx
+++ b/web/src/pages/Login.page.tsx
@@ -115,14 +115,12 @@ export function LoginPage() {
     }
   };
 
-  const displayError = localError;
-
   return (
     <Stack gap="md" maw={500} mx="auto" mt="xl">
       <div>
         <Title order={2}>Log In</Title>
         <Text c="dimmed" size="sm" mt="xs">
-          Sign in to your TinyCongress account
+          Enter your username and the backup password you chose when you signed up.
         </Text>
       </div>
 
@@ -145,8 +143,8 @@ export function LoginPage() {
             />
 
             <PasswordInput
-              label="Backup password"
-              placeholder="Enter your backup password"
+              label="Backup Password"
+              description="The password you chose when creating your account."
               required
               value={password}
               onChange={(e) => {
@@ -155,9 +153,9 @@ export function LoginPage() {
               disabled={loginMutation.isPending || isGeneratingKeys}
             />
 
-            {displayError ? (
+            {localError ? (
               <Alert icon={<IconAlertTriangle size={16} />} title="Login failed" color="red">
-                {displayError}
+                {localError}
               </Alert>
             ) : null}
 


### PR DESCRIPTION
## Summary

**Login page:**
- Label case fixed: `"Backup password"` → `"Backup Password"` (consistent with signup)
- Added description on the password field: "The password you chose when creating your account." — orients returning users who might not remember what "backup password" refers to
- Subtitle rewritten to be concrete: "Enter your username and the backup password you chose when you signed up."
- Removed unused `displayError` alias (was just `localError`)

**Header:**
- `"TinyCongress"` text hidden on mobile (`visibleFrom="sm"`) — the logo is sufficient and this frees header space for the burger, theme toggle, and user menu on small screens

## Test plan

- [ ] Login form shows "Backup Password" label with description
- [ ] Login subtitle explains what password to use
- [ ] Mobile: header shows logo without "TinyCongress" text
- [ ] Desktop: header still shows "TinyCongress" text
- [ ] `just test-frontend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)