### PR TITLE
chore(ci): optimize caching — save ~5-8 min per run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
   # ── Build WASM tc-crypto (shared artifact) ────────────────
   build-wasm:
     name: Build WASM
-    runs-on: ${{ needs.detect-changes.outputs.runner-medium }}
+    runs-on: ${{ needs.detect-changes.outputs.runner-small }}
     needs: [detect-changes]
     if: >-
       needs.detect-changes.outputs.ui == 'true' ||


### PR DESCRIPTION
## Summary

Four independent commits to `.github/workflows/ci.yml`, each targeting a distinct caching or deduplication opportunity:

| Commit | Change | Estimated savings |
|--------|--------|-------------------|
| 1 | Remove redundant Helm downloads from `lint-kube` and `e2e-tests` — already baked into ARC runner image | ~10–15s |
| 2 | Cache sqlx-cli binary in `sqlx-check` via `runs-on/cache@v4`, keyed to version 0.8.6 | ~3–5 min |
| 3 | Cache Skaffold binary (~100MB) in `e2e-tests` via `runs-on/cache@v4`, keyed to `.skaffold-version` | ~30–60s |
| 4 | Deduplicate WASM build — new `build-wasm` job compiles once and uploads artifact; `unit-tests` and `e2e-tests` both download it | ~2–3 min |

**Note:** hadolint/actionlint/shellcheck are kept as explicit installs (not removed in favor of baked image) to maintain version parity with GHA-hosted runners.

## Architecture notes

- `build-wasm` uses `if: ui || api || ci` (union of both consumer conditions) — guarantees the artifact exists whenever either `unit-tests` or `e2e-tests` runs. A skipped `build-wasm` produces `result == 'skipped'` which the existing `always() && !contains(needs.*.result, 'failure')` guard in `e2e-tests` handles correctly.
- `build-wasm` runs in parallel with `build-images` (~5 min), so it completes well before `e2e-tests` starts — no critical path regression.
- sqlx-cli cache key is pinned to `0.8.6` (not `hashFiles('Cargo.lock')`) to avoid busting on unrelated dependency updates. Comment in the file ties it to `service/Cargo.lock`.
- Skaffold cache key uses `runner.os + hashFiles('.skaffold-version')` for consistency with other cache keys.

## Test plan

- [ ] CI passes on this PR
- [ ] `sqlx-check` job shows cache hit on second run (check Actions step summary)
- [ ] `e2e-tests` job shows Skaffold cache hit on second run
- [ ] `build-wasm` job appears in the workflow run and both `unit-tests`/`e2e-tests` show "Download WASM artifact" instead of "Build WASM"

🤖 Generated with [Claude Code](https://claude.com/claude-code)