### PR TITLE
fix(ci): pin kube-linter to v0.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           directory: kube/
           config: .kube-linter.yaml
-          version: "0.8.1"
+          version: "v0.8.1"
 
       # GHA ubuntu-24.04 pre-installs Helm; catthehacker ARC runners do not.
       # azure/setup-helm relies on GHA tool cache infrastructure absent on ARC runners.


### PR DESCRIPTION
## Summary

- Pin `stackrox/kube-linter-action` to version `0.8.1` — v0.8.2 was published 2026-03-09 with zero binary assets, breaking CI immediately
- One-line change; unpin when v0.8.2 assets ship upstream

## Test plan

- [ ] `lint-kube` job passes with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)