### PR TITLE
docs: add "how voting works" end-user explainer

### DIFF
--- a/web/src/content/about.md
+++ b/web/src/content/about.md
@@ -14,3 +14,25 @@ trusted authority.
 2. **Verify your identity** to prove you're a real person
 3. **Join a room** and vote on multi-dimensional polls
 4. **See how the community thinks** — not just averages, but the shape of opinion
+
+<a id="voting"></a>
+
+### How voting works
+
+Polls on TinyCongress can have multiple **dimensions** — different aspects of the
+same question. Each dimension gets its own slider.
+
+**Using the sliders:** Each slider runs between two labeled positions (for example,
+"Strongly Disagree" to "Strongly Agree"). Drag the slider to wherever you fall on
+that spectrum. There is no right or wrong answer — it's your position.
+
+**Reading results:** The bar chart below each dimension shows how everyone voted,
+spread across the spectrum. Taller bars mean more people landed in that range. This
+shows the full shape of opinion, not just a single average.
+
+**Updating your vote:** You can change your vote at any time while a poll is open.
+Just move the sliders and hit "Update Vote."
+
+**Who can vote:** You need to verify your identity before you can vote. Verification
+proves you're a real person, not a bot. Without it, you can browse rooms and see
+results but can't cast a vote.

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -189,7 +189,11 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
 
             {!hasVoted && canVote ? (
               <Text size="sm" c="dimmed">
-                Move the sliders to set your position on each dimension, then submit.
+                Each slider is a different aspect of the question. Drag to set where you fall
+                between the two labeled positions, then submit.{' '}
+                <Text component={Link} to="/about#voting" size="sm" c="blue" inherit>
+                  How does this work?
+                </Text>
               </Text>
             ) : null}
 
@@ -274,6 +278,9 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
               </Text>
             ) : null}
           </Group>
+          <Text size="xs" c="dimmed">
+            Each chart shows how responses are distributed across the spectrum.
+          </Text>
 
           {distributionQuery.isLoading ? <Loader size="sm" /> : null}
 


### PR DESCRIPTION
## Summary
- Adds a "How voting works" section to the `/about` page explaining dimensions, sliders, results, vote updating, and verification in plain language
- Rewrites poll page pre-vote instructions to briefly explain what sliders represent, with a "How does this work?" link to `/about#voting`
- Adds a one-line results subtitle explaining what the distribution charts show

Closes #592

## Test plan
- [ ] `just lint-frontend` passes
- [ ] `just test-frontend` passes (103/103)
- [ ] Navigate to `/about` — "How voting works" section renders with anchor
- [ ] Navigate to `/about#voting` — page scrolls to the voting section
- [ ] Open an active poll while verified — pre-vote text explains sliders and links to about page
- [ ] Results section shows subtitle "Each chart shows how responses are distributed across the spectrum."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>