### PR TITLE
docs: add in-app 'how keys work' end-user reference page

### DIFF
--- a/web/src/Router.tsx
+++ b/web/src/Router.tsx
@@ -13,6 +13,7 @@ import { AuthRequiredOutlet } from './components/AuthRequiredOutlet';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AboutPage } from './pages/About.page';
 import { HomePage } from './pages/Home.page';
+import { KeysPage } from './pages/Keys.page';
 import { Layout } from './pages/Layout';
 import { LoginPage } from './pages/Login.page';
 import { PollPage } from './pages/Poll.page';
@@ -101,6 +102,12 @@ const verifyCallbackRoute = createRoute({
   }),
 });
 
+const keysRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'keys',
+  component: KeysPage,
+});
+
 const roomsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'rooms',
@@ -116,6 +123,7 @@ const pollRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   homeRoute,
   aboutRoute,
+  keysRoute,
   guestOnlyLayout.addChildren([signupRoute, loginRoute]),
   authRequiredLayout.addChildren([settingsRoute, verifyCallbackRoute]),
   roomsRoute,

--- a/web/src/content/keys.md
+++ b/web/src/content/keys.md
@@ -1,0 +1,52 @@
+## How Your Keys Work
+
+TinyCongress uses cryptographic keys instead of traditional passwords to prove
+your identity. Your keys are generated in your browser and never leave your
+device — the server only sees the public half, which can verify your identity
+but can't impersonate you.
+
+### Your root key
+
+When you create an account, a **root key pair** is generated in your browser.
+Think of it as your master identity — it's the ultimate proof that you own your
+account. Your root key:
+
+- Is created locally on your device, never on the server
+- Signs and authorizes every device you log in from
+- Can't be reset or recovered by anyone else (including us)
+
+Because it's so important, TinyCongress encrypts a backup copy with your
+**backup password** and stores the encrypted version on the server. The server
+can't read it — only your password can unlock it.
+
+### Your backup password
+
+Your backup password protects the encrypted copy of your root key. You'll need
+it when you log in on a new browser or device. Without it, there is no way to
+recover your root key.
+
+- Choose something strong and memorable
+- TinyCongress cannot reset it for you
+- It's only used during login to decrypt your root key — it's never sent to the
+  server in plain text
+
+### Device keys
+
+Each browser or device you log in from gets its own **device key**. Device keys
+are authorized by your root key (via a signed certificate), so the server knows
+they belong to you.
+
+- You can have up to 10 devices at a time
+- Each device key is independent — revoking one doesn't affect the others
+- You can manage your devices from the Settings page
+
+### Why this matters
+
+Most platforms store your credentials on their servers. If the server is
+compromised, everyone's accounts are at risk. TinyCongress flips this: the
+server is a **witness**, not an authority. It can verify your signatures but
+can't forge them, which means:
+
+- No one at TinyCongress can impersonate you or vote on your behalf
+- A server breach can't leak your private keys (they were never there)
+- Your identity is truly yours — backed by math, not trust

--- a/web/src/features/identity/components/SignupForm.tsx
+++ b/web/src/features/identity/components/SignupForm.tsx
@@ -99,12 +99,7 @@ export function SignupForm({
                 </Text>
               </List.Item>
             </List>
-            <Anchor
-              href="https://github.com/icook/tiny-congress/blob/master/docs/domain-model.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              size="xs"
-            >
+            <Anchor component={Link} to="/keys" size="xs">
               Learn more about how TinyCongress keys work →
             </Anchor>
           </Stack>

--- a/web/src/pages/Keys.page.tsx
+++ b/web/src/pages/Keys.page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Keys page - Plain-language explainer of how TinyCongress keys work
+ */
+
+import { IconKey } from '@tabler/icons-react';
+import { Group, Stack, Title } from '@mantine/core';
+import { MarkdownContent } from '../components/MarkdownContent';
+import keysContent from '../content/keys.md?raw';
+
+export function KeysPage() {
+  return (
+    <Stack gap="md">
+      <Group gap="xs">
+        <IconKey size={20} />
+        <Title order={2}>How Your Keys Work</Title>
+      </Group>
+
+      <MarkdownContent>{keysContent}</MarkdownContent>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/keys` route with a plain-language explainer of root keys, device keys, backup passwords, and the crypto trust model — written for non-technical demo users
- Updates the signup success screen's "Learn more about how TinyCongress keys work →" link to point to `/keys` instead of the GitHub `domain-model.md`
- Content file at `web/src/content/keys.md` follows the same pattern as the about page (`?raw` import + `MarkdownContent`)

Closes #644

## Test plan

- [ ] Navigate to `/keys` — page renders with key icon and markdown content
- [ ] Sign up a new account — "Learn more" link on success screen navigates to `/keys` (not GitHub)
- [ ] Content is readable by a non-technical person on mobile
- [ ] All 103 frontend tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)