### PR TITLE
fix(ci): add xz-utils for shellcheck, build arc-runner on PRs

### DIFF
--- a/.github/workflows/build-arc-runner.yml
+++ b/.github/workflows/build-arc-runner.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
     paths:
       - 'dockerfiles/Dockerfile.arc-runner'
+  pull_request:
+    paths:
+      - 'dockerfiles/Dockerfile.arc-runner'
   workflow_dispatch:
   schedule:
     # Weekly rebuild to pick up base image security patches (Monday 6am UTC)
@@ -46,7 +49,8 @@ jobs:
         with:
           context: dockerfiles
           file: dockerfiles/Dockerfile.arc-runner
-          push: true
+          # Only push on master/main and manual/scheduled runs; PRs just build.
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
           tags: |
             ghcr.io/${{ github.repository }}/arc-runner:latest

--- a/dockerfiles/Dockerfile.arc-runner
+++ b/dockerfiles/Dockerfile.arc-runner
@@ -26,7 +26,8 @@ USER root
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-      python3 python3-pip python3-venv; \
+      python3 python3-pip python3-venv \
+      xz-utils; \
     rm -rf /var/lib/apt/lists/*; \
     # just (used in 7+ CI jobs)
     curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" \


### PR DESCRIPTION
## Summary

Follow-up to #543. The `build-arc-runner` workflow failed on master because:

1. `tar xJ` (xz decompression) requires `xz-utils` which isn't in the `actions-runner` base image. Added to the apt-get install block.
2. The workflow wasn't triggering on PRs, making failures like this invisible until merge. Added `pull_request` trigger with `push: false` so the image builds (but doesn't publish) on PRs.

## Test plan

- [ ] `build-arc-runner` workflow passes on this PR
- [ ] Image builds and pushes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)