### PR TITLE
Expose Prometheus metrics from nginx frontend

### DIFF
--- a/kube/app/templates/deployment.yaml
+++ b/kube/app/templates/deployment.yaml
@@ -179,6 +179,28 @@ spec:
               mountPath: /tmp
             - name: nginx-cache
               mountPath: /var/cache/nginx
+        {{- if .Values.metrics.enabled }}
+        - name: nginx-exporter
+          image: "{{ .Values.frontend.exporter.image.repository }}:{{ .Values.frontend.exporter.image.tag }}"
+          args:
+            - --nginx.scrape-uri=http://127.0.0.1:{{ .Values.frontend.service.targetPort | default .Values.frontend.service.port }}/stub_status
+          ports:
+            - name: metrics
+              containerPort: 9113
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/kube/app/templates/service.yaml
+++ b/kube/app/templates/service.yaml
@@ -39,6 +39,12 @@ spec:
       targetPort: {{ .Values.frontend.service.targetPort | default .Values.frontend.service.port }}
       protocol: TCP
       name: http
+    {{- if .Values.metrics.enabled }}
+    - port: 9113
+      targetPort: 9113
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "app.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/kube/app/templates/servicemonitor.yaml
+++ b/kube/app/templates/servicemonitor.yaml
@@ -9,11 +9,32 @@ spec:
   selector:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
     - port: http
+      path: /metrics
+      interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "app.fullname" . }}-frontend
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
       path: /metrics
       interval: 30s
 ---

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -145,6 +145,10 @@ frontend:
     capabilities:
       drop:
         - ALL
+  exporter:
+    image:
+      repository: nginx/nginx-prometheus-exporter
+      tag: "1.4.1"
   resources: {}
   podDisruptionBudget:
     enabled: false

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -14,6 +14,14 @@ server {
         try_files $uri =404;
     }
 
+    # Prometheus metrics via nginx-prometheus-exporter sidecar
+    location /stub_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+
     # SPA routing — serve index.html for navigation routes only
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

- Add `nginx-prometheus-exporter` sidecar to frontend deployment, fixing permanent `TargetDown` alerts from Prometheus scraping a service with no `/metrics` endpoint
- Add `stub_status` location block to nginx.conf (restricted to localhost)
- Scope existing API ServiceMonitor selector to `component: api` so it no longer matches the frontend service

All changes are gated behind `metrics.enabled` (already `true` in demo). No impact on local dev.

## Changes

| File | What |
|------|------|
| `web/nginx.conf` | Add `/stub_status` location (localhost-only, no access log) |
| `kube/app/templates/deployment.yaml` | Add `nginx-exporter` sidecar container |
| `kube/app/templates/service.yaml` | Add metrics port 9113 to frontend service |
| `kube/app/templates/servicemonitor.yaml` | Add frontend ServiceMonitor + scope API one to `component: api` |
| `kube/app/values.yaml` | Add `frontend.exporter.image` config (`nginx/nginx-prometheus-exporter:1.4.1`) |

## Test plan

- [ ] `helm template tc-demo kube/app -f kube/environments/demo.yaml` renders exporter sidecar, metrics port, and both ServiceMonitors
- [ ] `helm template tc-dev kube/app` (default values) renders no metrics resources
- [ ] After deploy: `kubectl get servicemonitor -n tiny-congress-demo` shows `tc-demo` (API) and `tc-demo-frontend`
- [ ] Prometheus targets page shows frontend target as UP
- [ ] `TargetDown{job="tc-demo-frontend"}` alert resolves

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)