### PR TITLE
feat(ci): add preflight health checks to smoke test workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -42,9 +42,11 @@ jobs:
           fi
           API="${BASE/https:\/\/tiny-congress-demo./https://tc-api-demo.}"
           VERIFIER="${BASE/https:\/\/tiny-congress-demo./https://tc-verify-demo.}"
-          echo "frontend=$BASE" >> "$GITHUB_OUTPUT"
-          echo "api=$API" >> "$GITHUB_OUTPUT"
-          echo "verifier=$VERIFIER" >> "$GITHUB_OUTPUT"
+          {
+            echo "frontend=$BASE"
+            echo "api=$API"
+            echo "verifier=$VERIFIER"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check HTTPS — frontend
         run: |


### PR DESCRIPTION
## Summary

- Adds a `preflight` job to `smoke-test.yml` that runs once before the 5-browser matrix
- Preflight validates HTTPS reachability on all three demo domains (frontend, API at `/health`, demo verifier)
- Preflight confirms sim worker has seeded content via GraphQL rooms query
- `smoke` matrix now depends on `preflight` and consumes URL outputs — no more per-runner URL resolution
- Guards against non-default `workflow_dispatch` URLs that can't be derived from the demo pattern

Closes #460, closes #461

## Test plan

- [ ] Workflow runs automatically after CI passes on master
- [ ] Preflight fails fast if any domain is unreachable (smoke skipped, not burned)
- [ ] Manual `workflow_dispatch` with non-default URL fails immediately with a clear error message