### PR TITLE
ci(arc-runner): note Playwright deps in image comment

### DIFF
--- a/dockerfiles/Dockerfile.arc-runner
+++ b/dockerfiles/Dockerfile.arc-runner
@@ -2,6 +2,7 @@
 #
 # Based on the official actions-runner image so the GitHub Actions runner binary
 # is baked in — no init container needed to copy it at pod startup.
+# Includes Playwright Chromium OS-level dependencies for e2e-test jobs.
 #
 # Pre-installs small, stable CLI tools that are used across many CI jobs.
 # Heavy toolchains (Rust, Node) are excluded — they are cached effectively by


### PR DESCRIPTION
## Summary

- Adds a one-line comment to `Dockerfile.arc-runner` noting the baked-in Playwright deps
- Primary purpose: trigger `build-arc-runner.yml` on merge to push a fresh image and exercise the gitops auto-update job from #580

## Test plan

- [ ] `build-arc-runner.yml` build job passes on this PR (build-only, no push)
- [ ] After merge: `deploy-gitops` job in `build-arc-runner.yml` runs and commits a new digest to `homelab-gitops`
- [ ] ARC runner pods restart with updated image

🤖 Generated with [Claude Code](https://claude.com/claude-code)