### PR TITLE
ci: use setup-rust composite in security-audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,12 @@ jobs:
           config: .kube-linter.yaml
 
       # GHA ubuntu-24.04 pre-installs Helm; catthehacker ARC runners do not.
+      # azure/setup-helm relies on GHA tool cache infrastructure absent on ARC runners.
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        run: |
+          HELM_VERSION=v3.17.3
+          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+            | sudo tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm
 
       - name: Validate environment values
         run: |
@@ -756,8 +760,12 @@ jobs:
           cluster_name: skaffold-ci
 
       # GHA ubuntu-24.04 pre-installs Helm; catthehacker ARC runners do not.
+      # azure/setup-helm relies on GHA tool cache infrastructure absent on ARC runners.
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        run: |
+          HELM_VERSION=v3.17.3
+          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+            | sudo tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm
 
       - name: Start KinD cluster in background
         run: |


### PR DESCRIPTION
## Problem

`audit-deps` (`cargo deny check`) was failing on ARC runners with:

```
sh: 1: cargo: not found
```

The `security-audit` job had a manual `Add Cargo to PATH` step that added `~/.cargo/bin` to `$PATH`, but never actually installed Rust. On GitHub-hosted `ubuntu-24.04` runners, `cargo` is pre-installed — so this worked silently. On `catthehacker/ubuntu:runner-24.04` (our ARC runner image), it is not.

## Fix

Replace the `Add Cargo to PATH` step with the existing `./.github/actions/setup-rust` composite action (`cache-dependencies: 'false'`), consistent with how other jobs install Rust.

This gives the job:
- `cargo` via `dtolnay/rust-toolchain` (prebuilt, ~10s)
- `~/.cargo/bin` cached via `runs-on/cache@v4` → Garage S3 (warm runs: free)
- `cargo-deny` and `cargo-machete` binaries from `taiki-e/install-action` land in `~/.cargo/bin` and are picked up by the toolchain cache on subsequent runs

No GHA cache API is used — all caching goes through our S3 backend.

The commit includes `[arc]` to route this CI run through ARC runners for immediate validation.