### PR TITLE
feat(ci): bake GitHub Action tarballs into ARC runner image

### DIFF
--- a/.github/workflows/build-arc-runner.yml
+++ b/.github/workflows/build-arc-runner.yml
@@ -5,9 +5,11 @@ on:
     branches: [master]
     paths:
       - 'dockerfiles/Dockerfile.arc-runner'
+      - 'dockerfiles/cache-actions.sh'
   pull_request:
     paths:
       - 'dockerfiles/Dockerfile.arc-runner'
+      - 'dockerfiles/cache-actions.sh'
   workflow_dispatch:
   schedule:
     # Weekly rebuild to pick up base image security patches (Monday 6am UTC)
@@ -58,3 +60,8 @@ jobs:
             ghcr.io/${{ github.repository }}/arc-runner:${{ steps.versions.outputs.date }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/arc-runner:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/arc-runner:cache,mode=max
+          # Pass GITHUB_TOKEN as a BuildKit secret so cache-actions.sh can call
+          # the GitHub API without rate limiting. The token never lands in the
+          # image layer — it's only available during the RUN step that uses it.
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/dockerfiles/Dockerfile.arc-runner
+++ b/dockerfiles/Dockerfile.arc-runner
@@ -60,6 +60,19 @@ RUN set -eux; \
     shellcheck --version && helm version --short && python3 --version && \
     yq --version && kubectl version --client
 
+# Pre-cache GitHub Action archives so runners skip the per-job download.
+# The runner checks ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE for
+# {owner}-{repo}-{sha}.tar.gz before fetching from GitHub.
+# GITHUB_TOKEN is injected at build time via BuildKit secret (never in image).
+ENV ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=/opt/actions-archive-cache
+COPY cache-actions.sh /tmp/cache-actions.sh
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) \
+    CACHE_DIR="${ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE}" \
+    bash /tmp/cache-actions.sh && \
+    chmod -R a+r "${ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE}" && \
+    rm /tmp/cache-actions.sh
+
 # Ensure ~/.cargo/bin is on PATH so taiki-e/install-action binaries are
 # immediately usable without a separate "Add Cargo to PATH" step.
 ENV PATH="/home/runner/.cargo/bin:${PATH}"

--- a/dockerfiles/cache-actions.sh
+++ b/dockerfiles/cache-actions.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Pre-download GitHub Action archives into ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE.
+#
+# The runner checks this directory for {owner}-{repo}-{sha}.tar.gz before
+# downloading from GitHub, so baking these in eliminates per-job download
+# overhead for all frequently-used actions.
+#
+# Usage (in Dockerfile via BuildKit secret):
+#   RUN --mount=type=secret,id=github_token \
+#       GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+#       CACHE_DIR=/opt/actions-archive-cache \
+#       /tmp/cache-actions.sh
+set -euo pipefail
+
+CACHE_DIR="${CACHE_DIR:?CACHE_DIR must be set}"
+mkdir -p "$CACHE_DIR"
+
+# All action refs used across .github/workflows/ (on ARC runners).
+# taiki-e/install-action uses per-tool tags as the action ref.
+ACTIONS=(
+  "actions/checkout@v4"
+  "actions/checkout@v6"
+  "actions/download-artifact@v7"
+  "actions/github-script@v7"
+  "actions/setup-node@v6"
+  "actions/setup-python@v5"
+  "actions/upload-artifact@v4"
+  "actions/upload-artifact@v6"
+  "aquasecurity/trivy-action@0.34.0"
+  "docker/build-push-action@v6"
+  "docker/login-action@v3"
+  "docker/setup-buildx-action@v3"
+  "dorny/paths-filter@v3"
+  "dtolnay/rust-toolchain@stable"
+  "EnricoMi/publish-unit-test-result-action@v2"
+  "extractions/setup-just@v3"
+  "gitleaks/gitleaks-action@v2"
+  "helm/kind-action@v1.13.0"
+  "marocchino/sticky-pull-request-comment@v2"
+  "runs-on/cache@v4"
+  "stackrox/kube-linter-action@v1"
+  "Swatinem/rust-cache@v2"
+  "taiki-e/install-action@cargo-deny"
+  "taiki-e/install-action@cargo-llvm-cov"
+  "taiki-e/install-action@cargo-machete"
+  "taiki-e/install-action@v2"
+  "taiki-e/install-action@wasm-pack"
+)
+
+AUTH_ARGS=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  AUTH_ARGS=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+cache_action() {
+  local spec="$1"
+  local repo="${spec%@*}"
+  local ref="${spec#*@}"
+  local owner="${repo%%/*}"
+  local name="${repo#*/}"
+
+  # Resolve the ref (tag or branch) to the underlying commit SHA.
+  # The /commits/{ref} endpoint handles both annotated and lightweight tags.
+  local sha
+  sha=$(curl -fsSL "${AUTH_ARGS[@]}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${repo}/commits/${ref}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'])")
+
+  local outfile="${CACHE_DIR}/${owner}-${name}-${sha}.tar.gz"
+  if [[ -f "$outfile" ]]; then
+    printf '  hit  %-45s %s\n' "${spec}" "${sha:0:12}"
+    return
+  fi
+
+  printf '  fetch %-45s %s\n' "${spec}" "${sha:0:12}"
+  # Download tarball via API (follows redirect to codeload.github.com).
+  curl -fsSL -L "${AUTH_ARGS[@]}" \
+    "https://api.github.com/repos/${repo}/tarball/${sha}" \
+    -o "$outfile"
+}
+
+echo "Pre-caching ${#ACTIONS[@]} GitHub Actions into ${CACHE_DIR} ..."
+for action in "${ACTIONS[@]}"; do
+  cache_action "$action"
+done
+echo "Done. $(du -sh "$CACHE_DIR" | cut -f1) total."


### PR DESCRIPTION
## Summary

- Adds `dockerfiles/cache-actions.sh` — resolves 27 action refs to commit SHAs via the GitHub API and downloads each as `{owner}-{repo}-{sha}.tar.gz`
- Sets `ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=/opt/actions-archive-cache` in the runner image so the runner checks the baked-in archives before downloading
- Passes `GITHUB_TOKEN` as a BuildKit secret during image build (never lands in an image layer)
- Adds `cache-actions.sh` to the `build-arc-runner.yml` path trigger so the image rebuilds when the action list changes

The runner resolves floating tags (`@v6`, `@stable`, etc.) to a SHA at job startup and looks for `{owner}-{repo}-{sha}.tar.gz` in the cache dir. Since we already do weekly rebuilds, the baked-in SHAs stay fresh within a week of any upstream tag move. Cache misses fall back to a live download transparently.

## Test plan

- [ ] Build job completes without errors (cache-actions.sh runs cleanly with API access)
- [ ] Image size increase is reasonable (~100–200 MB for 27 tarballs)
- [ ] ARC runner job logs no longer show "Download action repository" steps for cached actions
- [ ] Floating-tag fallback: confirm a cache miss (e.g. after a tag move) still runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)