### PR TITLE
perf(ci): cache rustdoc output in build-docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,8 +315,20 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
-      - name: Build docs
-        run: just docs
+      - name: Cache rustdoc output
+        id: cache-docs
+        uses: runs-on/cache@v4
+        with:
+          path: target/doc
+          key: rustdoc-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'service/src/**/*.rs', 'crates/**/*.rs') }}
+          restore-keys: rustdoc-${{ runner.os }}-
+
+      - name: Build Rust docs
+        if: steps.cache-docs.outputs.cache-hit != 'true'
+        run: cargo doc --workspace --no-deps
+
+      - name: Build TypeScript docs
+        run: cd web && yarn typedoc
 
       - name: Upload docs artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- Adds `runs-on/cache@v4` step to `build-docs` keyed on `Cargo.lock` + all `.rs` files
- Skips `cargo doc` entirely on exact cache hit (restores `target/doc` from cache)
- TypeScript docs (typedoc) still run unconditionally — they're fast
- Uses a dedicated `rustdoc-` prefix to keep doc artifacts isolated from the shared `rust-` target cache used by other jobs

Motivated by `build-docs` appearing on the critical path in ARC runs where E2E finished faster than expected. Cold rustdoc takes 2-4 min; warm cache should drop it to seconds.

## Test plan
- [ ] CI passes on this PR
- [ ] Second run against same commit shows `build-docs` step time drop significantly (cache hit)