### PR TITLE
fix(ux): improve markdown docs rendering and add docs nav tree

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -54,6 +54,8 @@
     "react-error-boundary": "^6.0.3",
     "react-markdown": "^10.1.0",
     "recharts": "^3.6.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "zod": "^4.3.5"
   },

--- a/web/src/Router.tsx
+++ b/web/src/Router.tsx
@@ -15,6 +15,7 @@ import { AboutPage } from './pages/About.page';
 import { DevArchitecturePage } from './pages/DevArchitecture.page';
 import { DevDomainModelPage } from './pages/DevDomainModel.page';
 import { DevIndexPage } from './pages/DevIndex.page';
+import { DocsIndexPage } from './pages/DocsIndex.page';
 import { EndorsePage } from './pages/Endorse.page';
 import { HomePage } from './pages/Home.page';
 import { KeysPage } from './pages/Keys.page';
@@ -46,6 +47,12 @@ const aboutRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'about',
   component: AboutPage,
+});
+
+const docsIndexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'docs',
+  component: DocsIndexPage,
 });
 
 const devIndexRoute = createRoute({
@@ -162,6 +169,7 @@ const routeTree = rootRoute.addChildren([
   homeRoute,
   aboutRoute,
   keysRoute,
+  docsIndexRoute,
   devIndexRoute,
   devArchitectureRoute,
   devDomainModelRoute,

--- a/web/src/components/DocsList.tsx
+++ b/web/src/components/DocsList.tsx
@@ -1,0 +1,45 @@
+import { IconBook2 } from '@tabler/icons-react';
+import { Link } from '@tanstack/react-router';
+import { Card, Group, Stack, Text } from '@mantine/core';
+
+export interface DocEntry {
+  title: string;
+  description: string;
+  path: string;
+}
+
+interface DocsListProps {
+  docs: readonly DocEntry[];
+}
+
+/** Vertical list of doc link cards — shared between docs index and dev docs index. */
+export function DocsList({ docs }: DocsListProps) {
+  return (
+    <Stack gap="sm">
+      {docs.map((doc) => (
+        <Card
+          key={doc.path}
+          component={Link}
+          to={doc.path}
+          shadow="sm"
+          padding="md"
+          radius="md"
+          withBorder
+          style={{ textDecoration: 'none', cursor: 'pointer' }}
+        >
+          <Group gap="xs" wrap="nowrap">
+            <IconBook2 size={16} style={{ flexShrink: 0 }} />
+            <div>
+              <Text fw={500} size="sm">
+                {doc.title}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {doc.description}
+              </Text>
+            </div>
+          </Group>
+        </Card>
+      ))}
+    </Stack>
+  );
+}

--- a/web/src/components/MarkdownContent.tsx
+++ b/web/src/components/MarkdownContent.tsx
@@ -1,17 +1,33 @@
-import Markdown from 'react-markdown';
+import Markdown, { type Components } from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
-import { Typography } from '@mantine/core';
+import { Anchor, Typography } from '@mantine/core';
 
 interface MarkdownContentProps {
   /** Raw markdown string (use Vite `?raw` import) */
   children: string;
 }
 
+const components: Components = {
+  a: ({ href, children: linkChildren }) => (
+    <Anchor href={href} target={href?.startsWith('http') ? '_blank' : undefined}>
+      {linkChildren}
+    </Anchor>
+  ),
+};
+
 /** Renders a markdown string with Mantine typography styles. */
 export function MarkdownContent({ children }: MarkdownContentProps) {
   return (
-    <Typography>
-      <Markdown remarkPlugins={[remarkGfm]}>{children}</Markdown>
+    <Typography style={{ maxWidth: 780, marginInline: 'auto' }}>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeSlug]}
+        components={components}
+      >
+        {children}
+      </Markdown>
     </Typography>
   );
 }

--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -1,9 +1,11 @@
 import {
+  IconBook2,
   IconCode,
   IconDoor,
   IconHeartHandshake,
   IconHome2,
   IconInfoCircle,
+  IconKey,
   IconLogin,
   IconShieldCheck,
   IconShieldHalfFilled,
@@ -16,11 +18,9 @@ import { buildVerifierUrl, useVerificationStatus } from '@/features/verification
 import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
 
-const publicNavLinks = [
+const topNavLinks = [
   { icon: IconHome2, label: 'Home', path: '/' },
   { icon: IconDoor, label: 'Rooms', path: '/rooms' },
-  { icon: IconInfoCircle, label: 'About', path: '/about' },
-  { icon: IconCode, label: 'Dev Docs', path: '/dev' },
 ];
 
 const authNavLinks = [
@@ -66,7 +66,7 @@ export function Navbar({ onNavigate }: NavbarProps) {
       style={{ borderRight: `1px solid ${borderColor}` }}
     >
       <Stack gap={4} style={{ flex: 1 }}>
-        {[...publicNavLinks, ...(isAuthenticated ? authNavLinks : [])].map((link) => (
+        {topNavLinks.map((link) => (
           <NavLink
             key={link.label}
             component={Link}
@@ -78,6 +78,75 @@ export function Navbar({ onNavigate }: NavbarProps) {
             fw={500}
           />
         ))}
+
+        <NavLink
+          component={Link}
+          to="/docs"
+          label="Docs"
+          leftSection={<IconBook2 size={18} stroke={1.5} />}
+          active={isActive('/docs')}
+          defaultOpened={
+            currentPath.startsWith('/about') ||
+            currentPath.startsWith('/keys') ||
+            currentPath.startsWith('/dev')
+          }
+          fw={500}
+        >
+          <NavLink
+            component={Link}
+            to="/about"
+            label="About"
+            leftSection={<IconInfoCircle size={16} stroke={1.5} />}
+            active={isActive('/about')}
+            onClick={onNavigate}
+          />
+          <NavLink
+            component={Link}
+            to="/keys"
+            label="How Keys Work"
+            leftSection={<IconKey size={16} stroke={1.5} />}
+            active={isActive('/keys')}
+            onClick={onNavigate}
+          />
+          <NavLink
+            component={Link}
+            to="/dev"
+            label="Dev Docs"
+            leftSection={<IconCode size={16} stroke={1.5} />}
+            active={isActive('/dev')}
+            defaultOpened={currentPath.startsWith('/dev/')}
+          >
+            <NavLink
+              component={Link}
+              to="/dev/architecture"
+              label="Architecture"
+              active={isActive('/dev/architecture')}
+              onClick={onNavigate}
+            />
+            <NavLink
+              component={Link}
+              to="/dev/domain-model"
+              label="Domain Model"
+              active={isActive('/dev/domain-model')}
+              onClick={onNavigate}
+            />
+          </NavLink>
+        </NavLink>
+
+        {isAuthenticated
+          ? authNavLinks.map((link) => (
+              <NavLink
+                key={link.label}
+                component={Link}
+                to={link.path}
+                label={link.label}
+                leftSection={<link.icon size={18} stroke={1.5} />}
+                active={isActive(link.path)}
+                onClick={onNavigate}
+                fw={500}
+              />
+            ))
+          : null}
       </Stack>
 
       {!isAuthenticated ? (

--- a/web/src/content/about.md
+++ b/web/src/content/about.md
@@ -1,5 +1,3 @@
-## About TinyCongress
-
 TinyCongress is an experimental platform for structured group decision-making.
 Instead of simple yes/no polls, participants vote across multiple dimensions —
 capturing the nuance of how people actually think about complex issues.

--- a/web/src/content/dev/architecture.md
+++ b/web/src/content/dev/architecture.md
@@ -1,5 +1,3 @@
-## System Components
-
 TinyCongress has four major pieces: a React frontend, a Rust API server, a
 background trust engine, and a shared crypto library that runs on both sides.
 

--- a/web/src/content/keys.md
+++ b/web/src/content/keys.md
@@ -1,5 +1,3 @@
-## How Your Keys Work
-
 TinyCongress uses cryptographic keys instead of traditional passwords to prove
 your identity. Your keys are generated in your browser and never leave your
 device — the server only sees the public half, which can verify your identity

--- a/web/src/pages/DevIndex.page.tsx
+++ b/web/src/pages/DevIndex.page.tsx
@@ -2,11 +2,11 @@
  * Developer documentation index — lists available technical reference pages.
  */
 
-import { IconBook2, IconBrandGithub, IconCode } from '@tabler/icons-react';
-import { Link } from '@tanstack/react-router';
-import { Anchor, Badge, Card, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { IconBrandGithub, IconCode } from '@tabler/icons-react';
+import { Anchor, Badge, Group, Stack, Text, Title } from '@mantine/core';
+import { DocsList, type DocEntry } from '../components/DocsList';
 
-const docs = [
+const docs: readonly DocEntry[] = [
   {
     title: 'Architecture Overview',
     description: 'System components, request flow, background workers, and how the pieces connect.',
@@ -18,7 +18,7 @@ const docs = [
       'Core entities, data invariants, trust boundaries, and the signup/login flows in detail.',
     path: '/dev/domain-model',
   },
-] as const;
+];
 
 export function DevIndexPage() {
   return (
@@ -32,39 +32,13 @@ export function DevIndexPage() {
       </Group>
 
       <Text c="dimmed" size="sm">
-        Technical reference for developers building on or contributing to TinyCongress. For end-user
-        guides, see{' '}
-        <Anchor component={Link} to="/about">
-          About
-        </Anchor>
-        .{' '}
+        Technical reference for developers building on or contributing to TinyCongress.{' '}
         <Anchor href="https://github.com/icook/tiny-congress" target="_blank" rel="noopener">
           <IconBrandGithub size={14} style={{ verticalAlign: 'text-bottom' }} /> Source on GitHub
         </Anchor>
       </Text>
 
-      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-        {docs.map((doc) => (
-          <Card
-            key={doc.path}
-            component={Link}
-            to={doc.path}
-            shadow="sm"
-            padding="lg"
-            radius="md"
-            withBorder
-            style={{ textDecoration: 'none', cursor: 'pointer' }}
-          >
-            <Group gap="xs" mb="xs">
-              <IconBook2 size={16} />
-              <Text fw={500}>{doc.title}</Text>
-            </Group>
-            <Text size="sm" c="dimmed">
-              {doc.description}
-            </Text>
-          </Card>
-        ))}
-      </SimpleGrid>
+      <DocsList docs={docs} />
     </Stack>
   );
 }

--- a/web/src/pages/DocsIndex.page.tsx
+++ b/web/src/pages/DocsIndex.page.tsx
@@ -1,0 +1,67 @@
+/**
+ * Documentation index — lists all user-facing and developer reference pages.
+ */
+
+import { IconBook2, IconBrandGithub, IconCode, IconInfoCircle } from '@tabler/icons-react';
+import { Anchor, Group, Stack, Text, Title } from '@mantine/core';
+import { DocsList, type DocEntry } from '../components/DocsList';
+
+const guideDocs: readonly DocEntry[] = [
+  {
+    title: 'About TinyCongress',
+    description: 'What the platform does, how voting works, and why keys matter.',
+    path: '/about',
+  },
+  {
+    title: 'How Your Keys Work',
+    description: 'Plain-language explainer of root keys, device keys, and backup envelopes.',
+    path: '/keys',
+  },
+];
+
+const devDocs: readonly DocEntry[] = [
+  {
+    title: 'Architecture Overview',
+    description: 'System components, request flow, background workers, and how the pieces connect.',
+    path: '/dev/architecture',
+  },
+  {
+    title: 'Domain Model',
+    description:
+      'Core entities, data invariants, trust boundaries, and the signup/login flows in detail.',
+    path: '/dev/domain-model',
+  },
+];
+
+export function DocsIndexPage() {
+  return (
+    <Stack gap="lg">
+      <Group gap="xs">
+        <IconBook2 size={20} />
+        <Title order={2}>Documentation</Title>
+      </Group>
+
+      <section>
+        <Group gap="xs" mb="xs">
+          <IconInfoCircle size={16} />
+          <Title order={4}>Guides</Title>
+        </Group>
+        <DocsList docs={guideDocs} />
+      </section>
+
+      <section>
+        <Group gap="xs" mb="xs">
+          <IconCode size={16} />
+          <Title order={4}>Developer Reference</Title>
+        </Group>
+        <Text c="dimmed" size="xs" mb="xs">
+          Technical docs for contributors.{' '}
+          <Anchor href="https://github.com/icook/tiny-congress" target="_blank" rel="noopener">
+            <IconBrandGithub size={12} style={{ verticalAlign: 'text-bottom' }} /> Source on GitHub
+          </Anchor>
+        </Text>
+        <DocsList docs={devDocs} />
+      </section>
+    </Stack>
+  );
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6153,6 +6153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"github-slugger@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "github-slugger@npm:2.0.0"
+  checksum: 10c0/21b912b6b1e48f1e5a50b2292b48df0ff6abeeb0691b161b3d93d84f4ae6b1acd6ae23702e914af7ea5d441c096453cf0f621b72d57893946618d21dd1a1c486
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -6469,6 +6476,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-from-parse5@npm:^8.0.0":
+  version: 8.0.3
+  resolution: "hast-util-from-parse5@npm:8.0.3"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    devlop: "npm:^1.0.0"
+    hastscript: "npm:^9.0.0"
+    property-information: "npm:^7.0.0"
+    vfile: "npm:^6.0.0"
+    vfile-location: "npm:^5.0.0"
+    web-namespaces: "npm:^2.0.0"
+  checksum: 10c0/40ace6c0ad43c26f721c7499fe408e639cde917b2350c9299635e6326559855896dae3c3ebf7440df54766b96c4276a7823e8f376a2b6a28b37b591f03412545
+  languageName: node
+  linkType: hard
+
+"hast-util-heading-rank@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-heading-rank@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10c0/1879c84f629e73f1f13247ab349324355cd801363b44e3d46f763aa5c0ea3b42dcd47b46e5643a0502cf01a6b1fdb9208fd12852e44ca6c671b3e4bccf9369a1
+  languageName: node
+  linkType: hard
+
+"hast-util-parse-selector@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "hast-util-parse-selector@npm:4.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10c0/5e98168cb44470dc274aabf1a28317e4feb09b1eaf7a48bbaa8c1de1b43a89cd195cb1284e535698e658e3ec26ad91bc5e52c9563c36feb75abbc68aaf68fb9f
+  languageName: node
+  linkType: hard
+
+"hast-util-raw@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "hast-util-raw@npm:9.1.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    hast-util-from-parse5: "npm:^8.0.0"
+    hast-util-to-parse5: "npm:^8.0.0"
+    html-void-elements: "npm:^3.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    parse5: "npm:^7.0.0"
+    unist-util-position: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/d0d909d2aedecef6a06f0005cfae410d6475e6e182d768bde30c3af9fcbbe4f9beb0522bdc21d0679cb3c243c0df40385797ed255148d68b3d3f12e82d12aacc
+  languageName: node
+  linkType: hard
+
 "hast-util-to-jsx-runtime@npm:^2.0.0":
   version: 2.3.6
   resolution: "hast-util-to-jsx-runtime@npm:2.3.6"
@@ -6492,12 +6554,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-to-parse5@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "hast-util-to-parse5@npm:8.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    property-information: "npm:^7.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/8e8a1817c7ff8906ac66e7201b1b8d19d9e1b705e695a6e71620270d498d982ec1ecc0e227bd517f723e91e7fdfb90ef75f9ae64d14b3b65239a7d5e1194d7dd
+  languageName: node
+  linkType: hard
+
+"hast-util-to-string@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "hast-util-to-string@npm:3.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10c0/b5fa1912a6ba6131affae52a0f4394406c4c0d23c2b0307f1d69988f1030c7bb830289303e67c5ad8f674f5f23a454c1dcd492c39e45a22c1f46d3c9bce5bd0c
+  languageName: node
+  linkType: hard
+
 "hast-util-whitespace@npm:^3.0.0":
   version: 3.0.0
   resolution: "hast-util-whitespace@npm:3.0.0"
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/b898bc9fe27884b272580d15260b6bbdabe239973a147e97fa98c45fa0ffec967a481aaa42291ec34fb56530dc2d484d473d7e2bae79f39c83f3762307edfea8
+  languageName: node
+  linkType: hard
+
+"hastscript@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "hastscript@npm:9.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    hast-util-parse-selector: "npm:^4.0.0"
+    property-information: "npm:^7.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+  checksum: 10c0/18dc8064e5c3a7a2ae862978e626b97a254e1c8a67ee9d0c9f06d373bba155ed805fc5b5ce21b990fb7bc174624889e5e1ce1cade264f1b1d58b48f994bc85ce
   languageName: node
   linkType: hard
 
@@ -6561,6 +6660,13 @@ __metadata:
   version: 3.0.1
   resolution: "html-url-attributes@npm:3.0.1"
   checksum: 10c0/496e4908aa8b77665f348b4b03521901794f648b8ac34a581022cd6f2c97934d5c910cd91bc6593bbf2994687549037bc2520fcdc769b31484f29ffdd402acd0
+  languageName: node
+  linkType: hard
+
+"html-void-elements@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "html-void-elements@npm:3.0.0"
+  checksum: 10c0/a8b9ec5db23b7c8053876dad73a0336183e6162bf6d2677376d8b38d654fdc59ba74fdd12f8812688f7db6fad451210c91b300e472afc0909224e0a44c8610d2
   languageName: node
   linkType: hard
 
@@ -7845,6 +7951,8 @@ __metadata:
     react-error-boundary: "npm:^6.0.3"
     react-markdown: "npm:^10.1.0"
     recharts: "npm:^3.6.0"
+    rehype-raw: "npm:^7.0.0"
+    rehype-slug: "npm:^6.0.0"
     remark-gfm: "npm:^4.0.1"
     rollup-plugin-visualizer: "npm:^6.0.5"
     storybook: "npm:^10.2.13"
@@ -9075,6 +9183,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^7.0.0":
+  version: 7.3.0
+  resolution: "parse5@npm:7.3.0"
+  dependencies:
+    entities: "npm:^6.0.0"
+  checksum: 10c0/7fd2e4e247e85241d6f2a464d0085eed599a26d7b0a5233790c49f53473232eb85350e8133344d9b3fd58b89339e7ad7270fe1f89d28abe50674ec97b87f80b5
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^8.0.0":
   version: 8.0.0
   resolution: "parse5@npm:8.0.0"
@@ -9790,6 +9907,30 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: 10c0/4702f85cda09f67747c1b2fb673a0f0e5d1ba39d55f177632265a0be471ba59e3f320623f411649141f752b126b8126eac3ff4c62d317921e430b0472bfc6071
+  languageName: node
+  linkType: hard
+
+"rehype-raw@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "rehype-raw@npm:7.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hast-util-raw: "npm:^9.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/1435b4b6640a5bc3abe3b2133885c4dbff5ef2190ef9cfe09d6a63f74dd7d7ffd0cede70603278560ccf1acbfb9da9faae4b68065a28bc5aa88ad18e40f32d52
+  languageName: node
+  linkType: hard
+
+"rehype-slug@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "rehype-slug@npm:6.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    github-slugger: "npm:^2.0.0"
+    hast-util-heading-rank: "npm:^3.0.0"
+    hast-util-to-string: "npm:^3.0.0"
+    unist-util-visit: "npm:^5.0.0"
+  checksum: 10c0/51303c33d039c271cabe62161b49fa737be488f70ced62f00c165e47a089a99de2060050385e5c00d0df83ed30c7fa1c79a51b78508702836aefa51f7e7a6760
   languageName: node
   linkType: hard
 
@@ -11612,6 +11753,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vfile-location@npm:^5.0.0":
+  version: 5.0.3
+  resolution: "vfile-location@npm:5.0.3"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/1711f67802a5bc175ea69750d59863343ed43d1b1bb25c0a9063e4c70595e673e53e2ed5cdbb6dcdc370059b31605144d95e8c061b9361bcc2b036b8f63a4966
+  languageName: node
+  linkType: hard
+
 "vfile-message@npm:^4.0.0":
   version: 4.0.3
   resolution: "vfile-message@npm:4.0.3"
@@ -11864,6 +12015,13 @@ __metadata:
   dependencies:
     xml-name-validator: "npm:^5.0.0"
   checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
+  languageName: node
+  linkType: hard
+
+"web-namespaces@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "web-namespaces@npm:2.0.1"
+  checksum: 10c0/df245f466ad83bd5cd80bfffc1674c7f64b7b84d1de0e4d2c0934fb0782e0a599164e7197a4bce310ee3342fd61817b8047ff04f076a1ce12dd470584142a4bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fix raw `<a>` tags rendering in markdown by adding `rehype-raw` plugin
- Add `rehype-slug` for linkable heading anchors (e.g. `/about#how-voting-works`)
- Constrain markdown prose to 780px max-width, centered
- Use Mantine `<Anchor>` for all markdown links (external links open in new tab)
- Remove duplicate `##` headings from markdown files that matched the page-level `<Title>`
- Add `/docs` index page grouping guides (About, Keys) and developer reference
- Shared `DocsList` component used by both `/docs` and `/dev` index pages (DRY)
- Expandable Docs tree in sidebar nav: About, How Keys Work, Dev Docs → Architecture, Domain Model
- Dev docs index now uses vertical list instead of horizontal grid

## Test plan
- [ ] Visit `/docs` — see guides and dev reference sections
- [ ] Visit `/about` — no duplicate heading, `<a id="voting">` renders correctly, prose is constrained width
- [ ] Visit `/dev/architecture` — heading anchors are clickable (`#` links work)
- [ ] Sidebar: Docs expands to show sub-pages; Dev Docs expands to show Architecture + Domain Model
- [ ] Mobile: nav tree collapses properly in hamburger menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)