### PR TITLE
fix(ci): remove redundant yarn install after setup-web action

### DIFF
--- a/.github/workflows/refine.yml
+++ b/.github/workflows/refine.yml
@@ -77,9 +77,6 @@ jobs:
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
 
-      - name: Install frontend dependencies
-        run: cd web && yarn install --immutable
-
       # ── Docker (for testcontainers in backend tests) ──
 
       - name: Build test postgres image

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -96,10 +96,6 @@ jobs:
       - name: Setup web toolchain
         uses: ./.github/actions/setup-web
 
-      - name: Install dependencies
-        working-directory: web
-        run: yarn install --immutable
-
       - name: Install Playwright browsers
         working-directory: web
         run: yarn playwright install --with-deps


### PR DESCRIPTION
## Summary

- `setup-web` action already installs frontend deps (with `node_modules` cache); the bare `yarn install --immutable` steps in `refine.yml` and `smoke-test.yml` were redundant
- Removes 2 steps that bypassed the cache and re-downloaded all packages on every run

## Test plan
- [ ] Verify smoke-test and refine workflows still pass after this change