### PR TITLE
fix(ci): remove collect-telemetry from deploy-gitops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1254,8 +1254,6 @@ jobs:
           ssh-key: ${{ secrets.GITOPS_DEPLOY_KEY }}
           ref: main
 
-      - uses: ./.github/actions/collect-telemetry
-
       - name: Install crane
         if: needs.detect-changes.outputs.use-arc == 'true'
         run: |


### PR DESCRIPTION
## Summary

- `deploy-gitops` checks out `icook/homelab-gitops` as its first step, so the working directory is that repo
- `uses: ./.github/actions/collect-telemetry` then fails because that local action only exists in `tiny-congress`
- Surfaced now that #654 fixed the skip cascade and the job actually runs

## Test plan

- [ ] Next master CI run should show `deploy-gitops` succeeding and pushing a digest commit to homelab-gitops