### PR TITLE
docs: document codegen requirement for SimpleObject/ToSchema types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ When a generated file needs changes, edit the source and run the generator. The 
 - Adding a frontend runtime config value without wiring both layers. A new `window.__TC_ENV__` field requires: (1) `web/src/config.ts` (interface + getter), (2) `kube/app/templates/deployment.yaml` (Helm value → container env var). The entrypoint auto-discovers `TC_*`/`VITE_*` env vars — no script changes needed. Missing the Helm layer means the value is silently empty in production.
 - Forgetting to run `just lint-static` before committing changes to Dockerfiles, GitHub Actions workflows, or shell scripts. `just lint` only covers Rust and TypeScript — static analysis (hadolint, actionlint, shellcheck) catches a different class of issues.
 - **Migration number conflicts on long-lived branches.** If another PR lands a migration while your branch is open, your migration number may collide. Always run `ls service/migrations/*.sql | sort -V | tail -1` before finalizing a migration to confirm your number is still the next available. Rebase onto master and rename your file if there's a collision.
+- **Forgetting `just codegen` after changing documented types.** Types annotated with `SimpleObject` (async-graphql) or `ToSchema` (utoipa) export their doc comments into `web/schema.graphql` and `web/openapi.json`. Changing doc comments on these types requires running `just codegen` and committing the regenerated files. CI checks for staleness but `just lint` and `just test` do not — the codegen step compiles and runs Rust binaries, so it's intentionally separate.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Adds a "Common Mistakes" entry to CLAUDE.md noting that changes to doc comments on types with `SimpleObject` or `ToSchema` derives require running `just codegen` and committing the regenerated schema files.
- CI catches staleness but `just lint` and `just test` do not — this documents the gap and explains why (codegen compiles and runs Rust binaries, so it's intentionally separate from lint).

Discovered during PR #585 where adding doc comments to `BuildInfo` fields caused a CI codegen failure.

## Test plan
- [ ] Docs-only change — no code affected
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)