### PR TITLE
fix(ci): add always() to deploy-gitops and deploy-reports if conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1238,7 +1238,7 @@ jobs:
   deploy-gitops:
     name: Update gitops image digests
     if: >-
-      github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+      always() && github.event_name == 'push' && github.ref == 'refs/heads/master' &&
       needs.ci-gate.result == 'success'
     needs: [ci-gate, detect-changes]
     runs-on: ${{ needs.detect-changes.outputs.runner-small }}
@@ -1388,7 +1388,7 @@ jobs:
     name: Upload CI reports to Dufs
     runs-on: ${{ needs.detect-changes.outputs.runner-small }}
     needs: [detect-changes, ci-gate, unit-tests, rust-checks, e2e-tests, frontend-checks, build-docs]
-    if: needs.ci-gate.result == 'success'
+    if: always() && needs.ci-gate.result == 'success'
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary

- `check-no-plans` (added in #617) only runs on `pull_request` events, so it is always **skipped** on master pushes
- GitHub's skip cascade propagates transitively through `ci-gate` (which uses `if: always()` and succeeds) to any downstream job whose `if` condition lacks a status check function
- Both `deploy-gitops` and `deploy-reports` were silently skipped on every master push since #617 landed — CD has been broken since then

Fix: prefix both jobs' `if` conditions with `always()`, which opts them out of the transitive skip cascade. The explicit `needs.ci-gate.result == 'success'` guard still controls whether they actually run.

## Test plan

- [ ] Merge this PR — next master CI run should show `deploy-gitops` running (not skipped)
- [ ] Verify `icook/homelab-gitops` receives a digest commit after the CI run completes