### PR TITLE
feat(ci): route jobs to sized runner tiers (nano/small/medium/large)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,15 +388,19 @@ jobs:
           # Default: ubuntu-latest (GHA hosted)
           commit_msg=$(git log -1 --format=%s HEAD)
           if echo "$commit_msg" | grep -qF '[arc]' || [ "${{ vars.USE_ARC_RUNNERS }}" = "true" ]; then
-            echo "nano=arc-runner-nano" >> "$GITHUB_OUTPUT"
-            echo "small=arc-runner-small" >> "$GITHUB_OUTPUT"
-            echo "medium=arc-runner-medium" >> "$GITHUB_OUTPUT"
-            echo "large=arc-runner-large" >> "$GITHUB_OUTPUT"
+            {
+              echo "nano=arc-runner-nano"
+              echo "small=arc-runner-small"
+              echo "medium=arc-runner-medium"
+              echo "large=arc-runner-large"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "nano=ubuntu-latest" >> "$GITHUB_OUTPUT"
-            echo "small=ubuntu-latest" >> "$GITHUB_OUTPUT"
-            echo "medium=ubuntu-latest" >> "$GITHUB_OUTPUT"
-            echo "large=ubuntu-latest" >> "$GITHUB_OUTPUT"
+            {
+              echo "nano=ubuntu-latest"
+              echo "small=ubuntu-latest"
+              echo "medium=ubuntu-latest"
+              echo "large=ubuntu-latest"
+            } >> "$GITHUB_OUTPUT"
           fi
       - uses: dorny/paths-filter@v3
         id: filter
@@ -949,6 +953,7 @@ jobs:
     name: CI Gate
     if: always()
     needs:
+      - detect-changes
       - lint
       - lint-kube
       - lint-web
@@ -1096,7 +1101,7 @@ jobs:
   deploy-reports:
     name: Upload CI reports to Dufs
     runs-on: ${{ needs.detect-changes.outputs.runner-small }}
-    needs: [unit-tests, rust-coverage, e2e-tests, build-storybook, build-docs]
+    needs: [detect-changes, unit-tests, rust-coverage, e2e-tests, build-storybook, build-docs]
     if: >-
       always() &&
       !contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
## Summary

Routes all CI jobs to appropriate ARC runner tiers based on actual resource usage (measured from 24h Prometheus data across ~170 runner pods).

| Tier | Jobs | Resources |
|------|------|-----------|
| `arc-runner-nano` | detect-changes, lint, lint-kube, check-dashboards, static-analysis, build-images, scan-images, ci-gate, deploy-gitops | 250m / 256Mi req |
| `arc-runner-small` | lint-web, build-storybook, security-audit, deploy-reports | 500m / 1Gi req |
| `arc-runner-medium` | build-docs, codegen-check, sqlx-check, unit-tests | 1 / 2Gi req |
| `arc-runner-large` | rust-coverage, e2e-tests | 4 / 8Gi req |

`detect-changes` emits four runner outputs (`runner-nano`, `runner-small`, `runner-medium`, `runner-large`) instead of a single `runner`. Each resolves to the ARC label when `[arc]` flag or `USE_ARC_RUNNERS=true`, otherwise `ubuntu-latest`.

Legacy `arc-runner-set` is preserved in homelab-gitops for any other workflows still using the old label.

## Test plan

- [x] Commit message contains `[arc]` — triggers ARC runner routing
- [ ] All jobs route to correct runner tier in Actions UI
- [ ] nano jobs (lint, scan) pick up `arc-runner-nano` pods
- [ ] large jobs (rust-coverage, e2e) pick up `arc-runner-large` pods
- [ ] CI gate passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)