### PR TITLE
feat(sim): configurable LLM and Exa base URLs for cache proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "conquer-once"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d008a441c0f269f36ca13712528069a86a3e60dffee1d98b976eb3b0b2160b4"
+dependencies = [
+ "conquer-util",
+]
+
+[[package]]
+name = "conquer-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3028,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3474,7 @@ dependencies = [
  "async-trait",
  "bollard",
  "bytes",
+ "conquer-once",
  "docker_credential",
  "either",
  "etcetera 0.11.0",
@@ -3462,6 +3488,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "signal-hook",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -3565,6 +3592,7 @@ dependencies = [
  "hmac",
  "hyper",
  "insta",
+ "libc",
  "proptest",
  "rand 0.8.5",
  "reqwest",

--- a/kube/app/templates/configmap-sim.yaml
+++ b/kube/app/templates/configmap-sim.yaml
@@ -16,4 +16,6 @@ data:
   SIM_LOG_LEVEL: {{ .Values.sim.logLevel | quote }}
   SIM_EVIDENCE_MODEL: {{ .Values.sim.evidenceModel | quote }}
   SIM_ROOM_TOPIC: {{ .Values.sim.roomTopic | quote }}
+  SIM_LLM_BASE_URL: {{ .Values.sim.llmBaseUrl | quote }}
+  SIM_EXA_BASE_URL: {{ .Values.sim.exaBaseUrl | quote }}
 {{- end }}

--- a/kube/app/values.yaml
+++ b/kube/app/values.yaml
@@ -262,6 +262,8 @@ sim:
   evidenceModel: "deepseek/deepseek-v3.2"
   exaApiKey: ""
   roomTopic: "civic"
+  llmBaseUrl: "https://openrouter.ai/api/v1"
+  exaBaseUrl: "https://api.exa.ai"
   targetRooms: 5
   votesPerPoll: 15
   voterCount: 20

--- a/kube/environments/demo.yaml
+++ b/kube/environments/demo.yaml
@@ -59,6 +59,8 @@ sim:
   openrouterModel: "meta-llama/llama-3.3-70b-instruct"
   evidenceModel: "deepseek/deepseek-v3.2"
   roomTopic: "brand_ethics"
+  llmBaseUrl: "http://litellm.tiny-congress-demo.svc.cluster.local:4001"
+  exaBaseUrl: "http://exa-cache.tiny-congress-demo.svc.cluster.local:4002"
   targetRooms: 5
   votesPerPoll: 15
   voterCount: 20

--- a/service/src/bin/sim.rs
+++ b/service/src/bin/sim.rs
@@ -43,6 +43,8 @@ async fn main() -> Result<(), anyhow::Error> {
         poll_duration_secs = config.poll_duration_secs,
         api_key_len = config.openrouter_api_key.len(),
         exa_key_len = config.exa_api_key.len(),
+        llm_base_url = %config.llm_base_url,
+        exa_base_url = %config.exa_base_url,
         dry_run = config.dry_run,
         "sim config loaded"
     );
@@ -71,7 +73,15 @@ async fn main() -> Result<(), anyhow::Error> {
             serde_json::from_str(&pairs_json).context("failed to parse battery config")?;
 
         tracing::info!(pairs = pairs.len(), "loaded battery config");
-        brand::battery(&http, &config.openrouter_api_key, company, ticker, &pairs).await?;
+        brand::battery(
+            &http,
+            &config.openrouter_api_key,
+            &config.llm_base_url,
+            company,
+            ticker,
+            &pairs,
+        )
+        .await?;
         tracing::info!("tc-sim battery complete");
         return Ok(());
     }

--- a/service/src/sim/brand.rs
+++ b/service/src/sim/brand.rs
@@ -309,6 +309,7 @@ struct BatteryEvidence {
 pub async fn battery(
     http: &reqwest::Client,
     api_key: &str,
+    llm_base_url: &str,
     company_name: &str,
     ticker: &str,
     pairs: &[BatteryConfig],
@@ -329,6 +330,7 @@ pub async fn battery(
         let result = llm::generate_company_evidence_with_overrides(
             http,
             api_key,
+            llm_base_url,
             &pair.model,
             pair.search,
             company_name,
@@ -340,9 +342,10 @@ pub async fn battery(
         match result {
             Ok((evidence, usage, raw, generation_id)) => {
                 // Fetch cost from OpenRouter generation stats (async, best-effort)
-                let cost_usd = llm::get_generation_cost(http, api_key, &generation_id)
-                    .await
-                    .unwrap_or(None);
+                let cost_usd =
+                    llm::get_generation_cost(http, api_key, llm_base_url, &generation_id)
+                        .await
+                        .unwrap_or(None);
 
                 tracing::info!(
                     model = %pair.model,

--- a/service/src/sim/config.rs
+++ b/service/src/sim/config.rs
@@ -46,6 +46,12 @@ pub struct SimConfig {
     /// Model for evidence synthesis step (default: Haiku for cost efficiency)
     #[serde(default = "default_evidence_model")]
     pub evidence_model: String,
+    /// Base URL for OpenAI-compatible LLM API (e.g., `LiteLLM` proxy)
+    #[serde(default = "default_llm_base_url")]
+    pub llm_base_url: String,
+    /// Base URL for Exa search API (e.g., nginx cache proxy)
+    #[serde(default = "default_exa_base_url")]
+    pub exa_base_url: String,
     /// Dry run: only run LLM generation and write output to JSON file, skip API calls
     #[serde(default)]
     pub dry_run: bool,
@@ -103,6 +109,14 @@ fn default_room_topic() -> String {
 
 const fn default_company_count() -> usize {
     25
+}
+
+fn default_llm_base_url() -> String {
+    "https://openrouter.ai/api/v1".to_string()
+}
+
+fn default_exa_base_url() -> String {
+    "https://api.exa.ai".to_string()
 }
 
 impl SimConfig {

--- a/service/src/sim/llm.rs
+++ b/service/src/sim/llm.rs
@@ -301,7 +301,7 @@ pub async fn generate_content(
     };
 
     let response = client
-        .post("https://openrouter.ai/api/v1/chat/completions")
+        .post(format!("{}/chat/completions", config.llm_base_url))
         .header(
             "Authorization",
             format!("Bearer {}", config.openrouter_api_key),
@@ -569,7 +569,7 @@ pub async fn generate_company_curation(
     };
 
     let response = client
-        .post("https://openrouter.ai/api/v1/chat/completions")
+        .post(format!("{}/chat/completions", config.llm_base_url))
         .header(
             "Authorization",
             format!("Bearer {}", config.openrouter_api_key),
@@ -650,10 +650,11 @@ pub async fn generate_company_evidence(
     for dim in &dimensions {
         let client = client.clone();
         let api_key = config.exa_api_key.clone();
+        let base_url = config.exa_base_url.clone();
         let company = company_name.to_string();
         let dim_name = (*dim).to_string();
         join_set.spawn(async move {
-            let result = exa_search(&client, &api_key, &company, &dim_name).await;
+            let result = exa_search(&client, &api_key, &base_url, &company, &dim_name).await;
             (dim_name, result)
         });
     }
@@ -721,7 +722,7 @@ pub async fn generate_company_evidence(
     };
 
     let response = client
-        .post("https://openrouter.ai/api/v1/chat/completions")
+        .post(format!("{}/chat/completions", config.llm_base_url))
         .header(
             "Authorization",
             format!("Bearer {}", config.openrouter_api_key),
@@ -772,6 +773,7 @@ pub async fn generate_company_evidence(
 async fn exa_search(
     client: &reqwest::Client,
     api_key: &str,
+    exa_base_url: &str,
     company_name: &str,
     dimension: &str,
 ) -> Result<Vec<ExaResult>, anyhow::Error> {
@@ -787,7 +789,7 @@ async fn exa_search(
     };
 
     let response = client
-        .post("https://api.exa.ai/search")
+        .post(format!("{exa_base_url}/search"))
         .header("x-api-key", api_key)
         .json(&request)
         .send()
@@ -864,9 +866,10 @@ Respond with ONLY valid JSON matching this schema:
 pub async fn get_generation_cost(
     client: &reqwest::Client,
     api_key: &str,
+    llm_base_url: &str,
     generation_id: &str,
 ) -> Result<Option<f64>, anyhow::Error> {
-    let url = format!("https://openrouter.ai/api/v1/generation?id={generation_id}");
+    let url = format!("{llm_base_url}/generation?id={generation_id}");
 
     let resp = client
         .get(&url)
@@ -897,6 +900,7 @@ pub async fn get_generation_cost(
 pub async fn generate_company_evidence_with_overrides(
     client: &reqwest::Client,
     api_key: &str,
+    llm_base_url: &str,
     model: &str,
     search: bool,
     company_name: &str,
@@ -941,7 +945,7 @@ pub async fn generate_company_evidence_with_overrides(
     };
 
     let response = client
-        .post("https://openrouter.ai/api/v1/chat/completions")
+        .post(format!("{llm_base_url}/chat/completions"))
         .header("Authorization", format!("Bearer {api_key}"))
         .json(&request)
         .send()
@@ -1119,6 +1123,8 @@ mod tests {
             battery_ticker: None,
             exa_api_key: String::new(),
             evidence_model: "deepseek/deepseek-v3.2".to_string(),
+            llm_base_url: "https://openrouter.ai/api/v1".to_string(),
+            exa_base_url: "https://api.exa.ai".to_string(),
         };
 
         let client = reqwest::Client::new();
@@ -1149,6 +1155,8 @@ mod tests {
             battery_ticker: None,
             exa_api_key: String::new(),
             evidence_model: "deepseek/deepseek-v3.2".to_string(),
+            llm_base_url: "https://openrouter.ai/api/v1".to_string(),
+            exa_base_url: "https://api.exa.ai".to_string(),
         };
 
         let messages = build_messages(&config, 2);


### PR DESCRIPTION
## Summary

- Add `SIM_LLM_BASE_URL` (default: `https://openrouter.ai/api/v1`) and `SIM_EXA_BASE_URL` (default: `https://api.exa.ai`) config fields
- Replace all hardcoded API URLs in `llm.rs` with config-driven values
- Wire through Helm chart (ConfigMap) and set demo env to in-cluster LiteLLM (:4001) and nginx cache (:4002) proxies
- Enables transparent caching of LLM and search calls — first run pays full cost, subsequent runs within TTL are free

Depends on #714 (brand ethics room).

## Test plan

- [x] All 253 unit tests pass (`cargo test -p tinycongress-api --lib`)
- [x] `cargo clippy` clean
- [x] `helm template` renders correct URLs for demo env
- [x] `kube-linter` passes
- [x] Default behavior unchanged (direct API access when env vars unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)