### PR TITLE
fix(ci): install Rust toolchain in security-audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,10 +286,10 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
-      # GHA ubuntu-24.04 adds ~/.cargo/bin to PATH automatically; catthehacker ARC runners do not.
-      # Must run before taiki-e/install-action so installed binaries are in PATH for subsequent steps.
-      - name: Add Cargo to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-dependencies: 'false'
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@cargo-deny


### PR DESCRIPTION
## Summary

- Replaces the manual `Add Cargo to PATH` workaround with `setup-rust` in the `security-audit` job
- The catthehacker ARC runner image had `cargo` pre-installed; the new `actions-runner` base image does not, so `cargo deny check` was failing with `cargo: not found`
- Uses `cache-dependencies: false` since the job doesn't build the full workspace

## Context

Triaged from https://github.com/icook/tiny-congress/actions/runs/22795968569/job/66130559197

The `build-essential`/`pkg-config` fix (linker `cc not found` for all other Rust jobs) was pushed directly to master as `fcc5d9df`.

## Test plan

- [ ] CI passes on this PR — specifically Security & Dependency Audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)