### PR TITLE
fix(ux): readable countdown format + slider labels visible at all viewports

### DIFF
--- a/web/src/engines/polling/components/PollCountdown.test.tsx
+++ b/web/src/engines/polling/components/PollCountdown.test.tsx
@@ -24,6 +24,16 @@ describe('PollCountdown', () => {
     expect(screen.getByText('Closes in 00:45')).toBeInTheDocument();
   });
 
+  it('displays hours and minutes for durations >= 1 hour', () => {
+    wrap(<PollCountdown secondsLeft={3661} />);
+    expect(screen.getByText('Closes in 1h 1m')).toBeInTheDocument();
+  });
+
+  it('displays days and hours for durations >= 24 hours', () => {
+    wrap(<PollCountdown secondsLeft={90000} />);
+    expect(screen.getByText('Closes in 1d 1h')).toBeInTheDocument();
+  });
+
   it('displays closing message when secondsLeft is 0', () => {
     wrap(<PollCountdown secondsLeft={0} />);
     expect(screen.getByText('Closing...')).toBeInTheDocument();

--- a/web/src/engines/polling/components/PollCountdown.tsx
+++ b/web/src/engines/polling/components/PollCountdown.tsx
@@ -5,6 +5,16 @@ interface Props {
 }
 
 function formatTime(seconds: number): string {
+  if (seconds >= 86400) {
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    return h > 0 ? `${String(d)}d ${String(h)}h` : `${String(d)}d`;
+  }
+  if (seconds >= 3600) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return m > 0 ? `${String(h)}h ${String(m)}m` : `${String(h)}h`;
+  }
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -398,7 +398,9 @@ function VoteSlider({
           styles={{
             markLabel: {
               fontSize: 'var(--mantine-font-size-xs)',
-              whiteSpace: 'nowrap',
+              whiteSpace: 'normal',
+              textAlign: 'center',
+              maxWidth: 100,
             },
           }}
         />


### PR DESCRIPTION
## Summary
- **Countdown format** (#716): `formatTime` now adapts — `1d 5h` for >=24h, `2h 30m` for >=1h, `MM:SS` for <1h. No more "1438:43".
- **Slider labels** (#667): Changed `whiteSpace: nowrap` to `normal` with `maxWidth: 100px` so endpoint anchors wrap instead of clipping.

## Test plan
- [x] PollCountdown unit tests pass (6/6, including 2 new cases for hours and days)
- [ ] Visual check: slider labels fully visible at 1280px desktop
- [ ] Visual check: slider labels fully visible at 375px mobile
- [ ] Visual check: countdown shows "23h 58m" for 24h polls

Closes #667, closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)