### PR TITLE
fix(ci): use REST /rooms endpoint in smoke test preflight

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -65,11 +65,8 @@ jobs:
 
       - name: Check sim worker — rooms exist
         run: |
-          QUERY='{"query":"{ rooms(first: 1) { edges { node { id } } } }"}'
           RESP=$(curl -sSf --max-time 15 \
-            -H "Content-Type: application/json" \
-            -d "$QUERY" \
-            "${{ steps.urls.outputs.api }}/graphql")
+            "${{ steps.urls.outputs.api }}/rooms")
           echo "Response: $RESP"
           echo "$RESP" | grep -q '"id"' || { echo "No rooms found — sim worker may not be running"; exit 1; }
           echo "Sim worker content verified"


### PR DESCRIPTION
## Summary
- Smoke test preflight was querying GraphQL for `rooms`, which doesn't exist in the schema (GraphQL is `buildInfo`-only per architecture)
- Switched to `GET /rooms` (REST), which is the correct data path

## Root cause
The `rooms` field was never part of the GraphQL schema. Per CLAUDE.md: "GraphQL exists but is a placeholder (`buildInfo` query only). All feature work uses REST."

## Test plan
- [ ] Smoke test preflight "Check sim worker — rooms exist" passes on next master merge

Fixes the smoke test failures since 2026-03-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)