### PR TITLE
fix(ci): exclude build-arc-runner.yml from ci paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,7 @@ jobs:
               - 'kube/app/files/dashboards/**'
             ci:
               - '.github/workflows/**'
+              - '!.github/workflows/build-arc-runner.yml'
               - 'skaffold.yaml'
               - 'justfile'
 


### PR DESCRIPTION
## Summary

Changes to `build-arc-runner.yml` rebuild the runner image but don't affect application code, tests, or the Helm chart. Without this exclusion, those changes match `.github/workflows/**` → `ci = true` → all CI stages run unnecessarily.

One-line change to the `detect-changes` paths-filter.

## Test plan

- [ ] CI on this PR only triggers `detect-changes` (ci filter = false, all other jobs skipped)
- [ ] After merge: a PR that only modifies `build-arc-runner.yml` does not trigger full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)