### PR TITLE
fix(ci): cache Node.js toolchain and node_modules on ARC runners

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -32,14 +32,17 @@ runs:
         printf '#!/bin/sh\nexec node "%s" "$@"\n' "$YARN_BIN" | sudo tee /usr/local/bin/yarn > /dev/null
         sudo chmod +x /usr/local/bin/yarn
 
-    - name: Get yarn cache directory
-      id: yarn-cache-dir
-      shell: bash
-      run: echo "dir=$(cd web && yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-
-    - name: Cache yarn dependencies
+    - name: Cache node_modules
+      id: nm-cache
       uses: runs-on/cache@v4
       with:
-        path: ${{ steps.yarn-cache-dir.outputs.dir }}
-        key: yarn-${{ runner.os }}-${{ hashFiles('web/yarn.lock') }}
-        restore-keys: yarn-${{ runner.os }}-
+        path: web/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('web/yarn.lock') }}
+        save-always: true
+
+    - name: Install frontend dependencies
+      if: steps.nm-cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: web
+      run: yarn install --immutable
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,9 +224,6 @@ jobs:
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
 
-      - name: Install dependencies
-        run: cd web && yarn install --immutable
-
       - name: Install just
         uses: extractions/setup-just@v3
 
@@ -304,9 +301,6 @@ jobs:
 
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
-
-      - name: Install frontend dependencies
-        run: cd web && yarn install --immutable
 
       - name: Run dependency audit
         run: just audit-deps
@@ -694,10 +688,6 @@ jobs:
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
 
-      - name: Install web dependencies
-        working-directory: web
-        run: yarn install --immutable
-
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-rust
         with:
@@ -849,10 +839,6 @@ jobs:
 
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
-
-      - name: Install web dependencies
-        working-directory: web
-        run: yarn install --immutable
 
       - name: Cache Playwright browsers
         uses: runs-on/cache@v4
@@ -1192,10 +1178,6 @@ jobs:
 
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
-
-      - name: Install web dependencies
-        working-directory: web
-        run: yarn install --immutable
 
       # GHA ubuntu-24.04 pre-installs gettext (envsubst); catthehacker ARC runners do not.
       - name: Install envsubst


### PR DESCRIPTION
## Summary

- Cache `${{ runner.tool_cache }}` via `runs-on/cache` before `actions/setup-node` so Node.js binary is not re-downloaded on every ARC runner job
- Disable `setup-node@v6`'s built-in `package-manager-cache` (default `true` in v6) which conflicted with our explicit `runs-on/cache` yarn management
- Replace global yarn cache with direct `web/node_modules` cache keyed on `yarn.lock`; install step is skipped entirely on cache hit
- Remove 5 duplicate `yarn install --immutable` calls from job definitions — `setup-web` composite action now owns the full install lifecycle

## Why

ARC self-hosted runners have no pre-installed tool cache, so `setup-node` fetched Node.js from GitHub on every run. The global yarn cache required yarn to re-link all packages even on a hit. Caching `node_modules` directly and skipping install on hit is significantly faster.

Both cache steps use `save-always: true` so the cache is populated even when a later job step fails.

## Test plan

- [ ] First run after merge will cold-populate both caches (Node toolchain + node_modules)
- [ ] Subsequent runs should skip "Install frontend dependencies" step (cache-hit = true)
- [ ] No job should run `yarn install` — verify no such step appears in job logs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)