### PR TITLE
docs: file trust architecture ADRs (026-031)

### DIFF
--- a/docs/decisions/019-trust-engine-computation.md
+++ b/docs/decisions/019-trust-engine-computation.md
@@ -3,6 +3,8 @@
 ## Status
 Accepted
 
+**Amended 2026-03-16 (ADR-028):** Path diversity computation replaced. The original `COUNT(DISTINCT endorser_id)` approximation has been superseded by exact vertex-disjoint path count via Edmonds-Karp max-flow (PR #652). The approximation was exploitable: a colluding ring of 6 nodes scored diversity=6 under the old formula but diversity=1 under exact vertex connectivity. The `diversity = bridge_count` security reduction (ADR-030, proven in scale simulation PR #684) depends on the exact max-flow formulation.
+
 ## Context
 
 The trust graph needs two quantitative metrics to gate participation: a measure of *how close* someone is to known-trusted identities (depth), and a measure of *how independently verified* they are (width). Together these form the composite trust score.
@@ -61,24 +63,16 @@ GROUP BY user_id;
 
 Path diversity measures how many independent social circles vouch for a person. It answers: "if one branch of the trust graph is compromised, does this person still have a path to the anchor?"
 
-**Approximation (not exact max-flow):** For each target user, count the number of distinct active endorsers who are themselves reachable from the anchor:
+**Exact vertex-disjoint path count via Edmonds-Karp max-flow.** For each target user, compute the maximum number of vertex-disjoint paths from the anchor using the standard vertex-split construction: each node (except source and sink) is split into an in-node and out-node connected by a capacity-1 edge. Edmonds-Karp finds the maximum flow, which equals the number of vertex-disjoint paths by Menger's theorem.
 
-```sql
-SELECT
-    e.subject_id AS user_id,
-    COUNT(DISTINCT e.endorser_id)::int AS path_diversity
-FROM reputation__endorsements e
-WHERE e.revoked_at IS NULL
-  AND e.endorser_id IS NOT NULL
-  AND e.endorser_id = ANY(:reachable_user_ids)
-GROUP BY e.subject_id;
-```
+This is computed in-memory by `FlowGraph` in the trust engine:
+1. Build the flow graph from all active (non-revoked) endorsement edges.
+2. Apply vertex splitting so that each intermediate node can appear on at most one path.
+3. Run Edmonds-Karp to find max-flow from anchor to each target.
 
-This is a two-step process:
-1. Run `compute_distances_from(anchor)` to get the reachable set.
-2. For each user, count distinct endorsers within that reachable set.
+**Sybil-resistance property:** The vertex-disjoint formulation provides the `diversity = bridge_count` security reduction (ADR-030). A Sybil mesh of N fake nodes with dense internal endorsements achieves diversity exactly equal to the number of bridge nodes on independent paths from anchor — internal mesh endorsements cannot inflate the count. A colluding ring of 6 nodes with a single attachment point scores diversity=1 regardless of internal connectivity.
 
-**Sybil-resistance property:** A hub-and-spoke attacker who routes N endorsements through a single node gives each target `diversity = 1`. A user endorsed by K independent reachable nodes gets `diversity = K`. This is intentionally an approximation — true edge-disjoint path counting requires max-flow computation, which is prohibitive at scale and unnecessary at demo scale.
+**Superseded approximation:** The original implementation used `COUNT(DISTINCT endorser_id)` — counting distinct active endorsers reachable from the anchor. This approximation was exploitable: a colluding ring of 6 nodes where each endorses the next scored diversity=6 under the old formula (6 distinct endorsers) but diversity=1 under exact vertex connectivity (single attachment point). Replaced in PR #652 (fixes #648).
 
 ### Composite Trust Score
 
@@ -109,12 +103,12 @@ A placeholder exists for eigenvector centrality as a global (non-anchor-relative
 ### Positive
 - The CTE runs entirely in PostgreSQL — no external graph database needed.
 - The `1/weight` cost function creates a natural penalty for low-quality edges. Social referral chains are expensive; physical QR chains are cheap.
-- The diversity approximation is O(E) where E is the edge count in the reachable subgraph — tractable for demo scale.
+- The exact vertex-disjoint path count provides the `diversity = bridge_count` security reduction — a clean, auditable Sybil resistance claim (ADR-030).
 - Materialized scores make room eligibility checks a simple table lookup.
 
 ### Negative
 - The recursive CTE explores all paths up to distance 10.0, which can be expensive on dense graphs. The 10.0 cutoff is a tuning parameter that trades accuracy for performance.
-- The diversity approximation can overcount in some topologies (a user with two endorsers who share an upstream path gets diversity 2, even though the paths aren't truly independent). For demo scale this is acceptable.
+- The `FlowGraph` for max-flow uses a dense O(n^2) adjacency matrix. At 1k nodes this is ~4MB; at 5k it hits ~100MB. A sparse Edmonds-Karp implementation has been proven equivalent in simulation tests and needs to be ported to the engine (#681).
 - Anchor-scoped recomputation means Alice's view of the graph may disagree with Bob's view until both anchors are recomputed. The batch model resolves this by recomputing all anchors together.
 
 ### Neutral
@@ -131,9 +125,9 @@ A placeholder exists for eigenvector centrality as a global (non-anchor-relative
 - Load the graph into memory, compute paths in Rust.
 - Rejected because it duplicates state (graph in both DB and memory), requires synchronization, and the PostgreSQL CTE already expresses the algorithm correctly.
 
-### Exact edge-disjoint paths (max-flow)
-- Computes the true number of independent paths between two nodes.
-- Rejected for MVP due to computational cost (max-flow is O(V * E^2) in the general case). The distinct-endorser approximation provides adequate Sybil resistance at demo scale.
+### Distinct-endorser count approximation (superseded)
+- The original diversity implementation: `COUNT(DISTINCT endorser_id)` for each user's active endorsers reachable from anchor.
+- Superseded by exact vertex-disjoint max-flow in PR #652. The approximation was exploitable: colluding rings and dense Sybil clusters scored artificially high diversity because distinct endorsers do not imply distinct paths. The security reduction `diversity = bridge_count` (ADR-030) requires the exact formulation.
 
 ## References
 - [ADR-008: Account-based verifiers](008-account-based-verifiers.md) — verifier endorsements populate the same table the CTE traverses
@@ -141,6 +135,9 @@ A placeholder exists for eigenvector centrality as a global (non-anchor-relative
 - [ADR-018: Handshake protocol](018-handshake-protocol.md) — how edges are created and weighted
 - [ADR-020: Reputation scarcity](020-reputation-scarcity.md) — trust scores may influence slot allocation
 - [ADR-021: Batch reconciliation](021-batch-reconciliation.md) — when scores are recomputed
+- [ADR-030: Sybil resistance security reduction](030-sybil-resistance-security-reduction.md) — `diversity = bridge_count` proven from the vertex-disjoint formulation
 - `service/src/trust/engine.rs` — `compute_distances_from`, `compute_diversity_from`, `recompute_from_anchor`
 - `service/src/trust/repo/scores.rs` — `upsert_score`, `get_score`, `get_all_scores`
+- PR #652: Replaced endorser-count approximation with exact vertex connectivity (fixes #648)
+- PR #684: Scale simulation proving `diversity = bridge_count` across 1-5 bridge scenarios
 - TRD §3 (The Trust Engine) — original specification

--- a/docs/decisions/024-denouncement-mechanism.md
+++ b/docs/decisions/024-denouncement-mechanism.md
@@ -1,7 +1,9 @@
 # ADR-024: Denouncement Mechanism — Denouncer-Only Edge Revocation
 
 ## Status
-Draft
+Accepted (2026-03-13)
+
+**Expanded 2026-03-16 (ADR-029):** Added Propagation section documenting the one-hop cascade parameters, penalty operating point, and loss function bias. These were validated by simulation sweep across all adversarial topologies (PR #678).
 
 ## Context
 
@@ -41,17 +43,44 @@ Full disconnection (revoking all edges) or slashing is too consequential for an 
 
 This is a substantial design problem and will be addressed in a separate ADR when the governance model is designed.
 
+## Propagation (Sponsorship Cascade)
+
+Endorsing someone who later gets denounced carries consequences. This is the "sponsorship risk" principle from ADR-020: you stake your reputation when you vouch for someone.
+
+### One-hop cascade only.
+
+When user B is denounced, B's endorsers (users who endorsed B) receive a penalty. The cascade does not propagate further — a denouncement against Bob penalizes Alice (who endorsed Bob) but not Carol (who endorsed Alice). This was tested explicitly; no propagation occurs beyond direct endorsers.
+
+### Fixed penalty: 2.0 distance / -1 diversity.
+
+Endorsers of a denounced user receive a +2.0 distance penalty and -1 diversity reduction. This is lighter than the primary denouncement effect (edge revocation removes a full path) and represents the cost of poor judgment in endorsement, not direct complicity.
+
+### Operating point selected via sweep.
+
+A penalty sweep from 1.0 through 4.0 was run against all adversarial topologies (hub-and-spoke Sybil, mercenary bot network, colluding ring). Higher penalty values increase blue casualties (legitimate users caught in cascade) without meaningfully improving red blocking. The 2.0/-1 point minimizes the loss function: bad actors reliably lose eligibility while legitimate users caught in cascade retain a remediation path (seek a fresh endorsement from someone who actually knows them).
+
+### Loss function bias: false negatives >> false positives.
+
+The tuning bias is defensive. False negatives (bad actors retaining eligibility) are weighted much more costly than false positives (legitimate users temporarily downgraded). Rationale: early in the network, real-world consequences of being temporarily downgraded are minimal, and the remediation path is organic. Cascade collateral (e.g., 1/7 blue nodes in the mercenary scenario) is acceptable under this bias.
+
+This asymmetry should narrow as the network matures and trust status carries real-world weight — the threshold shifts toward due process at scale.
+
+### Circular cascade safety.
+
+Tested on ring topology A->B->C->A. No runaway penalty accumulation. The engine does not follow cycles — each node is visited once per anchor computation.
+
 ## Consequences
 
 ### Positive
 - **Non-weaponizable.** A single malicious actor can only revoke their own edge — no way to disconnect a legitimate user.
 - **Proportionate.** The response scales with the number of independent denouncers, not with any single actor's influence.
 - **Simple.** No score mutations, no cascade logic, no threshold parameters to tune. A denouncement is a revocation.
-- **Composable.** Denouncement propagation (endorsers of denounced users suffer consequences) can layer on top of this baseline without changing the core mechanism.
+- **Composable.** Denouncement propagation (one-hop cascade, documented above) layers on top of this baseline without changing the core mechanism.
 
 ### Negative
 - **May be too soft.** If a bad actor has many endorsers, losing one edge doesn't meaningfully degrade their scores. They remain reachable and potentially eligible. Mitigated by: time decay will naturally erode stale edges; denouncement propagation will penalize endorsers; adjudication handles severe cases.
-- **Requires complementary mechanisms.** Denouncer-only revocation alone won't remove a well-connected bad actor. It depends on time decay, propagation, and adjudication to complete the picture. This ADR is one layer, not the whole system.
+- **Requires complementary mechanisms.** Denouncer-only revocation alone won't remove a well-connected bad actor. It composes with the one-hop cascade (documented above), time decay (ADR-025), and adjudication (future work) to complete the picture.
+- **Cascade produces collateral.** The one-hop penalty affects legitimate endorsers of a denounced user. In the mercenary scenario, 1/7 blue nodes are temporarily affected. The loss function bias accepts this trade-off — remediation via fresh endorsement is available.
 
 ### Neutral
 - ADR-020's denouncement budget (d=2) works naturally with this mechanism: each denouncement costs 1 budget and revokes 1 edge.
@@ -81,5 +110,9 @@ Not rejected but reframed: the "right" version of this is adjudication with gove
 - [ADR-020: Reputation scarcity](020-reputation-scarcity.md) — denouncement budget (d=2)
 - [ADR-023: Fixed slots with variable weight](023-fixed-slot-variable-weight.md) — slot model for endorsements
 - [ADR-019: Trust engine computation](019-trust-engine-computation.md) — distance/diversity scoring
+- [ADR-025: Trust edge time decay](025-trust-edge-time-decay.md) — complementary passive Sybil resistance
 - [GitHub #624: Trust graph simulation](https://github.com/icook/tiny-congress/issues/624) — adversarial topology testing
 - PR #643: Simulation harness with mechanism comparison framework
+- PR #678: Adversarial simulation suite — 31 scenarios, mechanism comparison, penalty sweep
+- `.plan/2026-03-13-trust-robustness-overview.md` — section 3c (cascade parameters and loss function)
+- `.plan/2026-03-13-open-questions.md` — Q16-Q19 (denouncement propagation)

--- a/docs/decisions/026-anchor-relative-scoring.md
+++ b/docs/decisions/026-anchor-relative-scoring.md
@@ -1,0 +1,74 @@
+# ADR-026: Anchor-Relative Scoring for Trust Eligibility; Global Algorithms Rejected
+
+## Status
+Accepted (2026-03-16)
+
+## Context
+
+The trust engine uses anchor-relative scoring: all trust is measured from a single "anchor" node via two metrics — distance (weighted shortest path via Dijkstra) and diversity (vertex-disjoint path count via Edmonds-Karp max-flow). This design has a clean security reduction (`diversity = bridge_count`) but creates structural dependence on the anchor.
+
+The question was whether anchor-free global algorithms — EigenTrust and PageRank — could replace or supplement anchor-relative scoring for trust eligibility. Both compute reputation from graph structure alone, with no distinguished root node. If viable, they would eliminate the single-point-of-failure concern inherent to any anchor-based design.
+
+A spike (2026-03-13, branch `test/680-scale-simulation-framework`) implemented both algorithms and tested them against adversarial topologies using the simulation harness.
+
+### Spike results
+
+| Scenario | Anchor-relative separation | EigenTrust/PageRank separation |
+|---|---|---|
+| Sybil mesh, 1 bridge (20 fake nodes) | **1.36x** (blue closer to anchor) | **0.95x** (Sybils score HIGHER) |
+| Sybil mesh, 2 bridges | **1.36x** | **0.94x** (Sybils score HIGHER) |
+| Sybil mesh, 5 bridges | — | **0.83x** (Sybils score 1.21x HIGHER) |
+| Colluding ring (6 nodes, circular endorsements) | **5.4x** | **0.68x** (ring inflates scores 1.46x) |
+
+EigenTrust alpha sensitivity (2-bridge Sybil, varying pretrust blend):
+
+| Alpha | Separation (blue/red) | Interpretation |
+|---|---|---|
+| 0.05 (graph-driven) | 0.78x (Sybils win) | More graph influence = worse Sybil detection |
+| 0.15 (default) | 0.94x (Sybils win) | Default EigenTrust parameter — still fails |
+| 0.30 | 1.01x (near parity) | Pretrust starts dominating |
+| 0.50 (pretrust-driven) | 1.04x (slight blue edge) | Algorithm adds almost no value over uniform |
+
+## Decision
+
+### Anchor-free global scoring cannot be used for trust eligibility.
+
+EigenTrust and PageRank answer "how connected are you to well-connected nodes?" Sybil meshes are by construction densely connected — every fake node endorses every other fake node. The algorithms cannot distinguish "endorsed by many real people" from "endorsed by many fake people endorsing each other."
+
+**Circular endorsement amplification:** A colluding ring (A->B->C->D->E->F->A) creates a trust feedback loop. Each iteration amplifies ring members' scores. In testing, ring members scored 1.46x higher than legitimate nodes.
+
+**The alpha dilemma:** EigenTrust's pretrust parameter controls weight given to the trusted seed set vs. graph structure. Low alpha (graph-driven) lets Sybils exploit dense connectivity. High alpha (pretrust-driven) converges to uniform scores, adding no value. There is no sweet spot where graph structure alone correctly identifies Sybils without a trusted reference.
+
+**The anchor breaks this symmetry.** Anchor-relative scoring works because trust must originate from the anchor and flow outward through real endorsements. Self-reinforcing loops do not create new paths from the anchor. The anchor provides an external reference point that circular structures cannot game.
+
+### EigenTrust/PageRank retain value ONLY for anomaly detection.
+
+The spike revealed a valid use case: topology shift monitoring. A sudden change in a node's PageRank indicates a topology shift — useful for detecting compromised accounts or Sybil cluster formation — even if the absolute score does not reliably separate real from fake. Relative changes over time are meaningful; absolute values are not.
+
+Recommended use: nightly batch anomaly detection, not eligibility scoring.
+
+### Computational feasibility is not the constraint.
+
+At 100k users with k=10 endorsement slots, the entire graph is ~16 MB. EigenTrust (258ms at 1k nodes) and PageRank (316ms at 1k nodes) are trivially fast. The problem is not performance — it is that the algorithms produce the wrong answer for Sybil detection.
+
+## Consequences
+
+### Positive
+- **Eliminates a class of design mistakes.** Future proposals to "add PageRank for eligibility" can be rejected by reference to this ADR and the empirical data.
+- **Clarifies the anchor's role.** The anchor is not an arbitrary design choice — it provides a security property (symmetry-breaking) that global algorithms cannot replicate.
+- **Preserves anomaly detection as a valid future capability.** Reframing EigenTrust/PageRank as anomaly detectors (not eligibility scorers) keeps them in the toolkit for operational security at scale.
+
+### Negative
+- **The anchor remains a single point of failure.** This ADR accepts that anchor-relative scoring is necessary, which means the genesis-drop concern and anchor compromise risk (red team A5) persist. These are addressed by ADR-027 (founder as anchor at launch, multi-anchor migration at scale).
+- **Anomaly detection is deferred work.** The valid use case (topology shift monitoring) is identified but not implemented.
+
+### Neutral
+- The spike's negative result is itself valuable — it empirically constrains the solution space for future trust scoring proposals.
+- EigenTrust/PageRank may compose with anchor-relative scoring as supplementary signals for graph health monitoring (Tier 3+ work).
+
+## References
+- [ADR-019: Trust engine computation](019-trust-engine-computation.md) — anchor-relative distance and diversity
+- [ADR-027: Founder as trust anchor](027-founder-trust-anchor.md) — addresses the anchor's single-point-of-failure
+- `.plan/2026-03-13-anchor-problem-statement.md` — full spike analysis with data tables and root cause
+- `.plan/2026-03-13-trust-expansion-concepts.md` — reframing of EigenTrust/PageRank as anomaly detection
+- PR #684: Scale simulation framework (branch `test/680-scale-simulation-framework`)

--- a/docs/decisions/027-founder-trust-anchor.md
+++ b/docs/decisions/027-founder-trust-anchor.md
@@ -1,0 +1,68 @@
+# ADR-027: Founder as Trust Anchor at Launch; Multi-Anchor Migration at Tier 3+
+
+## Status
+Accepted (2026-03-16)
+
+## Context
+
+The trust engine computes all scores relative to a single anchor node (ADR-019). ADR-026 established that this anchor is a necessary security property — anchor-free global algorithms (EigenTrust, PageRank) fail at Sybil detection. The anchor provides the symmetry-breaking reference point that prevents self-reinforcing trust loops from gaming eligibility.
+
+This creates a structural question: who is the anchor, and what happens if the anchor is compromised?
+
+At launch scale (demo, ~100 users), the platform creator is bootstrapping the trust graph from their personal network. Every trust network — PGP, BrightID, real-world social networks — starts from a founder's personal connections. The anchor is not "unearned structural privilege"; it is the inevitable shape of a new trust graph.
+
+At scale (~10k+ users), the founder cannot personally vouch for the network's integrity. The structural advantage becomes politically significant, and anchor compromise (red team A5) becomes a distinct threat vector rather than a special case of account compromise (A2).
+
+BrightID's experience validates this sequencing: attempting to decentralize trust governance before a user base exists creates more problems than it solves.
+
+## Decision
+
+### At launch, the founder's account is the trust anchor.
+
+This is accepted and pragmatic. Concretely:
+
+- Anchor = founder account. Anchor compromise = founder account compromise (red team A2, not a separate threat vector).
+- The "single point of failure" risk is bounded by the small user base — at demo scale, the founder personally knows most participants.
+- The genesis-drop concern (one node's position is structural, not earned) becomes real only if/when platform participation carries material value AND the founder's structural advantage persists without accountability. At demo scale, neither condition holds.
+
+### Multi-anchor migration is deferred to Tier 3+ (~10k users).
+
+When the network is large enough that the founder does not personally know most participants, the anchor should transition to a distributed model. The solution space (evaluated but not selected):
+
+1. **Multi-anchor with consensus.** Compute anchor-relative scores from N independent anchors. Require agreement (intersection, minimum, or weighted combination). Preserves the `diversity = bridge_count` security reduction while distributing the point of failure. Open questions: anchor selection, disagreement handling, quorum size.
+
+2. **Personalized PageRank (PPR).** PPR computes PageRank relative to a specific "teleport" node — essentially anchor-relative PageRank. Used by SybilRank for Sybil detection. Retains the anchor's symmetry-breaking property while computing a smoother score than shortest-path distance. Open question: whether this offers genuinely different properties or is just "better anchor-relative scoring."
+
+3. **Distributed / rotating anchor.** Keep anchor-relative scoring but make the anchor a governance role: rotatable, electable, or distributed. Open questions: score stability during rotation, migration path when anchor changes.
+
+4. **Community detection hybrid.** Use graph clustering (Louvain, spectral) to identify communities, then detect the "attack edge" between real communities and Sybil clusters as a supplementary signal. Open question: whether community detection can replace the anchor or is only a heuristic.
+
+### Identity verification is a separate concern.
+
+The anchor problem applies to the trust graph — who vouches for whom. Identity verification (proving unique humanity) is orthogonal: it is a node property (verified by which verifiers), not a graph edge. Verifiers confirm facts; they do not have a trust relationship. See ADR-031 for how verifiers participate in the graph.
+
+## Consequences
+
+### Positive
+- **Unblocks launch.** No need to solve the multi-anchor problem before shipping the demo.
+- **Honest about bootstrapping.** Acknowledges that every trust network starts from a founder, rather than pretending otherwise.
+- **Bounded risk.** At demo scale, the attack surface is small enough that mechanism security alone is sufficient — operational security is not yet needed.
+- **Clear migration trigger.** The transition criterion is concrete: when the founder does not personally know most participants (~10k users).
+
+### Negative
+- **Single point of failure persists.** Founder account compromise at launch = total trust graph compromise. Mitigated by: the founder presumably has strong key management, and at demo scale the impact is bounded.
+- **No rotation procedure exists.** If the founder needs to be replaced (voluntary or involuntary), there is no defined process. This is acceptable at launch but becomes a gap at scale.
+- **Philosophical tension.** "The server is a dumb witness, not a trusted authority" — but the anchor IS the ultimate trusted authority. This tension is acknowledged, not resolved. Resolution requires the multi-anchor migration.
+
+### Neutral
+- The anchor question reframes from "remove the anchor" (impossible per ADR-026) to "make the anchor more accountable and redundant" — a governance problem, not an algorithm problem.
+- At demo scale, anchor = founder is operationally simpler than any distributed alternative.
+
+## References
+- [ADR-019: Trust engine computation](019-trust-engine-computation.md) — anchor-relative scoring mechanism
+- [ADR-026: Anchor-relative scoring](026-anchor-relative-scoring.md) — why anchor-free alternatives fail
+- [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — platform trust layer that the anchor serves
+- `.plan/2026-03-13-anchor-problem-statement.md` — launch decision, solution space, and BrightID precedent
+- `.plan/2026-03-13-open-questions.md` — Q28 (anchor redundancy), Q29 (anchor-free scoring)
+- `.plan/2026-03-13-red-team-threat-model.md` — A5 (anchor compromise)
+- `.plan/2026-03-13-scale-readiness-matrix.md` — Tier 3 gate: multi-anchor migration evaluated

--- a/docs/decisions/030-sybil-resistance-security-reduction.md
+++ b/docs/decisions/030-sybil-resistance-security-reduction.md
@@ -1,0 +1,69 @@
+# ADR-030: Sybil Resistance Security Reduction — diversity = bridge_count
+
+## Status
+Accepted (2026-03-16)
+
+## Context
+
+The trust engine's diversity metric counts vertex-disjoint paths from the anchor to each user via Edmonds-Karp max-flow (ADR-019, as amended). The eligibility threshold requires diversity >= 2, meaning at least two independent paths from the anchor must exist. The question is: what does this threshold actually guarantee against a Sybil attacker?
+
+The scale simulation framework (PR #684) tested Sybil mesh topologies across multiple bridge counts (1, 2, 3, and 5 bridges) to determine whether internal mesh endorsements (fake-to-fake) can inflate the diversity score.
+
+### Simulation evidence
+
+Sybil mesh topology: N fake nodes (tested with 20) forming a fully-connected internal mesh, attached to the legitimate graph through B bridge nodes on vertex-disjoint paths from the anchor.
+
+| Bridges | Mesh diversity (all members) | Internal edges present | Diversity inflated? |
+|---|---|---|---|
+| 1 bridge | diversity = 1 | Yes (20 nodes, ~190 edges) | **No** |
+| 2 bridges | diversity = 2 | Yes | **No** |
+| 3 bridges | diversity = 3 | Yes | **No** |
+| 5 bridges | diversity = 5 | Yes | **No** |
+
+In every case, mesh members' diversity equals exactly the number of bridge nodes, regardless of how many internal fake-to-fake endorsements exist. A colluding ring of 6 nodes with circular endorsements also scored diversity = 1 (single attachment point), despite the dense internal connectivity.
+
+The max-weight Sybil test (all internal edges at weight 1.0) confirmed: diversity = 1 regardless of weight magnitude. Weight affects distance but not the diversity metric's path-independence counting.
+
+## Decision
+
+### The core security claim: diversity = bridge_count.
+
+Sybil mesh members achieve diversity exactly equal to the number of bridge nodes on vertex-disjoint paths from the anchor. Internal mesh endorsements cannot inflate diversity. This is a direct consequence of the vertex-disjoint path formulation: every independent path from anchor to a mesh node must pass through a distinct bridge node, and no amount of internal mesh connectivity can create a new path that does not pass through an existing bridge.
+
+### Sybil resistance reduces to bridge compromise cost.
+
+The practical security question becomes: "how hard is it to compromise 2+ accounts on genuinely independent paths from the anchor?" This is the attacker's minimum cost to get any Sybil identity past the diversity >= 2 threshold. The cost depends on:
+
+- **Population size.** If willingness to sell/compromise an endorsement is normally distributed, the cheapest 2 accounts on independent paths get cheaper as N grows.
+- **Attack vector.** Social engineering the endorsement ceremony (red team A3) requires physical copresence per bridge. Account takeover (A2) bypasses the ceremony entirely but requires credential compromise.
+- **Slot budget constraint.** Each bridge can endorse at most k=10 mesh nodes directly (ADR-020). Mesh-internal endorsements can extend reach beyond direct bridge connections.
+
+### What this reduction does NOT guarantee.
+
+The mechanism math is sound — `diversity = bridge_count` holds at any scale. But the *cost* of compromising bridge accounts decreases with population. Account takeover (A2) bypasses the endorsement ceremony entirely: the attacker inherits an already-endorsed account's full graph position. The reduction proves the mechanism works; operational security (detection, response, heuristics) determines whether the mechanism is sufficient.
+
+## Consequences
+
+### Positive
+- **Clean, auditable security claim.** The system's Sybil resistance can be stated precisely: "an attacker needs B compromised accounts on independent paths to create Sybil identities with diversity = B." No hand-waving about "approximately resistant."
+- **Formally reasoned about.** The claim follows from Menger's theorem applied to the vertex-split graph construction in the max-flow computation. It is testable, falsifiable, and has been empirically verified across multiple mesh sizes and bridge counts.
+- **Bounds the attacker's problem.** Internal mesh operations (creating fake accounts, fake-to-fake endorsements) do not help. Only bridge acquisition matters. This simplifies both the defender's mental model and the attacker's cost analysis.
+
+### Negative
+- **The per-bridge cost decreases with scale.** At 100k users, the tail of the willingness-to-compromise distribution gets cheaper. The diversity threshold sets *how many* bridges are needed but not the *per-unit cost*. This is addressed by heuristic detection (Tier 3+ work).
+- **Account compromise bypasses the endorsement ceremony.** The reduction assumes bridges are acquired through the endorsement process. Account takeover skips this entirely — the compromised account IS a legitimate bridge. Detection requires behavioral/temporal analysis, not graph structure.
+- **Single bridge count = N Sybils.** Once an attacker acquires B >= 2 bridges, they can create an arbitrarily large number of Sybil identities that all achieve diversity = B (bounded by k=10 direct endorsements per bridge, extended through mesh-internal paths). The slot budget limits per-bridge fanout but not mesh-internal propagation.
+
+### Neutral
+- The reduction composes with all other trust mechanisms: denouncement (ADR-024) can remove bridge edges, time decay (ADR-025) forces bridge renewal, slot budget (ADR-020) limits per-bridge fanout.
+- The reduction is independent of edge weights — diversity counts paths, not their weights.
+
+## References
+- [ADR-019: Trust engine computation](019-trust-engine-computation.md) — vertex-disjoint max-flow (as amended by ADR-028)
+- [ADR-020: Reputation scarcity](020-reputation-scarcity.md) — slot budget k=10 bounding bridge fanout
+- [ADR-023: Fixed slots with variable weight](023-fixed-slot-variable-weight.md) — weight independence confirmed
+- `.plan/2026-03-13-trust-robustness-overview.md` — "Key scale insight" section
+- `.plan/2026-03-13-red-team-threat-model.md` — A4 (Sybil mesh with purchased bridges)
+- `.plan/2026-03-13-scale-readiness-matrix.md` — Tier 1 gate: diversity = bridge_count proven
+- PR #684: Scale simulation framework (Sybil mesh analysis across 1-5 bridge scenarios)
+- PR #652: Diversity fix replacing endorser-count approximation with exact vertex connectivity

--- a/docs/decisions/031-identity-verification-graph-participation.md
+++ b/docs/decisions/031-identity-verification-graph-participation.md
@@ -1,0 +1,70 @@
+# ADR-031: Identity Verification as Graph Participation
+
+## Status
+Accepted (2026-03-16)
+
+## Context
+
+The trust graph carries an implicit identity signal: when a trusted person endorses someone via QR handshake, they are attesting to both humanity and social trust. As the system grows, external identity verifiers (BrightID, passport services, trusted community organizers at events) will need to participate. The question is: how do verifiers integrate with the trust model?
+
+Two conceptual operations are at play:
+
+- **Identity verification** — proving someone is a unique human. A fact about the person, not a relationship.
+- **Trust endorsement** — vouching for someone. A relationship between two people.
+
+At launch, the QR handshake implicitly conflates both. Separating them becomes necessary before adding external identity providers.
+
+### The slot budget problem
+
+ADR-020 establishes k=10 endorsement slots as a core Sybil defense. A verifier entity that needs to endorse thousands of verified humans cannot operate within k=10. Four options were evaluated:
+
+| Option | Mechanism complexity | Blast radius if compromised | Scales to 10k verified? | Special entity types? |
+|---|---|---|---|---|
+| A. Variable k per entity | Low (one parameter) | High (k=infinity node) | Yes | Yes |
+| B. Light endorsement tier | Medium (new edge tier) | Low (low-weight edges) | Yes | No |
+| C. Multiple k=10 instances | None | Low (k=10 per instance) | Awkward (1000 instances for 10k) | No |
+| D. Room endorsement | Low (reuse rooms) | Medium (room entity) | Yes | Sort of |
+
+## Decision
+
+### Verifiers participate as entities in the trust graph, not as a separate system.
+
+The founder endorses verifier entities with high trust. Verifiers endorse verified humans. Those humans get graph position through the verifier's path from anchor. This is architecturally clean: the security model is unchanged (`diversity = bridge_count` still holds per ADR-030), a compromised verifier only affects paths through that verifier, and the graph does not need to know what a "verifier" is — it just sees edges.
+
+### Identity verification and trust endorsement are distinct operations.
+
+Verifiers confirm facts about a person (unique humanity). Endorsers confirm trust in a person (social vouching). These are different signals with different semantics. The trust graph carries both, but the distinction matters for: weight assignment (verification may warrant a different weight than personal trust), blast radius (a compromised verifier affects identity claims, not personal trust relationships), and future audit (which edges represent personal judgment vs. institutional verification).
+
+### The slot budget problem is deferred; light endorsement tier is the leading option.
+
+Option B (light endorsement tier) is the most aligned with existing design principles: no special entity types, general mechanism available to all users, bounded blast radius from low-weight edges. Everyone would get k=10 full endorsements plus k=N light endorsements (lower weight, e.g., 0.1-0.2). Verifiers use the light tier. This is the same "additional endorsement tiers" concept described in the trust expansion analysis.
+
+Option C (multiple k=10 instances) works naturally when verifiers are humans performing a role at community events — no mechanism changes required, just operational scaling.
+
+The choice depends on whether verifiers are primarily automated services (favors B) or humans performing a role (favors C). This does not need to be resolved before launch because the founder's personal network covers the initial user base.
+
+## Consequences
+
+### Positive
+- **No separate verification layer.** Verifiers use the same graph infrastructure as everyone else. No new tables, no new trust computation, no new API surface.
+- **Security model preserved.** A compromised verifier is just a compromised node — `diversity = bridge_count` still applies. Users verified through a single compromised verifier have diversity contribution only through that verifier's paths.
+- **Graceful degradation.** If a verifier is revoked, only paths through that verifier are affected. Users with endorsements from other sources retain their graph position.
+- **General mechanism.** The light endorsement tier (if chosen) is available to all users, not just verifiers — it also addresses the diversity problem for tight communities where all paths funnel through one bridge.
+
+### Negative
+- **Deferred implementation.** The slot budget solution is identified but not built. This is acceptable at launch scale but becomes a blocker before adding external identity providers.
+- **Conflation at launch.** The QR handshake still conflates identity verification and trust endorsement. Users cannot distinguish "this person is verified as human" from "this person is trusted by their endorser." Acceptable for demo but needs separation before scale.
+- **Light endorsement tier adds complexity.** Two tiers of endorsement (full and light) with different weights and potentially different slot budgets increases the mechanism surface area.
+
+### Neutral
+- ADR-008 (account-based verifiers) already establishes verifier accounts. This ADR clarifies how those accounts participate in the trust graph specifically.
+- The existing weight table (ADR-023) already supports low weights (email = 0.1). A light endorsement tier may be primarily a UX change rather than a mechanism change.
+
+## References
+- [ADR-008: Account-based verifiers](008-account-based-verifiers.md) — verifier account concept
+- [ADR-017: Two-layer trust architecture](017-two-layer-trust-architecture.md) — platform vs. room trust layers
+- [ADR-020: Reputation scarcity](020-reputation-scarcity.md) — slot budget (k=10) and verifier exemption
+- [ADR-030: Sybil resistance security reduction](030-sybil-resistance-security-reduction.md) — diversity = bridge_count holds regardless of verifier design
+- `.plan/2026-03-13-open-questions.md` — Q30 (full analysis with 4 options and trade-off table)
+- `.plan/2026-03-13-anchor-problem-statement.md` — identity verification as separate concern
+- `.plan/2026-03-13-trust-expansion-concepts.md` — additional endorsement tiers concept


### PR DESCRIPTION
## Summary

Graduate trust architecture decisions from `.plan/` design workspace into permanent ADRs. All decisions are backed by simulation evidence from the trust simulation harness.

### New ADRs

- **ADR-026: Anchor-Relative Scoring** — EigenTrust/PageRank cannot be used for trust eligibility; Sybil mesh nodes score equal/higher than legitimate nodes. Anchor provides necessary symmetry-breaking. Global algorithms retained only for anomaly detection.
- **ADR-027: Founder as Trust Anchor** — Founder is the trust root at launch (pragmatic, every trust network bootstraps this way). Multi-anchor migration deferred to Tier 3+ (~10k users).
- **ADR-030: Sybil Resistance Security Reduction** — Core claim: `diversity = bridge_count`. Internal Sybil mesh endorsements cannot inflate diversity. Proven across 1/2/3/5-bridge scenarios.
- **ADR-031: Identity Verification as Graph Participation** — Verifiers participate as entities in the trust graph, not a separate system. Slot budget problem identified; light endorsement tier is the leading option.

### Amendments to existing ADRs

- **ADR-028 (amends ADR-019):** Replace endorser-count approximation with exact vertex-disjoint max-flow. The old `COUNT(DISTINCT endorser_id)` was exploitable (colluding ring scored diversity=6 vs correct diversity=1). References PR #652, ADR-030.
- **ADR-029 (expands ADR-024):** Add Propagation section: one-hop cascade only, 2.0 distance / -1 diversity penalty, circular cascade safe, operating point selected via sweep, loss function biased defensive. Also updates status from Draft to Accepted.

### Source evidence

All decisions trace to simulation results in `.plan/` documents from the design workspace (PR #676) and implementation PRs #652, #678, #679, #684.

## Test plan

- [ ] Verify ADR numbering is sequential (025 -> 026 -> 027 -> ... -> 031)
- [ ] Verify amendments to ADR-019 and ADR-024 are consistent with existing content
- [ ] Verify cross-references between ADRs are correct
- [ ] Verify all simulation data cited matches `.plan/` source documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)