### PR TITLE
fix(ci): deduplicate gitleaks + fix broken telemetry action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Full history for gitleaks
 
       - uses: ./.github/actions/collect-telemetry
 
@@ -54,12 +52,6 @@ jobs:
       - name: Lint backend
         if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ci == 'true'
         run: just lint-backend
-
-      # gitleaks GitHub Action provides richer integration than the CLI
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ── Codegen check ──
       - name: Install frontend dependencies


### PR DESCRIPTION
## Summary
- **Duplicate gitleaks:** gitleaks ran in both `backend-checks` and `security-audit` jobs, causing a 409 Conflict on SARIF artifact upload during re-runs. Removed the duplicate from `backend-checks`; `security-audit` is the correct home.
- **Broken telemetry in scan-images:** `scan-images` used `catchpoint/workflow-telemetry-action@v2` directly (which is broken), instead of the pinned `whywaita` fork used by the composite `collect-telemetry` action. Swapped to the same pinned SHA. (This job runs before checkout, so using the composite local action isn't possible.)

Closes #616

## Test plan
- [ ] CI passes on this PR
- [ ] Re-run the workflow to confirm no gitleaks artifact collision
- [ ] `scan-images` job telemetry step no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)