### PR TITLE
fix(ci): use restore/save split for Skaffold binary cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -922,7 +922,7 @@ jobs:
           fi
 
       - name: Save Playwright browser cache
-        if: always()
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: runs-on/cache/save@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}


### PR DESCRIPTION
## Summary

- Switches Skaffold binary cache from `runs-on/cache@v4` to the restore/save split pattern (`runs-on/cache/restore@v4` + `runs-on/cache/save@v4` with `if: always()`)
- Matches the existing pattern used for the Playwright browser cache
- Binary is now persisted even when the job fails after a cache miss

## Test plan
- [ ] CI passes on ARC runners