### PR TITLE
fix(ci): isolate KinD clusters per run and add cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -901,6 +901,7 @@ jobs:
         run: |
           set -euo pipefail
           skaffold deploy -p "${SKAFFOLD_PROFILE}" --status-check=true \
+            --kube-context "kind-${KIND_CLUSTER_NAME}" \
             --build-artifacts "${{ steps.artifacts.outputs.file }}"
 
       - name: Build instrumented frontend for E2E tests

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -201,11 +201,9 @@ profiles:
               - "tc-ui-release:cache-main"
               - "tc-ui-release:cache"
     deploy:
-      # Explicitly target the KinD cluster context. Without this, Skaffold
-      # running inside an ARC runner pod (which has KUBERNETES_SERVICE_HOST
-      # set) can pick up the pod's in-cluster namespace ("arc-runners") as
-      # the default Helm namespace, causing install to fail in KinD.
-      kubeContext: kind-skaffold-ci
+      # For ARC runners with in-cluster KUBERNETES_SERVICE_HOST, we explicitly
+      # set namespace to prevent Skaffold from falling back to "arc-runners".
+      # kubeContext is set via --kube-context CLI flag by the workflow.
       helm:
         releases:
           - name: tc


### PR DESCRIPTION
## Summary

- Use unique cluster names (`skaffold-ci-{run_id}`) to prevent collisions on self-hosted runners with persistent Docker volumes
- Add cleanup step with `if: always()` to delete cluster after each job completes
- Enables parallel e2e-tests jobs without "node(s) already exist" errors

## Test plan

- [ ] Push to branch and verify CI passes
- [ ] Confirm no "node(s) already exist" errors on subsequent e2e-tests runs
- [ ] Verify cleanup step runs even on job failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)