### PR TITLE
ci: bake Playwright Chromium deps into ARC runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,6 +894,7 @@ jobs:
         uses: ./.github/actions/setup-web
 
       - name: Restore Playwright browser cache
+        id: playwright-cache
         uses: runs-on/cache/restore@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
@@ -901,7 +902,16 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: web
-        run: yarn playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
+            # ARC runner: deps pre-installed in image, binary from cache — nothing to do.
+            yarn playwright install chromium
+          elif [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            # GHA hosted: binary from cache, but still need OS deps from apt.
+            yarn playwright install-deps chromium
+          else
+            yarn playwright install --with-deps chromium
+          fi
 
       - name: Save Playwright browser cache
         if: always()

--- a/dockerfiles/Dockerfile.arc-runner
+++ b/dockerfiles/Dockerfile.arc-runner
@@ -22,6 +22,8 @@ ARG SHELLCHECK_VERSION=v0.10.0
 ARG HELM_VERSION=v3.17.3
 ARG YQ_VERSION=v4.44.3
 ARG KUBECTL_VERSION=v1.32.0
+# Keep in sync with @playwright/test version in web/yarn.lock
+ARG PLAYWRIGHT_VERSION=1.57.0
 
 USER root
 
@@ -59,6 +61,20 @@ RUN set -eux; \
     just --version && hadolint --version && actionlint --version && \
     shellcheck --version && helm version --short && python3 --version && \
     yq --version && kubectl version --client
+
+# Pre-install Playwright Chromium OS-level dependencies so e2e-tests jobs skip
+# the apt-get step entirely when the browser binary is restored from cache.
+# Node is installed temporarily to drive `playwright install-deps`, then removed.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends nodejs npm; \
+    npm install -g "playwright@${PLAYWRIGHT_VERSION}"; \
+    playwright install-deps chromium; \
+    # Remove nodejs/npm but NOT autoremove — autoremove would strip chromium deps
+    # that were pulled in as transitive deps of nodejs.
+    apt-get purge -y nodejs npm; \
+    npm uninstall -g playwright 2>/dev/null || true; \
+    rm -rf /root/.npm /var/lib/apt/lists/*
 
 # Pre-cache GitHub Action archives so runners skip the per-job download.
 # The runner checks ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE for


### PR DESCRIPTION
## Summary

- Pre-installs Playwright Chromium OS-level dependencies in `Dockerfile.arc-runner` so e2e-tests jobs skip `apt-get` entirely on ARC self-hosted runners when the browser binary is restored from cache
- Adds `id: playwright-cache` to the restore step to expose cache-hit output
- Branches install behavior: ARC + cache hit → binary-only install (no apt); GHA + cache hit → `install-deps` only (apt, no download); cache miss → `--with-deps` as before

## Test plan

- [ ] ARC runner image rebuilds successfully (`build-arc-runner.yml` triggers on Dockerfile change)
- [ ] E2E tests pass on ARC runners (self-hosted path exercises the no-apt branch)
- [ ] E2E tests pass on GHA-hosted runners if tested

## Follow-up

If this passes: refactor `PLAYWRIGHT_VERSION` to a single source of truth (derive from `web/yarn.lock` at image build time rather than a manually-synced ARG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)