### PR TITLE
fix(e2e): check aria-disabled on slider thumb, not hidden input

### DIFF
--- a/web/tests/e2e/voting.spec.ts
+++ b/web/tests/e2e/voting.spec.ts
@@ -25,8 +25,8 @@ test('unverified user sees verification gate on poll page @smoke', async ({ page
   // Should see verification gate (user is signed up but not verified)
   await expect(page.getByText(/verify your identity/i)).toBeVisible({ timeout: 10_000 });
 
-  // Sliders should be disabled
-  await expect(page.locator('.mantine-Slider-root input').first()).toBeDisabled();
+  // Sliders should be disabled (Mantine v8 sets aria-disabled on the thumb div, not the hidden input)
+  await expect(page.locator('[role="slider"]').first()).toHaveAttribute('aria-disabled', 'true');
 
   // Screenshot: verification gate
   await test.info().attach('verification-gate', {


### PR DESCRIPTION
## Summary
- `voting.spec.ts` was asserting `.toBeDisabled()` on `.mantine-Slider-root input`, which resolves to Mantine's hidden value input (`type="hidden"`)
- Mantine v8 sets `aria-disabled="true"` on the `[role="slider"]` thumb div when disabled — it does not set `disabled` on the hidden input
- Updated the assertion to `toHaveAttribute('aria-disabled', 'true')` on `[role="slider"]`

## Failure observed
`mobile-chrome` only — other browsers passed, likely due to element ordering differences at mobile viewport size.

## Test plan
- [ ] `unverified user sees verification gate on poll page @smoke` passes on all 5 browser projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)