### PR TITLE
docs: trust architecture ADR series (017-021)

### DIFF
--- a/docs/decisions/017-two-layer-trust-architecture.md
+++ b/docs/decisions/017-two-layer-trust-architecture.md
@@ -26,7 +26,7 @@ The trust system is split into two layers with distinct responsibilities:
 - All humans are welcome, even untrustworthy ones. An untrustworthy human has poor graph position (high distance, low diversity), which limits their scope of impact — but they are never expelled from the platform for being untrustworthy.
 - The trust engine computes graph metrics (distance, diversity, endorsement budget) and publishes them. It does not make access decisions.
 
-**Platform trust governs:** endorsement slot count, daily action budget, and participation in the identity/trust network itself.
+**Platform trust governs:** endorsement slot count, daily action budget, and participation in the identity/trust network itself. (Slot and budget specifics are defined in ADR-020 and ADR-021, both currently Proposed.)
 
 ### Layer 2: Communication Permission (Rooms)
 
@@ -39,7 +39,7 @@ The trust system is split into two layers with distinct responsibilities:
 
 TinyCongress cannot know what a room thinks. The platform provides the identity infrastructure; rooms make their own judgments.
 
-**Room admission is immediate.** When a user's trust graph position changes (e.g., after a new handshake), room eligibility updates in real-time. This contrasts with the trust engine's batch cadence (see ADR-021) — the graph recomputes on a schedule, but rooms evaluate the latest snapshot immediately.
+**Room admission evaluates immediately against the latest snapshot.** When a daily batch reconciliation produces new trust scores (see ADR-021), room eligibility checks reflect those scores immediately — there is no additional delay between score publication and room access.
 
 ### Architectural boundary
 
@@ -89,6 +89,7 @@ The Room Service should be a separate service boundary, analogous to how the Ver
 - Rejected because it duplicates Sybil resistance work across every room and makes cross-room identity impossible.
 
 ## References
+- [ADR-008: Account-based verifiers](008-account-based-verifiers.md) — verifier endorsements predate the two-layer split; reframing pending
 - [ADR-015: Identity model](015-identity-model.md) — the cryptographic identity layer this builds on
 - [ADR-021: Batch reconciliation](021-batch-reconciliation.md) — the cadence at which platform trust updates
 - TRD §3 (Trust Engine) and §7 (MVP Scope) — original design context

--- a/docs/decisions/018-handshake-protocol.md
+++ b/docs/decisions/018-handshake-protocol.md
@@ -52,7 +52,7 @@ Trust edges are stored in `reputation__endorsements` with the following relevant
 | `topic` | Edge topic — trust graph traversal uses `"trust"` topic |
 | `weight` | Edge weight in (0.0, 1.0], determined by handshake context |
 | `attestation` | JSONB metadata: method, relationship context, confidence |
-| `influence_staked` | Amount of endorser's influence locked on this edge |
+| `influence_staked` | Amount of endorser's influence locked on this edge (legacy — ADR-020 replaces continuous influence with discrete endorsement slots) |
 | `revoked_at` | Non-null if the endorser revoked this edge |
 
 Edges are directed: Alice endorsing Bob does not imply Bob endorsing Alice. Mutual trust requires two separate handshakes.
@@ -115,6 +115,7 @@ The invite is single-use. The low weight ensures referral-only paths are long in
 - Rejected because it conflates "I vouch for you" with "you vouch for me." A QR scan proves Alice showed up, but Bob might have been coerced. Asymmetric edges preserve the distinction.
 
 ## References
+- [ADR-008: Account-based verifiers](008-account-based-verifiers.md) — verifier endorsements write to the same `reputation__endorsements` table
 - [ADR-015: Identity model](015-identity-model.md) — the cryptographic keys used to sign handshake tokens
 - [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — handshakes serve the platform trust layer
 - TRD §2 (Identity & Handshake Protocol) — original specification

--- a/docs/decisions/019-trust-engine-computation.md
+++ b/docs/decisions/019-trust-engine-computation.md
@@ -136,8 +136,10 @@ A placeholder exists for eigenvector centrality as a global (non-anchor-relative
 - Rejected for MVP due to computational cost (max-flow is O(V * E^2) in the general case). The distinct-endorser approximation provides adequate Sybil resistance at demo scale.
 
 ## References
+- [ADR-008: Account-based verifiers](008-account-based-verifiers.md) — verifier endorsements populate the same table the CTE traverses
 - [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — the trust engine serves the platform trust layer
 - [ADR-018: Handshake protocol](018-handshake-protocol.md) — how edges are created and weighted
+- [ADR-020: Reputation scarcity](020-reputation-scarcity.md) — trust scores may influence slot allocation
 - [ADR-021: Batch reconciliation](021-batch-reconciliation.md) — when scores are recomputed
 - `service/src/trust/engine.rs` — `compute_distances_from`, `compute_diversity_from`, `recompute_from_anchor`
 - `service/src/trust/repo/scores.rs` — `upsert_score`, `get_score`, `get_all_scores`

--- a/docs/decisions/020-reputation-scarcity.md
+++ b/docs/decisions/020-reputation-scarcity.md
@@ -29,6 +29,8 @@ When all slots are occupied, the user must revoke an existing endorsement before
 
 Platform trust level (computed from the user's own graph position) may increase the slot count over time. A well-established user with high diversity and long tenure might earn additional slots. The mechanism for this is not yet defined and will be calibrated from real usage data.
 
+**Platform/verifier accounts are exempt from slot limits.** Accounts designated as platform verifiers (see ADR-008) issue endorsements as infrastructure, not as peer trust signals. These accounts have effectively unlimited endorsement capacity. This exemption is necessary for bootstrapping — the initial verifier must be able to onboard the first cohort of users without exhausting a personal slot budget. Long-term, the system's credibility depends on users graduating from platform-issued endorsements to peer-verified handshakes.
+
 ### Renewable daily action budget
 
 Separate from endorsement slots, each user has a daily **action budget** — a renewable resource that limits how many trust actions they can perform per reconciliation cycle (see ADR-021).
@@ -98,6 +100,7 @@ Denouncements are recorded but **do not currently affect trust graph traversal**
 ## References
 - [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — slots and budgets are platform trust concepts
 - [ADR-018: Handshake protocol](018-handshake-protocol.md) — endorsements are the edges that consume slots
+- [ADR-019: Trust engine computation](019-trust-engine-computation.md) — scores that may drive dynamic slot allocation
 - [ADR-021: Batch reconciliation](021-batch-reconciliation.md) — action budgets regenerate each reconciliation cycle
 - [GitHub #624: Trust graph red/blue simulation](https://github.com/icook/tiny-congress/issues/624) — will inform sponsorship risk design
 - TRD §4 (Reputation Scarcity Model) — original slot-based design

--- a/docs/decisions/021-batch-reconciliation.md
+++ b/docs/decisions/021-batch-reconciliation.md
@@ -91,6 +91,7 @@ The cadence may be adjusted (12h, 48h) based on observed user behavior, but the 
 - Rejected. If a revocation is urgent, the room layer can respond to a "pending revocation" signal without the trust graph recomputing.
 
 ## References
+- [ADR-003: pgmq job queue](003-pgmq-job-queue.md) — queue infrastructure for action storage and batch triggering
 - [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — the layer separation this cadence applies to
 - [ADR-020: Reputation scarcity](020-reputation-scarcity.md) — the action budgets consumed during each batch
 - TRD §3.4 (Materialization Strategy) — original discussion of when to recompute


### PR DESCRIPTION
## Summary

Captures trust system design decisions from the TRD and ongoing design refinements as permanent ADRs in the repo. The TRD (`tiny-congress-trd.docx`) was never committed as a tracked document — these ADRs extract and formalize the durable architectural decisions.

- **ADR-017: Two-layer trust architecture** — Platform trust (humanity/Sybil resistance) vs communication permission (room-level gating). Rooms are independent relying parties that consume trust graph signals. *New decision from design session.*
- **ADR-018: Handshake protocol** — Handshake contexts (Physical QR, Synchronous Remote, Social Referral), weight semantics, zero-PII invariant. *Documents existing design.*
- **ADR-019: Trust engine computation** — Recursive CTE for distance, path diversity approximation, composite trust score, materialization. *Documents existing implementation.*
- **ADR-020: Reputation scarcity** — Endorsement slots (discrete, not continuous influence), renewable daily action budgets, sponsorship risk as a principle (mechanism TBD). *Proposed — diverges from current backend.*
- **ADR-021: Batch reconciliation** — 24-hour action cadence. Actions are declared intentions, reconciled daily. Room admission remains immediate. *Proposed — diverges from current backend.*

### Implementation notes

ADRs 017, 018, 019 are **Accepted** — they describe current architecture or formalize existing intent. ADRs 020, 021 are **Proposed** — they represent design direction that requires backend changes (continuous influence → slots, real-time processing → batch).

### Plan graduation

No `.plan/` files on this branch.

## Test plan

- [ ] Docs-only change — no code to test
- [ ] Cross-references between ADRs are consistent
- [ ] References to code files (`service/src/trust/...`) are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)