### PR TITLE
fix(sim): remove non-existent poll_duration_secs from test SimConfig literals

### DIFF
--- a/service/src/sim/llm.rs
+++ b/service/src/sim/llm.rs
@@ -381,7 +381,6 @@ mod tests {
             voter_count: 20,
             log_level: "info".to_string(),
             mock_llm: true,
-            poll_duration_secs: 86400,
         };
 
         let client = reqwest::Client::new();
@@ -403,7 +402,6 @@ mod tests {
             voter_count: 20,
             log_level: "info".to_string(),
             mock_llm: false,
-            poll_duration_secs: 86400,
         };
 
         let messages = build_messages(&config, 2);


### PR DESCRIPTION
## Summary

- PR #535 introduced two `SimConfig` struct literals in `llm.rs` tests with `poll_duration_secs: 86400`, but that field doesn't exist in `SimConfig`
- This caused a compile error on master, breaking the `rust-coverage` CI job
- Without the Rust coverage artifact, `deploy-reports` finds no coverage data and exits with "No coverage data found. No report generated."

## Fix

Remove the two spurious `poll_duration_secs: 86400` lines from the test struct literals. No behavior change — these are test-only `SimConfig` instances.

## Test plan

- [ ] `cargo check` passes locally (confirmed)
- [ ] `rust-coverage` CI job succeeds
- [ ] `deploy-reports` job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)