### PR TITLE
[arc] feat(ci): pull E2E images from in-cluster Zot instead of GHCR on ARC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,9 +533,29 @@ jobs:
           # Always retag from branch-master (last successful master build)
           SOURCE="${{ steps.registries.outputs.images }}/${{ matrix.image }}:branch-master"
           echo "No source changes for ${{ matrix.image }} — retagging ${SOURCE} as ${{ github.sha }}"
-          docker buildx imagetools create \
+
+          # On ARC the remote BuildKit driver doesn't carry registry config,
+          # so imagetools defaults to HTTPS and fails against HTTP-only Zot.
+          # Create a short-lived local builder with Zot configured as HTTP.
+          # On ARC the remote BuildKit driver doesn't carry registry config,
+          # so imagetools defaults to HTTPS and fails against HTTP-only Zot.
+          # Create a short-lived local builder with Zot configured as HTTP.
+          BUILDER=()
+          if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
+            ZOT="zot.zot.svc.cluster.local:5000"
+            printf '[registry."%s"]\n  http = true\n  insecure = true\n' "$ZOT" \
+              > /tmp/buildkitd-zot.toml
+            docker buildx create --name zot-retag --driver docker-container \
+              --driver-opt network=host --config /tmp/buildkitd-zot.toml
+            BUILDER=(--builder zot-retag)
+          fi
+
+          docker buildx imagetools create "${BUILDER[@]}" \
             --tag "${{ steps.tags.outputs.sha_tag }}" \
             "${SOURCE}"
+
+          # Clean up the temporary builder if created
+          docker buildx rm zot-retag 2>/dev/null || true
 
       - name: Set build metadata
         if: steps.should-build.outputs.changed != 'false'


### PR DESCRIPTION
## Summary

- `build-images`: after pushing to GHCR, mirrors the built image manifests to in-cluster Zot (`zot.zot.svc.cluster.local:5000`) on ARC runners — manifest-only operation, layers already in Zot from the build cache
- `e2e-tests`: KinD cluster configured with `containerdConfigPatches` to trust Zot as an HTTP mirror; Skaffold artifacts file uses Zot as image source on ARC, GHCR on GHA
- GHCR imagePullSecret step skipped on ARC (Zot allows unauthenticated in-cluster access)

## Why

KinD currently pulls images from GHCR — slow external round-trip on every E2E run. With Zot in-cluster, image loading goes over the cluster network. No duplicate layer transfer: `imagetools create` copies only the manifest reference since layers are already present in Zot's storage backend from the build.

## No prerequisites

Zot already accepts unauthenticated reads from in-cluster clients (consistent with how build-images writes to it today without a login step).

## Test plan

- [ ] ARC E2E run: KinD pulls from Zot — check for `zot.zot.svc.cluster.local` in Skaffold output
- [ ] GHA E2E run: still pulls from GHCR — no regression
- [ ] Measure E2E job time before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)