### PR TITLE
M3: Trust UI design + implementation

### DIFF
--- a/web/src/Router.tsx
+++ b/web/src/Router.tsx
@@ -24,6 +24,7 @@ import { PollPage } from './pages/Poll.page';
 import { RoomsPage } from './pages/Rooms.page';
 import { SettingsPage } from './pages/Settings.page';
 import { SignupPage } from './pages/Signup.page';
+import { TrustPage } from './pages/Trust.page';
 import { VerifyCallbackPage } from './pages/VerifyCallback.page';
 import { useDevice } from './providers/DeviceProvider';
 
@@ -111,6 +112,12 @@ const settingsRoute = createRoute({
   component: SettingsPage,
 });
 
+const trustRoute = createRoute({
+  getParentRoute: () => authRequiredLayout,
+  path: 'trust',
+  component: TrustPage,
+});
+
 const endorseRoute = createRoute({
   getParentRoute: () => authRequiredLayout,
   path: 'endorse',
@@ -159,7 +166,7 @@ const routeTree = rootRoute.addChildren([
   devArchitectureRoute,
   devDomainModelRoute,
   guestOnlyLayout.addChildren([signupRoute, loginRoute]),
-  authRequiredLayout.addChildren([settingsRoute, endorseRoute, verifyCallbackRoute]),
+  authRequiredLayout.addChildren([settingsRoute, trustRoute, endorseRoute, verifyCallbackRoute]),
   roomsRoute,
   pollRoute,
 ]);

--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -6,10 +6,12 @@ import {
   IconInfoCircle,
   IconLogin,
   IconShieldCheck,
+  IconShieldHalfFilled,
   IconUserPlus,
 } from '@tabler/icons-react';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { Badge, Box, NavLink, Stack, useComputedColorScheme, useMantineTheme } from '@mantine/core';
+import { useTrustScores } from '@/features/trust';
 import { buildVerifierUrl, useVerificationStatus } from '@/features/verification';
 import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
@@ -21,7 +23,10 @@ const publicNavLinks = [
   { icon: IconCode, label: 'Dev Docs', path: '/dev' },
 ];
 
-const authNavLinks = [{ icon: IconHeartHandshake, label: 'Endorse', path: '/endorse' }];
+const authNavLinks = [
+  { icon: IconShieldHalfFilled, label: 'Trust', path: '/trust' },
+  { icon: IconHeartHandshake, label: 'Endorse', path: '/endorse' },
+];
 
 const guestLinks = [
   { icon: IconLogin, label: 'Login', path: '/login' },
@@ -41,8 +46,10 @@ export function Navbar({ onNavigate }: NavbarProps) {
   const colorScheme = useComputedColorScheme();
   const { crypto } = useCrypto();
   const verificationQuery = useVerificationStatus(deviceKid, privateKey, crypto);
+  const trustScoresQuery = useTrustScores(deviceKid, privateKey, crypto);
   const isVerified = verificationQuery.data?.isVerified ?? false;
   const isAuthenticated = Boolean(deviceKid);
+  const trustScore = trustScoresQuery.data?.[0] ?? null;
 
   const borderColor = colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3];
 
@@ -92,7 +99,29 @@ export function Navbar({ onNavigate }: NavbarProps) {
         </Box>
       ) : (
         <Box pt="sm" style={{ borderTop: `1px solid ${borderColor}` }}>
-          {isVerified ? (
+          {isVerified && trustScore ? (
+            (() => {
+              if (trustScore.distance <= 3.0 && trustScore.path_diversity >= 2) {
+                return (
+                  <Badge color="violet" leftSection={<IconShieldCheck size={14} />} variant="light">
+                    Congress
+                  </Badge>
+                );
+              }
+              if (trustScore.distance <= 6.0 && trustScore.path_diversity >= 1) {
+                return (
+                  <Badge color="blue" leftSection={<IconShieldCheck size={14} />} variant="light">
+                    Community
+                  </Badge>
+                );
+              }
+              return (
+                <Badge color="green" leftSection={<IconShieldCheck size={14} />} variant="light">
+                  Verified
+                </Badge>
+              );
+            })()
+          ) : isVerified ? (
             <Badge color="green" leftSection={<IconShieldCheck size={14} />} variant="light">
               Verified
             </Badge>

--- a/web/src/features/trust/api/client.ts
+++ b/web/src/features/trust/api/client.ts
@@ -1,0 +1,123 @@
+/**
+ * Trust API client
+ * Type-safe REST client for trust scores, budget, endorsements, and invites
+ */
+
+import { signedFetchJson } from '@/api/signing';
+import type { CryptoModule } from '@/providers/CryptoProvider';
+
+// === Types ===
+
+export interface ScoreSnapshot {
+  subject_id: string;
+  distance: number;
+  path_diversity: number;
+  computed_at: string;
+}
+
+export interface TrustBudget {
+  slots_total: number;
+  slots_used: number;
+  slots_available: number;
+  denouncements_total: number;
+  denouncements_used: number;
+  denouncements_available: number;
+}
+
+export interface Invite {
+  id: string;
+  delivery_method: string;
+  accepted_by: string | null;
+  expires_at: string;
+  accepted_at: string | null;
+}
+
+export interface AcceptInviteResult {
+  endorser_id: string;
+  accepted_at: string;
+}
+
+export interface EndorsePayload {
+  subject_id: string;
+  weight: number;
+  attestation: Record<string, unknown>;
+}
+
+export interface RevokePayload {
+  subject_id: string;
+}
+
+export interface CreateInvitePayload {
+  envelope: string;
+  delivery_method: string;
+  attestation: Record<string, unknown>;
+}
+
+// === API functions ===
+
+export async function getMyScores(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<ScoreSnapshot[]> {
+  return signedFetchJson('/trust/scores/me', 'GET', deviceKid, privateKey, wasmCrypto);
+}
+
+export async function getMyBudget(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<TrustBudget> {
+  return signedFetchJson('/trust/budget', 'GET', deviceKid, privateKey, wasmCrypto);
+}
+
+export async function createInvite(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  payload: CreateInvitePayload
+): Promise<Invite> {
+  return signedFetchJson('/trust/invites', 'POST', deviceKid, privateKey, wasmCrypto, payload);
+}
+
+export async function listMyInvites(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<Invite[]> {
+  return signedFetchJson('/trust/invites/mine', 'GET', deviceKid, privateKey, wasmCrypto);
+}
+
+export async function acceptInvite(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  inviteId: string
+): Promise<AcceptInviteResult> {
+  return signedFetchJson(
+    `/trust/invites/${inviteId}/accept`,
+    'POST',
+    deviceKid,
+    privateKey,
+    wasmCrypto
+  );
+}
+
+export async function endorse(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  payload: EndorsePayload
+): Promise<void> {
+  await signedFetchJson('/trust/endorse', 'POST', deviceKid, privateKey, wasmCrypto, payload);
+}
+
+export async function revokeEndorsement(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  subjectId: string
+): Promise<void> {
+  const payload: RevokePayload = { subject_id: subjectId };
+  await signedFetchJson('/trust/revoke', 'POST', deviceKid, privateKey, wasmCrypto, payload);
+}

--- a/web/src/features/trust/api/index.ts
+++ b/web/src/features/trust/api/index.ts
@@ -1,0 +1,26 @@
+export {
+  getMyScores,
+  getMyBudget,
+  createInvite,
+  listMyInvites,
+  acceptInvite,
+  endorse,
+  revokeEndorsement,
+} from './client';
+export type {
+  ScoreSnapshot,
+  TrustBudget,
+  Invite,
+  AcceptInviteResult,
+  EndorsePayload,
+  CreateInvitePayload,
+} from './client';
+export {
+  useTrustScores,
+  useTrustBudget,
+  useMyInvites,
+  useCreateInvite,
+  useAcceptInvite,
+  useEndorse,
+  useRevokeEndorsement,
+} from './queries';

--- a/web/src/features/trust/api/queries.ts
+++ b/web/src/features/trust/api/queries.ts
@@ -1,0 +1,129 @@
+/**
+ * TanStack Query hooks for trust API
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CryptoModule } from '@/providers/CryptoProvider';
+import {
+  acceptInvite,
+  createInvite,
+  endorse,
+  getMyBudget,
+  getMyScores,
+  listMyInvites,
+  revokeEndorsement,
+  type CreateInvitePayload,
+  type EndorsePayload,
+} from './client';
+
+export function useTrustScores(
+  deviceKid: string | null,
+  privateKey: CryptoKey | null,
+  wasmCrypto: CryptoModule | null
+) {
+  return useQuery({
+    queryKey: ['trust-scores', deviceKid],
+    queryFn: async () => {
+      if (!deviceKid || !privateKey || !wasmCrypto) {
+        throw new Error('Not authenticated');
+      }
+      return getMyScores(deviceKid, privateKey, wasmCrypto);
+    },
+    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
+    staleTime: 30_000,
+  });
+}
+
+export function useTrustBudget(
+  deviceKid: string | null,
+  privateKey: CryptoKey | null,
+  wasmCrypto: CryptoModule | null
+) {
+  return useQuery({
+    queryKey: ['trust-budget', deviceKid],
+    queryFn: async () => {
+      if (!deviceKid || !privateKey || !wasmCrypto) {
+        throw new Error('Not authenticated');
+      }
+      return getMyBudget(deviceKid, privateKey, wasmCrypto);
+    },
+    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
+    staleTime: 30_000,
+  });
+}
+
+export function useMyInvites(
+  deviceKid: string | null,
+  privateKey: CryptoKey | null,
+  wasmCrypto: CryptoModule | null
+) {
+  return useQuery({
+    queryKey: ['trust-invites', deviceKid],
+    queryFn: async () => {
+      if (!deviceKid || !privateKey || !wasmCrypto) {
+        throw new Error('Not authenticated');
+      }
+      return listMyInvites(deviceKid, privateKey, wasmCrypto);
+    },
+    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateInvite(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateInvitePayload) =>
+      createInvite(deviceKid, privateKey, wasmCrypto, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
+    },
+  });
+}
+
+export function useAcceptInvite(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (inviteId: string) => acceptInvite(deviceKid, privateKey, wasmCrypto, inviteId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
+    },
+  });
+}
+
+export function useEndorse(deviceKid: string, privateKey: CryptoKey, wasmCrypto: CryptoModule) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: EndorsePayload) => endorse(deviceKid, privateKey, wasmCrypto, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
+    },
+  });
+}
+
+export function useRevokeEndorsement(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (subjectId: string) =>
+      revokeEndorsement(deviceKid, privateKey, wasmCrypto, subjectId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
+    },
+  });
+}

--- a/web/src/features/trust/components/TrustScoreCard.tsx
+++ b/web/src/features/trust/components/TrustScoreCard.tsx
@@ -1,0 +1,110 @@
+import { IconShield, IconUsers } from '@tabler/icons-react';
+import { Badge, Card, Group, Loader, Progress, Stack, Text, Title } from '@mantine/core';
+import type { CryptoModule } from '@/providers/CryptoProvider';
+import { useTrustBudget, useTrustScores } from '../api';
+
+interface TrustScoreCardProps {
+  deviceKid: string | null;
+  privateKey: CryptoKey | null;
+  wasmCrypto: CryptoModule | null;
+}
+
+function getTierInfo(distance: number, diversity: number): { label: string; color: string } | null {
+  if (distance <= 3.0 && diversity >= 2) {
+    return { label: 'Congress', color: 'blue' };
+  }
+  if (distance <= 6.0 && diversity >= 1) {
+    return { label: 'Community', color: 'teal' };
+  }
+  return null;
+}
+
+export function TrustScoreCard({ deviceKid, privateKey, wasmCrypto }: TrustScoreCardProps) {
+  const scoresQuery = useTrustScores(deviceKid, privateKey, wasmCrypto);
+  const budgetQuery = useTrustBudget(deviceKid, privateKey, wasmCrypto);
+
+  if (!deviceKid) {
+    return null;
+  }
+
+  if (scoresQuery.isLoading || budgetQuery.isLoading) {
+    return (
+      <Card withBorder padding="lg">
+        <Group justify="center">
+          <Loader size="sm" />
+        </Group>
+      </Card>
+    );
+  }
+
+  const topScore = scoresQuery.data?.[0];
+  const budget = budgetQuery.data;
+
+  if (!topScore) {
+    return (
+      <Card withBorder padding="lg">
+        <Text c="dimmed" ta="center">
+          No trust score yet. Get endorsed by a trusted member to join the network.
+        </Text>
+      </Card>
+    );
+  }
+
+  const tier = getTierInfo(topScore.distance, topScore.path_diversity);
+  const budgetUsed = budget?.slots_used ?? 0;
+  const budgetTotal = budget?.slots_total ?? 0;
+  const budgetPercent = budgetTotal > 0 ? Math.round((budgetUsed / budgetTotal) * 100) : 0;
+
+  return (
+    <Card withBorder padding="lg">
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start">
+          <Title order={4}>Trust Score</Title>
+          {tier !== null && (
+            <Badge color={tier.color} variant="light">
+              {tier.label}
+            </Badge>
+          )}
+        </Group>
+
+        <Group gap="xl">
+          <Stack gap={4} align="center">
+            <Group gap={4} align="center">
+              <IconShield size={16} />
+              <Text size="xl" fw={700}>
+                {topScore.distance.toFixed(1)}
+              </Text>
+            </Group>
+            <Text size="xs" c="dimmed">
+              Distance
+            </Text>
+          </Stack>
+
+          <Stack gap={4} align="center">
+            <Group gap={4} align="center">
+              <IconUsers size={16} />
+              <Text size="xl" fw={700}>
+                {topScore.path_diversity}
+              </Text>
+            </Group>
+            <Text size="xs" c="dimmed">
+              Path Diversity
+            </Text>
+          </Stack>
+        </Group>
+
+        {budget !== undefined && (
+          <Stack gap={4}>
+            <Group justify="space-between">
+              <Text size="sm">Endorsement Budget</Text>
+              <Text size="sm" c="dimmed">
+                {budgetUsed} / {budgetTotal}
+              </Text>
+            </Group>
+            <Progress value={budgetPercent} size="sm" />
+          </Stack>
+        )}
+      </Stack>
+    </Card>
+  );
+}

--- a/web/src/features/trust/components/index.ts
+++ b/web/src/features/trust/components/index.ts
@@ -1,0 +1,1 @@
+export { TrustScoreCard } from './TrustScoreCard';

--- a/web/src/features/trust/index.ts
+++ b/web/src/features/trust/index.ts
@@ -1,0 +1,25 @@
+export {
+  getMyScores,
+  getMyBudget,
+  createInvite,
+  listMyInvites,
+  acceptInvite,
+  endorse,
+  revokeEndorsement,
+  useTrustScores,
+  useTrustBudget,
+  useMyInvites,
+  useCreateInvite,
+  useAcceptInvite,
+  useEndorse,
+  useRevokeEndorsement,
+} from './api';
+export type {
+  ScoreSnapshot,
+  TrustBudget,
+  Invite,
+  AcceptInviteResult,
+  EndorsePayload,
+  CreateInvitePayload,
+} from './api';
+export { TrustScoreCard } from './components';

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -28,6 +28,7 @@ import {
   type Dimension,
   type DimensionVote,
 } from '@/features/rooms';
+import { useTrustScores } from '@/features/trust';
 import { buildVerifierUrl, useVerificationStatus } from '@/features/verification';
 import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
@@ -49,6 +50,8 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
   const voteMutation = useCastVote(roomId, pollId, deviceKid, privateKey, crypto);
   const verificationQuery = useVerificationStatus(deviceKid, privateKey, crypto);
   const isVerified = verificationQuery.data?.isVerified ?? false;
+  const trustScoresQuery = useTrustScores(deviceKid, privateKey, crypto);
+  const hasTrustScore = (trustScoresQuery.data?.length ?? 0) > 0;
 
   const [votes, setVotes] = useState<Record<string, number>>({});
   const [hasInitialized, setHasInitialized] = useState(false);
@@ -224,6 +227,13 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
                   }
                   return null;
                 })()}
+              </Alert>
+            ) : null}
+
+            {isAuthenticated && isVerified && !hasTrustScore ? (
+              <Alert icon={<IconShieldOff size={16} />} color="yellow">
+                You&apos;re verified, but you need endorsements from trusted members to vote in this
+                room. Visit the Trust page to see your status.
               </Alert>
             ) : null}
 

--- a/web/src/pages/Settings.page.tsx
+++ b/web/src/pages/Settings.page.tsx
@@ -7,6 +7,7 @@ import { Alert, Badge, Button, Card, Group, Loader, Stack, Text, Title } from '@
 import { notifications } from '@mantine/notifications';
 import { useListDevices, useRenameDevice, useRevokeDevice } from '@/features/identity/api/queries';
 import { DeviceList } from '@/features/identity/components';
+import { TrustScoreCard } from '@/features/trust';
 import { buildVerifierUrl, useVerificationStatus } from '@/features/verification';
 import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
@@ -61,6 +62,8 @@ export function SettingsPage() {
           ) : null}
         </Stack>
       </Card>
+
+      <TrustScoreCard deviceKid={deviceKid} privateKey={privateKey} wasmCrypto={crypto} />
 
       <Card shadow="sm" padding="lg" radius="md" withBorder>
         <Stack gap="md">

--- a/web/src/pages/Trust.page.tsx
+++ b/web/src/pages/Trust.page.tsx
@@ -1,0 +1,105 @@
+/**
+ * Trust & Identity dashboard page
+ */
+
+import { IconAlertTriangle, IconCheck, IconClock, IconX } from '@tabler/icons-react';
+import { Alert, Badge, Card, Loader, Stack, Table, Text, Title } from '@mantine/core';
+import { TrustScoreCard, useMyInvites, type Invite } from '@/features/trust';
+import { useCrypto } from '@/providers/CryptoProvider';
+import { useDevice } from '@/providers/DeviceProvider';
+
+function InviteStatusBadge({ invite }: { invite: Invite }) {
+  if (invite.accepted_at) {
+    return (
+      <Badge color="green" leftSection={<IconCheck size={12} />} variant="light">
+        Accepted
+      </Badge>
+    );
+  }
+  if (new Date(invite.expires_at) < new Date()) {
+    return (
+      <Badge color="gray" leftSection={<IconX size={12} />} variant="light">
+        Expired
+      </Badge>
+    );
+  }
+  return (
+    <Badge color="blue" leftSection={<IconClock size={12} />} variant="light">
+      Pending
+    </Badge>
+  );
+}
+
+export function TrustPage() {
+  const { deviceKid, privateKey } = useDevice();
+  const { crypto } = useCrypto();
+
+  const invitesQuery = useMyInvites(deviceKid, privateKey, crypto);
+
+  // Defensive safety net — route guard guarantees deviceKid is set
+  if (!deviceKid) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md" maw={800} mx="auto" mt="xl" px="md">
+      <div>
+        <Title order={2}>Trust &amp; Identity</Title>
+        <Text c="dimmed" size="sm" mt="xs">
+          Your trust network and invite history
+        </Text>
+      </div>
+
+      <TrustScoreCard deviceKid={deviceKid} privateKey={privateKey} wasmCrypto={crypto} />
+
+      <Card shadow="sm" padding="lg" radius="md" withBorder>
+        <Stack gap="md">
+          <Title order={4}>My Invites</Title>
+
+          {invitesQuery.isLoading ? <Loader size="sm" /> : null}
+
+          {invitesQuery.isError ? (
+            <Alert icon={<IconAlertTriangle size={16} />} color="red">
+              Failed to load invites: {invitesQuery.error.message}
+            </Alert>
+          ) : null}
+
+          {invitesQuery.data?.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              You haven&apos;t sent any invites yet.
+            </Text>
+          ) : null}
+
+          {(invitesQuery.data?.length ?? 0) > 0 ? (
+            <Table>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Method</Table.Th>
+                  <Table.Th>Status</Table.Th>
+                  <Table.Th>Expires</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {invitesQuery.data?.map((invite) => (
+                  <Table.Tr key={invite.id}>
+                    <Table.Td>
+                      <Text size="sm">{invite.delivery_method}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <InviteStatusBadge invite={invite} />
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {new Date(invite.expires_at).toLocaleDateString()}
+                      </Text>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          ) : null}
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the frontend gap from #612 — surfaces the backend trust engine to users.

- **Trust feature module** (`web/src/features/trust/`): API client with signed REST calls to `/trust/scores/me`, `/trust/budget`, `/trust/invites/*`, plus TanStack Query hooks for data fetching and mutations
- **TrustScoreCard component**: Shows trust distance, path diversity, tier badge (Congress/Community), and endorsement budget progress bar. Empty state for new users without scores
- **Trust dashboard page** (`/trust`): Authenticated page with score card + invite history table (accepted/pending/expired status badges)
- **Navbar integration**: Trust nav link for authenticated users + tier badge replacing generic "Verified" when trust score exists
- **Settings page**: TrustScoreCard rendered above device management
- **Poll page**: Yellow alert for verified users lacking trust endorsements ("you need endorsements from trusted members to vote")

## Test plan

- [x] `just lint-frontend` passes (Prettier, ESLint, Stylelint)
- [x] `just lint-typecheck` passes (no TS errors)
- [x] `just test-frontend` passes (105/105 tests)
- [ ] CI checks pass
- [ ] Manual: navigate to `/trust` while authenticated — see score card + empty invites
- [ ] Manual: check navbar shows Trust link and tier badge
- [ ] Manual: check Settings page shows trust score card
- [ ] Manual: check Poll page shows trust eligibility alert for unendorsed user

## Linked Issue

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>