### PR TITLE
ci(arc-runner): auto-update gitops digest after image build

### DIFF
--- a/.github/workflows/build-arc-runner.yml
+++ b/.github/workflows/build-arc-runner.yml
@@ -121,8 +121,7 @@ jobs:
             echo "No digest changes detected"
             exit 0
           fi
-          git commit -m "chore(arc-runner): update image digest
-
-arc-runner: ${NEW_DIGEST}
-Source: ${SHORT_SHA:0:7} (tiny-congress)"
+          MSG=$(printf 'chore(arc-runner): update image digest\n\narc-runner: %s\nSource: %s (tiny-congress)' \
+            "${NEW_DIGEST}" "${SHORT_SHA:0:7}")
+          git commit -m "$MSG"
           git push origin main


### PR DESCRIPTION
## Summary

- Adds a `deploy-gitops` job to `build-arc-runner.yml` that runs after every successful image push (master, schedule, workflow_dispatch — not PRs)
- Captures the image digest from `build-push-action`'s `digest` output
- Checks out `icook/homelab-gitops` via `GITOPS_DEPLOY_KEY` (same secret used by `ci.yml`)
- Updates both `image` fields in `clusters/sauce/platform/arc/runners/base/helmrelease.yaml` (runner container + init-dind-externals) to `arc-runner:latest@<new-digest>`
- Skips the commit if the digest hasn't changed (idempotent on re-runs)

Follows the exact same pattern as the existing `deploy-gitops` job in `ci.yml` for app images.

## Test plan

- [ ] `build-arc-runner.yml` completes without error on this PR (build-only, no push, no gitops update)
- [ ] After merge, confirm the `deploy-gitops` job runs and commits a digest update to `homelab-gitops`
- [ ] Confirm Flux reconciles and ARC runner pods restart with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)