### PR TITLE
chore(ci): deploy-gitops depends on ci-gate instead of individual jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1065,11 +1065,9 @@ jobs:
   deploy-gitops:
     name: Update gitops image digests
     if: >-
-      always() &&
       github.event_name == 'push' && github.ref == 'refs/heads/master' &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
-    needs: [unit-tests, rust-coverage, e2e-tests, detect-changes]
+      needs.ci-gate.result == 'success'
+    needs: [ci-gate, detect-changes]
     runs-on: ${{ needs.detect-changes.outputs.runner-small }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- `deploy-gitops` now depends on `ci-gate` instead of enumerating `unit-tests`, `rust-coverage`, `e2e-tests` individually
- Replaces fragile `always() && !contains(failure/cancelled)` condition with clean `needs.ci-gate.result == 'success'`
- `ci-gate` already aggregates all required jobs, so this can't drift out of sync

## Test plan
- [ ] Verify `deploy-gitops` runs on master push when CI passes
- [ ] Verify `deploy-gitops` is skipped when any required job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)