### PR TITLE
ci: consolidate ARC runner tiers to small and large only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,25 +346,29 @@ jobs:
             docker start "$CONTAINER_NAME"
           else
             echo "Creating new postgres container..."
+            # Use -p 5432 (no host port) so Docker assigns a random host port.
+            # This avoids port collisions when multiple workflow runs share the
+            # same DinD pod's network namespace.
             docker run -d --name "$CONTAINER_NAME" \
-              --network host \
+              -p 5432 \
               -e POSTGRES_USER=postgres \
               -e POSTGRES_PASSWORD=postgres \
               ${{ env.REGISTRY }}/postgres:${{ github.sha }}
           fi
 
-          # On ARC runners Docker runs on a remote DinD pod; postgres uses host network
-          # so it's directly accessible on the DinD service IP at port 5432.
-          # On GHA-hosted runners DOCKER_HOST is unset and postgres binds to localhost.
+          # Discover the mapped host port via docker port.
+          # On ARC runners DOCKER_HOST is set to the remote DinD TCP address;
+          # extract the hostname so we can reach the mapped port.
+          # On GHA-hosted runners DOCKER_HOST is unset and everything is local.
           if [ -n "${DOCKER_HOST:-}" ]; then
             DOCKER_HOSTNAME=$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:[0-9]*$||')
           else
             DOCKER_HOSTNAME="127.0.0.1"
           fi
 
-          PG_PORT="5432"
+          PG_PORT=$(docker port "$CONTAINER_NAME" 5432 | head -1 | sed 's/.*://')
 
-          # Wait for postgres to be ready
+          # Wait for postgres to be ready (docker exec avoids needing network access)
           for i in {1..30}; do
             if docker exec "$CONTAINER_NAME" pg_isready -U postgres; then
               echo "Postgres is ready"


### PR DESCRIPTION
## Summary

- Remove `nano` and `medium` runner tiers from CI
- All former `nano` jobs → `runner-small`
- All former `medium` jobs → `runner-small` (docs, codegen, vitest, sqlx snapshots)
- Remove `medium` from the `detect-changes` runner selection script
- Only two tiers remain: `small` and `large`

## Why

The homelab ARC cluster only deploys `arc-runner-small` and `arc-runner-large` scale sets. The missing `arc-runner-medium` was causing 4+ CI jobs to queue indefinitely whenever `USE_ARC_RUNNERS=true` — jobs targeting a runner that never existed.

**Jobs remapped:**
| Job | Was | Now |
|-----|-----|-----|
| Lint Kubernetes manifests | nano | small |
| Validate Grafana dashboards | nano | small |
| Build Storybook | nano | small |
| Build images (scan jobs) | nano | small |
| Build documentation | medium | small |
| Check codegen | medium | small |
| Unit tests (Vitest) | medium | small |
| Check SQLx snapshots | medium | small |

## Test plan

- [ ] CI passes on this PR with `ubuntu-latest` (USE_ARC_RUNNERS=false)
- [ ] Re-enable ARC with `[arc]` in a commit message and verify all jobs are picked up by `arc-runner-small` or `arc-runner-large`