### PR TITLE
fix(ci): detect ARC runners from PR title, emit named check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,9 @@ jobs:
   detect-changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     outputs:
       postgres: ${{ steps.filter.outputs.postgres }}
       api: ${{ steps.filter.outputs.api }}
@@ -425,7 +428,6 @@ jobs:
       # Toggle: gh variable set USE_ARC_RUNNERS --body "false" --repo icook/tiny-congress
       runner-nano: ${{ steps.runner.outputs.small }}
       runner-small: ${{ steps.runner.outputs.small }}
-      runner-medium: ${{ steps.runner.outputs.medium }}
       runner-large: ${{ steps.runner.outputs.large }}
       # 'true' when running on ARC self-hosted runners, 'false' for GHA-hosted.
       use-arc: ${{ steps.runner.outputs.use-arc }}
@@ -433,18 +435,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Select runner
         id: runner
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Three ways to enable ARC runners (in priority order):
-          #   1. Commit message contains [arc]  — per-commit, good for iteration
-          #   2. Repo var USE_ARC_RUNNERS=true   — global override
-          # Default: ubuntu-latest (GHA hosted)
-          # For pull_request events checkout creates a synthetic merge commit so
-          # git log HEAD shows the merge message, not the branch commit. Fetch
-          # the actual head SHA (depth=1) and read its message directly.
-          head_sha="${{ github.event.pull_request.head.sha || github.sha }}"
-          git fetch origin "$head_sha" --depth=1 2>/dev/null || true
-          commit_msg=$(git log -1 --format=%s "$head_sha" 2>/dev/null || git log -1 --format=%s HEAD)
-          if echo "$commit_msg" | grep -qF '[arc]' || [ "${{ vars.USE_ARC_RUNNERS }}" = "true" ]; then
+          # Two ways to enable ARC runners:
+          #   1. PR title contains [arc]         — sticky for the whole PR lifecycle
+          #   2. Repo var USE_ARC_RUNNERS=true   — global default
+          # Fallback: ubuntu-latest (GHA hosted)
+          if echo "$PR_TITLE" | grep -qF '[arc]' || [ "${{ vars.USE_ARC_RUNNERS }}" = "true" ]; then
             {
               echo "use-arc=true"
               echo "small=arc-runner-small"
@@ -457,13 +455,27 @@ jobs:
               echo "large=ubuntu-latest"
             } >> "$GITHUB_OUTPUT"
           fi
-      - name: Print runner mode
-        run: |
-          if [ "${{ steps.runner.outputs.use-arc }}" = "true" ]; then
-            echo "::notice title=Runner Mode::🚀 ARC SELF-HOSTED RUNNERS"
-          else
-            echo "::notice title=Runner Mode::☁️  GHA-HOSTED RUNNERS (ubuntu-latest)"
-          fi
+      - name: Set CI runners check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const useArc = '${{ steps.runner.outputs.use-arc }}' === 'true';
+            // Use PR head SHA (not merge commit) so the check appears on the PR
+            const sha = context.payload.pull_request?.head?.sha || context.sha;
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: useArc ? 'CI runners: ARC self-hosted' : 'CI runners: GHA hosted',
+              head_sha: sha,
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: useArc ? '🚀 ARC self-hosted runners' : '☁️ GHA hosted runners (ubuntu-latest)',
+                summary: useArc
+                  ? 'Triggered by `[arc]` in PR title or `USE_ARC_RUNNERS=true`.'
+                  : 'Add `[arc]` to the PR title or set `USE_ARC_RUNNERS=true` to switch to ARC.',
+              },
+            });
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Summary

- Switch ARC runner detection from per-commit `[arc]` tag to PR title — sticky for the whole PR lifecycle and avoids the synthetic merge commit problem
- Pass `PR_TITLE` via env var to avoid GitHub's script injection warning
- Replace `::notice` with a Checks API call so runner tier appears as a named check ("CI runners: ARC self-hosted" / "CI runners: GHA hosted") in the PR checks list
- Add `checks: write` permission required by the Checks API
- Drop unused `runner-medium` output (no jobs referenced it)

## Test plan

- [ ] Open a PR without `[arc]` in the title — check named "CI runners: GHA hosted" appears
- [ ] Add `[arc]` to PR title — check named "CI runners: ARC self-hosted" appears
- [ ] Verify no script injection warning in runner selection step logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)