### PR TITLE
fix(demo-verifier): retry login on HTTP 5xx, not just network errors

### DIFF
--- a/service/src/bin/demo_verifier.rs
+++ b/service/src/bin/demo_verifier.rs
@@ -595,18 +595,20 @@ async fn main() -> Result<(), anyhow::Error> {
                     if status == 201 {
                         tracing::info!("demo verifier device key registered via login");
                         bg_state.ready.store(true, Ordering::Relaxed);
+                        return;
                     } else if status == 409 {
                         tracing::debug!("demo verifier device key already registered");
                         bg_state.ready.store(true, Ordering::Relaxed);
-                    } else {
-                        let body = resp.text().await.unwrap_or_default();
-                        tracing::warn!(
-                            status,
-                            body = %body,
-                            "demo verifier login returned unexpected status"
-                        );
+                        return;
                     }
-                    return;
+                    let body = resp.text().await.unwrap_or_default();
+                    tracing::warn!(
+                        attempt,
+                        status,
+                        body = %body,
+                        "demo verifier login returned unexpected status — retrying in 5s"
+                    );
+                    tokio::time::sleep(delay).await;
                 }
                 Err(e) => {
                     tracing::warn!(


### PR DESCRIPTION
## Summary

- The background login retry loop exited on **any** HTTP response, including 5xx — `return` was placed after the if/else block rather than inside the 201/409 branches
- HTTP 500 responses (API still starting up) hit `Ok(resp)`, logged a warning, then returned — killing the loop; only connection-level `Err` triggered retries
- Fixes CrashLoopBackOff on `tc-demo` during Helm upgrades when the API pod isn't ready yet
- Also adds `attempt` field to the warning log for better observability

## Test plan

- [ ] Deploy to homelab with a cold API; confirm verifier reaches ready state after API comes up
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)