### PR TITLE
docs: accept ADR-020/024/025 and fix cross-references

### DIFF
--- a/docs/decisions/008-account-based-verifiers.md
+++ b/docs/decisions/008-account-based-verifiers.md
@@ -49,6 +49,7 @@ Verifiers are regular accounts authenticated via the same device-key signing pro
 - Rejected: over-engineered for the current scale, adds infrastructure complexity (token issuer, certificate management), and still requires a separate auth path
 
 ## References
+- [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — verifier accounts are platform trust infrastructure; the exemption from slot limits is defined there
 - PR #381, #384: Generalized verifier API implementation
 - `service/src/reputation/bootstrap.rs`: Bootstrap logic
 - `service/src/reputation/http/mod.rs`: Endorsement endpoint with `AuthenticatedDevice`

--- a/docs/decisions/017-two-layer-trust-architecture.md
+++ b/docs/decisions/017-two-layer-trust-architecture.md
@@ -26,7 +26,7 @@ The trust system is split into two layers with distinct responsibilities:
 - All humans are welcome, even untrustworthy ones. An untrustworthy human has poor graph position (high distance, low diversity), which limits their scope of impact — but they are never expelled from the platform for being untrustworthy.
 - The trust engine computes graph metrics (distance, diversity, endorsement budget) and publishes them. It does not make access decisions.
 
-**Platform trust governs:** endorsement slot count, daily action budget, and participation in the identity/trust network itself. (Slot and budget specifics are defined in ADR-020 and ADR-021, both currently Proposed.)
+**Platform trust governs:** endorsement slot count, daily action budget, and participation in the identity/trust network itself. (Slot and budget specifics are defined in ADR-020 and ADR-021; ADR-021 is currently Proposed.)
 
 ### Layer 2: Communication Permission (Rooms)
 

--- a/docs/decisions/020-reputation-scarcity.md
+++ b/docs/decisions/020-reputation-scarcity.md
@@ -1,7 +1,7 @@
 # ADR-020: Reputation Scarcity — Endorsement Slots and Action Budgets
 
 ## Status
-Proposed
+Accepted (2026-03-13)
 
 ## Context
 
@@ -21,9 +21,8 @@ For a friends-and-family demo where the "aha moment" is endorsement scarcity, us
 
 Each user has a fixed number of **endorsement slots** (k). Each active trust edge (non-revoked endorsement) occupies one slot.
 
-- **Demo value:** k = 3 (tight budget forces deliberate allocation).
-- **Production default:** k = 5 (subject to calibration from observed behavior).
-- **Display:** "2 of 3 endorsements used" — immediately comprehensible.
+- **Slot count:** k = 10. Updated from k=3/k=5 based on scale simulation findings (PR #684). k=10 balances endorsement capacity against graph density at target scales.
+- **Display:** "2 of 10 endorsements used" — immediately comprehensible.
 
 When all slots are occupied, the user must revoke an existing endorsement before creating a new one. There is no partial-strength endorsement — a slot is either used or available.
 
@@ -61,7 +60,7 @@ This will be a separate ADR when the model solidifies, likely informed by the re
 
 Users have a small, finite denouncement budget (d = 2). Filing a denouncement consumes one slot permanently (non-refundable). This prevents spam-flagging while allowing genuine concerns to be raised.
 
-Denouncements are recorded but **do not currently affect trust graph traversal**. The future penalty system will be designed separately.
+The mechanism for how denouncements affect the trust graph is defined in ADR-024 (denouncer-only edge revocation).
 
 ## Consequences
 

--- a/docs/decisions/024-denouncement-mechanism.md
+++ b/docs/decisions/024-denouncement-mechanism.md
@@ -1,7 +1,7 @@
 # ADR-024: Denouncement Mechanism — Denouncer-Only Edge Revocation
 
 ## Status
-Draft
+Accepted (2026-03-13)
 
 ## Context
 
@@ -55,7 +55,7 @@ This is a substantial design problem and will be addressed in a separate ADR whe
 
 ### Neutral
 - ADR-020's denouncement budget (d=2) works naturally with this mechanism: each denouncement costs 1 budget and revokes 1 edge.
-- The simulation harness should add `apply_denouncer_revocation(denouncer, target)` to validate effectiveness against adversarial topologies.
+- The simulation harness validates denouncer-only revocation across 31 adversarial scenarios (PR #678).
 
 ## Alternatives considered
 

--- a/docs/decisions/025-trust-edge-time-decay.md
+++ b/docs/decisions/025-trust-edge-time-decay.md
@@ -1,7 +1,7 @@
 # ADR-025: Trust Edge Time Decay
 
 ## Status
-Draft
+Accepted (2026-03-13)
 
 ## Context
 
@@ -23,12 +23,12 @@ The commitment is that time decay is a required property of the trust graph, not
 
 ### Open design questions
 
-These will be resolved by simulation experiments and documented in an update to this ADR:
+These were resolved by simulation experiments (PR #679):
 
-1. **Decay function.** Linear, exponential, or step-function (e.g., weight halves after 1 year without interaction). The choice affects how aggressively the graph prunes.
-2. **Renewal mechanism.** How a user resets the decay clock — re-performing the swap, a lightweight confirmation ("I still vouch for this person"), or automatic renewal on interaction. The UX cost of renewal determines how many edges survive long-term.
-3. **Slot interaction.** A fully decayed endorsement still occupies a slot. Options: require explicit revocation to free the slot, or auto-release below a weight floor. Auto-release is simpler for users but changes topology without explicit action.
-4. **Engine integration.** Decay could be applied at query time (effective_weight = weight × decay_factor(age)) or via periodic batch reconciliation (ADR-021). Query-time is more accurate; batch is simpler and aligns with existing reconciliation infrastructure.
+1. **Decay function.** Step function: weight is 1.0 at creation, drops to 0.5 at 1 year without renewal, and drops to 0.0 at 2 years. This provides a clear, predictable degradation timeline.
+2. **Renewal mechanism.** Re-swap (re-performing the handshake resets the decay clock and can upgrade the weight, e.g., text→QR as trust deepens). No new UX needed — the existing swap flow handles it.
+3. **Slot interaction.** Auto-release below weight 0.05 (fully decayed edges release the slot). This simplifies the user experience by not requiring explicit revocation of dead edges.
+4. **Engine integration.** Batch reconciliation (ADR-021 reconciliation cycle). Simpler than query-time decay and aligns with existing reconciliation infrastructure.
 
 ### Simulation deliverable
 
@@ -47,12 +47,12 @@ The simulation harness should produce a developer-targeted document covering:
 
 ### Negative
 - **Renewal burden.** Users must periodically confirm endorsements or lose them. If renewal is too costly, legitimate edges decay and the graph becomes sparse.
-- **Complexity.** Adds a temporal dimension to every trust computation. Must decide between query-time decay (accurate, slower) and batch decay (simpler, stale between reconciliation runs).
+- **Complexity.** Adds a temporal dimension to every trust computation. Batch decay was chosen (ADR-021 reconciliation cycle) over query-time decay.
 - **Edge cases.** A user whose endorsers all go inactive could lose trust standing through no fault of their own.
 
 ### Neutral
-- Interacts with ADR-023's weight model: decay modifies effective weight over time, adding a third dimension beyond swap method and relationship depth.
-- May influence denouncement propagation design: if Alice's endorsement of Bob has mostly decayed, should she still be penalized when Bob is denounced?
+- Interacts with ADR-023's weight model: the step function applies a decay multiplier to the base weight (swap method × relationship depth). At 1 year the effective weight is 0.5× the base; at 2 years the edge is removed entirely.
+- Interacts with ADR-024's denouncement cascade: if Alice's endorsement of Bob has decayed below 0.05 (auto-released), she no longer holds an edge to Bob and would not be penalized when Bob is denounced.
 
 ## References
 - [ADR-024: Denouncement mechanism](024-denouncement-mechanism.md) — denouncer-only revocation as baseline


### PR DESCRIPTION
## Summary

Promotes three trust ADRs from Draft/Proposed to Accepted, and fixes cross-references across related ADRs. All decisions were already made and validated by simulation — this is a housekeeping commit to align the ADR files with the current state.

### ADR-020 (Reputation Scarcity)
- Status: Proposed → Accepted (2026-03-13)
- k values: k=3 (demo) / k=5 (prod) → k=10, with rationale from scale simulation (PR #684)
- Line 64: denouncement placeholder → forward reference to ADR-024

### ADR-024 (Denouncement Mechanism)
- Status: Draft → Accepted (2026-03-13)
- Neutral section: future tense ("should add") → past tense validating 31 adversarial scenarios (PR #678)

### ADR-025 (Trust Edge Time Decay)
- Status: Draft → Accepted (2026-03-13)
- Open design questions: filled in all 4 resolved answers (step function decay, re-swap renewal, auto-release at 0.05, batch reconciliation)
- Negative consequences: "must decide" → "batch decay was chosen"
- Neutral section: concrete ADR-023 multiplier description and ADR-024 cascade interaction

### ADR-017 (Two-Layer Trust Architecture)
- Fixed stale parenthetical: "(both currently Proposed)" → "(ADR-021 is currently Proposed)"

### ADR-008 (Account-Based Verifiers)
- Added ADR-017 cross-reference to References section

## No code changes

All changes are documentation only. No API surface, migration, or logic was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)