### PR TITLE
fix(trust): EndorsedByConstraint checks topic endorsements, not WoT scores

### DIFF
--- a/service/src/trust/constraints.rs
+++ b/service/src/trust/constraints.rs
@@ -29,28 +29,28 @@ pub trait RoomConstraint: Send + Sync {
 // EndorsedByConstraint
 // ---------------------------------------------------------------------------
 
-/// User must appear in the trust graph reachable from `room_anchor_id`.
-pub struct EndorsedByConstraint;
+/// User must have an active endorsement with the configured `topic`.
+///
+/// The topic is drawn from `constraint_config.topic` (set by migration 14 from
+/// the old `eligibility_topic` column).
+pub struct EndorsedByConstraint {
+    pub topic: String,
+}
 
 #[async_trait]
 impl RoomConstraint for EndorsedByConstraint {
     async fn check(
         &self,
         user_id: Uuid,
-        room_anchor_id: Option<Uuid>,
+        _room_anchor_id: Option<Uuid>,
         trust_repo: &dyn TrustRepo,
     ) -> Result<Eligibility, anyhow::Error> {
-        let snapshot = trust_repo
-            .get_score(user_id, room_anchor_id)
+        let endorsed = trust_repo
+            .has_topic_endorsement(user_id, &self.topic)
             .await
             .map_err(|e| anyhow::anyhow!("trust repo error: {e}"))?;
 
-        // A snapshot can exist without `trust_distance` if only centrality was computed.
-        // `trust_distance` being present means the user is reachable from the anchor —
-        // the distance was set during graph traversal, so Some(d) = reachable.
-        let is_eligible = snapshot.as_ref().and_then(|s| s.trust_distance).is_some();
-
-        if is_eligible {
+        if endorsed {
             Ok(Eligibility {
                 is_eligible: true,
                 reason: None,
@@ -58,7 +58,10 @@ impl RoomConstraint for EndorsedByConstraint {
         } else {
             Ok(Eligibility {
                 is_eligible: false,
-                reason: Some("not reachable from room anchor in trust graph".to_string()),
+                reason: Some(format!(
+                    "no '{}' endorsement found; complete identity verification first",
+                    self.topic
+                )),
             })
         }
     }
@@ -266,7 +269,14 @@ pub fn build_constraint(
     config: &serde_json::Value,
 ) -> Result<Box<dyn RoomConstraint>, anyhow::Error> {
     match constraint_type {
-        "endorsed_by" => Ok(Box::new(EndorsedByConstraint)),
+        "endorsed_by" => {
+            let topic = config
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .unwrap_or("identity_verified")
+                .to_string();
+            Ok(Box::new(EndorsedByConstraint { topic }))
+        }
         "community" => {
             let max_distance_f64 = get_f64_or_default(config, "max_distance", 5.0)?;
             if max_distance_f64 > f64::from(f32::MAX) {

--- a/service/src/trust/repo/mod.rs
+++ b/service/src/trust/repo/mod.rs
@@ -184,6 +184,14 @@ pub trait TrustRepo: Send + Sync {
     ) -> Result<Option<ScoreSnapshot>, TrustRepoError>;
 
     async fn get_all_scores(&self, user_id: Uuid) -> Result<Vec<ScoreSnapshot>, TrustRepoError>;
+
+    /// Returns `true` if `user_id` has at least one active (non-revoked) endorsement
+    /// with the given `topic` in `reputation__endorsements`.
+    async fn has_topic_endorsement(
+        &self,
+        user_id: Uuid,
+        topic: &str,
+    ) -> Result<bool, TrustRepoError>;
 }
 
 /// `PostgreSQL` implementation of [`TrustRepo`].
@@ -320,5 +328,23 @@ impl TrustRepo for PgTrustRepo {
 
     async fn get_all_scores(&self, user_id: Uuid) -> Result<Vec<ScoreSnapshot>, TrustRepoError> {
         scores::get_all_scores(&self.pool, user_id).await
+    }
+
+    async fn has_topic_endorsement(
+        &self,
+        user_id: Uuid,
+        topic: &str,
+    ) -> Result<bool, TrustRepoError> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(\
+               SELECT 1 FROM reputation__endorsements \
+               WHERE subject_id = $1 AND topic = $2 AND revoked_at IS NULL\
+             )",
+        )
+        .bind(user_id)
+        .bind(topic)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists)
     }
 }

--- a/service/tests/rooms_handler_tests.rs
+++ b/service/tests/rooms_handler_tests.rs
@@ -63,17 +63,15 @@ async fn endorse_user(pool: &sqlx::PgPool, account_id: uuid::Uuid, topic: &str) 
         .expect("endorsement");
 }
 
-/// Helper: seed a global trust score snapshot that makes `account_id` eligible to vote.
+/// Helper: insert an `identity_verified` endorsement that makes `account_id` eligible to vote.
 ///
-/// The `EndorsedByConstraint` with a nil anchor checks `trust_repo.get_score(user_id, None)`.
-/// Seeding a score with `trust_distance = Some(1.0)` makes the user reachable and eligible.
+/// `EndorsedByConstraint` (constraint_type = "endorsed_by", config.topic = "identity_verified")
+/// requires an active `reputation__endorsements` row with `topic = 'identity_verified'`.
 async fn make_eligible(pool: &sqlx::PgPool, account_id: uuid::Uuid, _room_id: uuid::Uuid) {
-    use tinycongress_api::trust::repo::{PgTrustRepo, TrustRepo};
-    let trust_repo = PgTrustRepo::new(pool.clone());
-    trust_repo
-        .upsert_score(account_id, None, Some(1.0), Some(1), None)
+    use tinycongress_api::reputation::repo::create_endorsement;
+    create_endorsement(pool, account_id, "identity_verified", None, None, 1.0, None)
         .await
-        .expect("trust score");
+        .expect("identity_verified endorsement");
 }
 
 /// Helper: parse JSON response body.

--- a/service/tests/trust_constraint_tests.rs
+++ b/service/tests/trust_constraint_tests.rs
@@ -12,89 +12,83 @@ use tinycongress_api::trust::constraints::{
 use tinycongress_api::trust::repo::{PgTrustRepo, TrustRepo};
 
 // ---------------------------------------------------------------------------
-// EndorsedByConstraint: user reachable from anchor → eligible
+// EndorsedByConstraint: user has matching topic endorsement → eligible
 // ---------------------------------------------------------------------------
 #[shared_runtime_test]
 async fn test_endorsed_by_eligible() {
     let db = isolated_db().await;
     let pool = db.pool().clone();
 
-    let anchor = AccountFactory::new()
+    let endorser = AccountFactory::new()
         .with_seed(80)
         .create(&pool)
         .await
-        .expect("create anchor");
+        .expect("create endorser");
     let user = AccountFactory::new()
         .with_seed(81)
         .create(&pool)
         .await
         .expect("create user");
 
-    // Insert endorsement edge and score snapshot
+    // Insert a topic endorsement for the user
     sqlx::query(
         "INSERT INTO reputation__endorsements (endorser_id, subject_id, topic, weight)
-         VALUES ($1, $2, 'trust', $3)",
+         VALUES ($1, $2, 'identity_verified', 1.0)",
     )
-    .bind(anchor.id)
+    .bind(endorser.id)
     .bind(user.id)
-    .bind(1.0_f32)
     .execute(&pool)
     .await
     .unwrap();
 
     let repo = PgTrustRepo::new(pool.clone());
-    repo.upsert_score(user.id, Some(anchor.id), Some(1.0), Some(1), None)
-        .await
-        .expect("upsert_score");
-
-    let constraint = EndorsedByConstraint;
+    let constraint = EndorsedByConstraint {
+        topic: "identity_verified".to_string(),
+    };
     let result = constraint
-        .check(user.id, Some(anchor.id), &repo)
+        .check(user.id, None, &repo)
         .await
         .expect("check should not error");
 
     assert!(
         result.is_eligible,
-        "User reachable from anchor should be eligible"
+        "User with matching topic endorsement should be eligible"
     );
     assert!(result.reason.is_none());
 }
 
 // ---------------------------------------------------------------------------
-// EndorsedByConstraint: no score snapshot → ineligible with reason
+// EndorsedByConstraint: no topic endorsement → ineligible with reason
 // ---------------------------------------------------------------------------
 #[shared_runtime_test]
 async fn test_endorsed_by_ineligible() {
     let db = isolated_db().await;
     let pool = db.pool().clone();
 
-    let anchor = AccountFactory::new()
-        .with_seed(82)
-        .create(&pool)
-        .await
-        .expect("create anchor");
     let user = AccountFactory::new()
         .with_seed(83)
         .create(&pool)
         .await
         .expect("create user");
 
-    // No score inserted — user is unreachable
+    // No endorsement inserted
     let repo = PgTrustRepo::new(pool.clone());
-    let constraint = EndorsedByConstraint;
+    let constraint = EndorsedByConstraint {
+        topic: "identity_verified".to_string(),
+    };
     let result = constraint
-        .check(user.id, Some(anchor.id), &repo)
+        .check(user.id, None, &repo)
         .await
         .expect("check should not error");
 
     assert!(
         !result.is_eligible,
-        "User with no score should be ineligible"
+        "User with no endorsement should be ineligible"
     );
     let reason = result.reason.expect("should have a reason");
     assert!(
-        reason.contains("not reachable"),
-        "Reason should mention 'not reachable', got: {reason}"
+        reason.contains("identity_verified"),
+        "Reason should mention the topic, got: {reason}"
     );
 }
 

--- a/service/tests/trust_e2e_tests.rs
+++ b/service/tests/trust_e2e_tests.rs
@@ -9,7 +9,7 @@ use common::factories::AccountFactory;
 use common::test_db::isolated_db;
 use tc_test_macros::shared_runtime_test;
 use tinycongress_api::reputation::repo::{PgReputationRepo, ReputationRepo};
-use tinycongress_api::trust::constraints::{EndorsedByConstraint, RoomConstraint};
+use tinycongress_api::trust::constraints::RoomConstraint;
 use tinycongress_api::trust::engine::TrustEngine;
 use tinycongress_api::trust::repo::{PgTrustRepo, TrustRepo};
 use tinycongress_api::trust::service::{DefaultTrustService, TrustService};
@@ -118,17 +118,30 @@ async fn test_demo_day_flow() {
         .expect("get dave score");
     assert!(dave_score.is_none(), "Dave should be unreachable");
 
-    // Step 6: Verify room constraint — Bob can enter, Dave cannot
-    let endorsed_by = EndorsedByConstraint;
+    // Step 6: Verify room constraint — Bob has identity_verified endorsement, Dave does not
+    // Insert an identity_verified endorsement for Bob (as a verifier would via /verifiers/endorsements)
+    sqlx::query(
+        "INSERT INTO reputation__endorsements (endorser_id, subject_id, topic, weight) \
+         VALUES ($1, $2, 'identity_verified', 1.0)",
+    )
+    .bind(alice.id)
+    .bind(bob.id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let endorsed_by = tinycongress_api::trust::constraints::EndorsedByConstraint {
+        topic: "identity_verified".to_string(),
+    };
 
     let bob_eligibility = endorsed_by
-        .check(bob.id, Some(alice.id), trust_repo.as_ref())
+        .check(bob.id, None, trust_repo.as_ref())
         .await
         .expect("check bob eligibility");
     assert!(bob_eligibility.is_eligible, "Bob should be eligible");
 
     let dave_eligibility = endorsed_by
-        .check(dave.id, Some(alice.id), trust_repo.as_ref())
+        .check(dave.id, None, trust_repo.as_ref())
         .await
         .expect("check dave eligibility");
     assert!(!dave_eligibility.is_eligible, "Dave should not be eligible");


### PR DESCRIPTION
## Summary

- `EndorsedByConstraint` was checking `trust__score_snapshots` for WoT graph reachability (`trust_distance IS NOT NULL`), but the sim verifier writes `identity_verified` entries to `reputation__endorsements` — a completely different table
- All sim users were ineligible to vote despite having valid verifier endorsements
- Root cause: `build_constraint("endorsed_by")` ignored `constraint_config.topic` entirely; migration 14 preserved the old `eligibility_topic` value in the config but the implementation never read it

See also #665, which tackles the same root problem from a different angle.

**Changes:**
- `EndorsedByConstraint` now holds a `topic` field and calls `trust_repo.has_topic_endorsement()` against `reputation__endorsements`
- `build_constraint` reads `topic` from config (default: `identity_verified`)
- Adds `has_topic_endorsement()` to `TrustRepo` trait + `PgTrustRepo` impl (SQL query against `reputation__endorsements WHERE subject_id = $1 AND topic = $2 AND revoked_at IS NULL`)
- Updates three test files (`trust_constraint_tests.rs`, `trust_e2e_tests.rs`, `rooms_handler_tests.rs`) to use the new mechanism

No migrations. No API surface changes. No frontend changes.

## Why I'm unsure

The original `EndorsedByConstraint` was checking WoT scores — that may have been intentional for a future state where the sim populates WoT scores, not just topic endorsements. This fix makes eligibility work for the current sim flow, but changes the semantics: **topic endorsements from a trusted verifier** vs **reachability in the WoT graph**. These aren't the same thing.

Worth a look before merge.

## Test plan

- [ ] `cargo test --test trust_constraint_tests` — all constraint unit tests
- [ ] `cargo test --test trust_e2e_tests` — demo day flow
- [ ] `cargo test --test rooms_handler_tests` — room handler eligibility tests
- [ ] Sim casts votes on demo polls (the original symptom from #666)

Fixes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)