### PR TITLE
fix(ci): replace deprecated save-always with restore/save split

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -6,12 +6,11 @@ runs:
   steps:
     # Cache Node.js binary — self-hosted runners have no pre-installed tool
     # cache, so setup-node downloads it from GitHub on every run without this.
-    - name: Cache Node.js toolchain
-      uses: runs-on/cache@v4
+    - name: Restore Node.js toolchain cache
+      uses: runs-on/cache/restore@v4
       with:
         path: ${{ runner.tool_cache }}
         key: node-toolcache-${{ runner.os }}-${{ hashFiles('web/.nvmrc') }}
-        save-always: true
 
     - name: Set up Node
       uses: actions/setup-node@v6
@@ -32,17 +31,30 @@ runs:
         printf '#!/bin/sh\nexec node "%s" "$@"\n' "$YARN_BIN" | sudo tee /usr/local/bin/yarn > /dev/null
         sudo chmod +x /usr/local/bin/yarn
 
-    - name: Cache node_modules
+    - name: Restore node_modules cache
       id: nm-cache
-      uses: runs-on/cache@v4
+      uses: runs-on/cache/restore@v4
       with:
         path: web/node_modules
         key: node-modules-${{ runner.os }}-${{ hashFiles('web/yarn.lock') }}
-        save-always: true
 
     - name: Install frontend dependencies
       if: steps.nm-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: web
       run: yarn install --immutable
+
+    - name: Save Node.js toolchain cache
+      if: always()
+      uses: runs-on/cache/save@v4
+      with:
+        path: ${{ runner.tool_cache }}
+        key: node-toolcache-${{ runner.os }}-${{ hashFiles('web/.nvmrc') }}
+
+    - name: Save node_modules cache
+      if: always()
+      uses: runs-on/cache/save@v4
+      with:
+        path: web/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('web/yarn.lock') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -893,16 +893,22 @@ jobs:
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
 
-      - name: Cache Playwright browsers
-        uses: runs-on/cache@v4
+      - name: Restore Playwright browser cache
+        uses: runs-on/cache/restore@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-chromium-${{ hashFiles('web/yarn.lock') }}
-          save-always: true
 
       - name: Install Playwright browsers
         working-directory: web
         run: yarn playwright install --with-deps chromium
+
+      - name: Save Playwright browser cache
+        if: always()
+        uses: runs-on/cache/save@v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-chromium-${{ hashFiles('web/yarn.lock') }}
 
       - name: Download WASM artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Replace deprecated `save-always: true` on `runs-on/cache@v4` with explicit `runs-on/cache/restore@v4` + `runs-on/cache/save@v4` (`if: always()`) steps
- Applies to Node.js toolchain cache, node_modules cache (setup-web action), and Playwright browser cache (ci.yml)
- Preserves save-on-failure behavior without the deprecation warning

## Test plan
- [ ] CI passes without `save-always` deprecation warnings
- [ ] Cache restore/save still works on ARC runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)