### PR TITLE
chart: template postgres-exporter resources from values

### DIFF
--- a/kube/app/templates/postgres.yaml
+++ b/kube/app/templates/postgres.yaml
@@ -105,13 +105,10 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             drop: [ALL]
+        {{- with .Values.postgres.exporter.resources }}
         resources:
-          requests:
-            cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 100m
-            memory: 64Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: postgres-data

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -216,6 +216,12 @@ postgres:
     image:
       repository: quay.io/prometheuscommunity/postgres-exporter
       tag: "v0.17.0"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
 
 # HMAC key for synthetic backup envelope generation (anti-enumeration).
 # REQUIRED — helm template will fail if this is empty and no existing secret


### PR DESCRIPTION
## Summary

- **postgres-exporter sidecar resources were hardcoded** in the template (`100m` CPU limit, `64Mi` memory limit), ignoring any overrides from `values.yaml` or HelmRelease `spec.values`
- Template now reads from `.Values.postgres.exporter.resources`, consistent with how other containers are configured
- Default values remove the CPU limit to avoid CFS throttling — the exporter is mostly idle with brief spikes during Prometheus scrapes

## Problem

`CPUThrottlingHigh` alert firing for `postgres-exporter` in the demo environment. The homelab HelmRelease set `postgres.exporter.resources.limits.cpu: 250m`, but the pod always deployed with `100m` because the template had literal values instead of `{{ toYaml }}`.

## Changes

| File | Change |
|------|--------|
| `kube/app/templates/postgres.yaml` | Replace hardcoded `resources:` block with `{{- with .Values.postgres.exporter.resources }}` |
| `kube/app/values.yaml` | Add `postgres.exporter.resources` defaults: 10m/32Mi requests, 64Mi memory limit, no CPU limit |

## Test plan

- [ ] `helm template` with default values produces exporter with memory limit only
- [ ] `helm template --set postgres.exporter.resources.limits.cpu=250m` applies CPU limit override
- [ ] CI `helm template` validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)