### PR TITLE
perf(ci): split integration-tests into parallel unit/rust/e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,13 +598,8 @@ jobs:
   unit-tests:
     name: Unit tests (Vitest)
     runs-on: ubuntu-24.04
-    needs:
-      - detect-changes
-    if: >-
-      always() &&
-      (needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true') &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.ci == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -642,14 +637,8 @@ jobs:
   rust-coverage:
     name: Rust coverage
     runs-on: ubuntu-24.04
-    needs:
-      - detect-changes
-      - build-images
-    if: >-
-      always() &&
-      (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ci == 'true') &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    needs: [detect-changes, build-images]
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ci == 'true'
     env:
       TEST_POSTGRES_IMAGE: ${{ needs.build-images.outputs.postgres-tag || format('ghcr.io/{0}/postgres:{1}', github.repository, github.sha) }}
     steps:
@@ -973,7 +962,7 @@ jobs:
       github.event_name == 'push' && github.ref == 'refs/heads/master' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    needs: [e2e-tests, detect-changes]
+    needs: [unit-tests, rust-coverage, e2e-tests, detect-changes]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Breaks the monolithic `integration-tests` job (616s wall clock) into 3 parallel jobs:

| Job | What it does | Est. time | Runs after |
|---|---|---|---|
| `unit-tests` | Vitest + WASM + coverage | ~150s | `detect-changes` |
| `rust-coverage` | `cargo llvm-cov --fail-under-lines 60` | ~180s | `build-images` (needs custom postgres) |
| `e2e-tests` | KinD + Skaffold deploy + Playwright | ~250s | `build-images` + `lint` + `lint-web` |
| `coverage-report` | Downloads artifacts, assembles unified report | ~30s | all 3 above |

**Eliminates duplicate Rust test execution:** `skaffold test` previously ran `cargo llvm-cov` without threshold, then a separate step re-ran it with `--fail-under-lines 60`. Now runs exactly once.

**Estimated critical path: ~250s** (e2e-tests) vs ~616s today.

## Changes to downstream jobs

- `ci-gate`: references `unit-tests`, `rust-coverage`, `e2e-tests`, `coverage-report` instead of `integration-tests`
- `deploy-gitops`: needs `e2e-tests` (was `integration-tests`)
- `deploy-reports`: needs `coverage-report` + `e2e-tests` (was `integration-tests`)

## Test plan

- [ ] CI passes — all 3 test jobs green
- [ ] Coverage report artifact is generated correctly
- [ ] Playwright report uploads work
- [ ] deploy-reports assembles all artifacts
- [ ] Verify parallel execution in Actions timeline view

🤖 Generated with [Claude Code](https://claude.com/claude-code)