### PR TITLE
fix(ux): audit trivial rollup — GitHub link, error message

### DIFF
--- a/web/src/pages/DevIndex.page.tsx
+++ b/web/src/pages/DevIndex.page.tsx
@@ -2,7 +2,7 @@
  * Developer documentation index — lists available technical reference pages.
  */
 
-import { IconBook2, IconCode } from '@tabler/icons-react';
+import { IconBook2, IconBrandGithub, IconCode } from '@tabler/icons-react';
 import { Link } from '@tanstack/react-router';
 import { Anchor, Badge, Card, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 
@@ -37,7 +37,10 @@ export function DevIndexPage() {
         <Anchor component={Link} to="/about">
           About
         </Anchor>
-        .
+        .{' '}
+        <Anchor href="https://github.com/icook/tiny-congress" target="_blank" rel="noopener">
+          <IconBrandGithub size={14} style={{ verticalAlign: 'text-bottom' }} /> Source on GitHub
+        </Anchor>
       </Text>
 
       <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -229,7 +229,9 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
 
             {voteMutation.isError ? (
               <Alert icon={<IconAlertTriangle size={16} />} color="red">
-                {voteMutation.error.message}
+                {voteMutation.error.message.includes('trust graph')
+                  ? "Your account isn't yet connected to this room's trust network. Ask an existing member to endorse you, or try a different room."
+                  : voteMutation.error.message}
               </Alert>
             ) : null}
 


### PR DESCRIPTION
## Summary
- Add GitHub source code link (icon + text) to the `/dev` developer docs index page
- Replace raw internal "not reachable from room anchor in trust graph" error with a human-readable message directing users to seek endorsement

Findings from a full live-site audit against `objectives.md`. Non-trivial items filed as separate tickets.

## Test plan
- [ ] Verify `/dev` page shows GitHub link pointing to `icook/tiny-congress`
- [ ] Trigger a trust-graph vote rejection and verify the user sees "Your account isn't yet connected to this room's trust network" instead of the raw internal error

🤖 Generated with [Claude Code](https://claude.com/claude-code)