### PR TITLE
feat(refine): multi-target continuous refinement loop

### DIFF
--- a/.github/workflows/refine.yml
+++ b/.github/workflows/refine.yml
@@ -10,10 +10,12 @@ name: Refinement Loop
 #                              Run: ./scripts/refine-setup.sh
 
 on:
+  schedule:
+    - cron: '0 */2 * * *'
   workflow_dispatch:
     inputs:
       max_prs:
-        description: 'Max PRs to create (0 = use refine.toml default)'
+        description: 'Max PRs per target (0 = use refine.toml default)'
         required: false
         default: '0'
         type: string
@@ -35,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Use PAT so pushed branches trigger CI workflows
@@ -117,7 +119,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: refine-logs-${{ github.run_id }}
           path: .claude/refine.log

--- a/refine.toml
+++ b/refine.toml
@@ -1,9 +1,27 @@
 # Automated refinement configuration
-# Edit [focus] to point at the directory you want refined.
+# Targets are processed in priority order. The loop picks the first
+# non-graduated target each run. After idle_limit consecutive "nothing
+# to improve" results, a target graduates and the loop advances.
 # Run: ./scripts/refine.sh
 
-[focus]
-path = "service/src/identity/"
+# ── Targets (priority order) ─────────────────────────────────────
+
+[[targets]]
+path = "service/src/trust/"
+
+[[targets]]
+path = "crates/tc-engine-api/"
+
+[[targets]]
+path = "service/src/rooms/"
+
+[[targets]]
+path = "service/src/sim/"
+
+[[targets]]
+path = "crates/tc-engine-polling/"
+
+# ── Global settings ──────────────────────────────────────────────
 
 [types]
 pattern_enforcement = true
@@ -14,9 +32,9 @@ security_hardening = true
 [behavior]
 # Seconds to wait between iterations (0 = as fast as possible)
 cooldown = 0
-# Stop after N PRs (0 = unlimited)
+# Stop after N PRs per target (0 = unlimited)
 max_prs = 0
-# Stop after N consecutive "nothing to improve" results
+# Graduate a target after N consecutive "nothing to improve" results
 idle_limit = 3
 # Minimum impact to create a PR: "low" = everything, "medium" = skip cleanup, "high" = only significant
 min_impact = "medium"

--- a/scripts/refine-prompt.md
+++ b/scripts/refine-prompt.md
@@ -44,6 +44,7 @@ After you are done, your final text output MUST be valid JSON matching this sche
 ```json
 {
   "action": "change" | "ticket" | "clean" | "skip",
+  "type": "security_hardening" | "pattern_enforcement" | "test_coverage" | "code_cleanup",
   "impact": "high" | "medium" | "low",
   "summary": "one-sentence description of what you did or found"
   // Only if action is "skip":
@@ -59,4 +60,4 @@ After you are done, your final text output MUST be valid JSON matching this sche
 - `"skip"`: You found an improvement but it's below the impact threshold. Do NOT make changes. Describe what you found.
 - `"clean"`: Nothing worth improving in the focus area. No changes made.
 
-`impact` is REQUIRED on all actions (including `clean` — rate what was found, even if nothing was worth doing).
+`type` and `impact` are REQUIRED on all actions (including `clean` — categorize and rate what was found, even if nothing was worth doing).

--- a/scripts/refine.sh
+++ b/scripts/refine.sh
@@ -28,7 +28,6 @@ require_config() {
     echo "$value"
 }
 
-FOCUS_PATH="$(require_config '.focus.path')"
 GUIDANCE_FILE="$(require_config '.prompts.guidance')"
 COOLDOWN="$(require_config '.behavior.cooldown')"
 MAX_PRS="$(require_config '.behavior.max_prs')"
@@ -59,7 +58,7 @@ mkdir -p "$LOG_DIR"
 log() {
     local msg
     msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-    echo "$msg"
+    echo "$msg" >&2
     echo "$msg" >> "$LOG_FILE"
 }
 
@@ -75,7 +74,10 @@ impact_to_num() {
 
 IMPACT_THRESHOLD="$(impact_to_num "$MIN_IMPACT")"
 
-log "Config loaded: focus=$FOCUS_PATH types=${ENABLED_TYPES[*]} idle_limit=$IDLE_LIMIT"
+# FOCUS_PATH is set dynamically per-target in main()
+FOCUS_PATH=""
+
+log "Config loaded: types=${ENABLED_TYPES[*]} idle_limit=$IDLE_LIMIT"
 
 # ── Prompt templating ───────────────────────────────────────────────
 
@@ -334,6 +336,10 @@ graduate_area() {
 }
 
 # Commit and push ledger changes to master if there are any.
+# NOTE: This pushes directly to master. The ledger is operational metadata
+# (run history, graduation status), not application code — it doesn't go
+# through PRs. Branch protection rules should exempt refine-ledger.json
+# or the bot's commit signature if needed.
 commit_ledger() {
     if [[ ! -f "$LEDGER" ]]; then
         return 0
@@ -386,16 +392,19 @@ get_pending_pr_summary() {
 }
 
 if $DRY_RUN; then
-    # Check graduated status even in dry-run
-    if [[ -f "$LEDGER" ]]; then
-        local_status="$(jq -r --arg key "$FOCUS_PATH" '.areas[$key].status // "null"' "$LEDGER" 2>/dev/null || echo "null")"
-        if [[ "$local_status" == "graduated" ]]; then
-            log "Focus area $FOCUS_PATH is graduated. Set status to 'active' in refine-ledger.json to re-run."
-            exit 0
+    target_count="$(yq -p toml -oy '.targets | length' "$CONFIG")"
+    for ((t = 0; t < target_count; t++)); do
+        FOCUS_PATH="$(yq -p toml -oy ".targets[$t].path" "$CONFIG")"
+        log "=== DRY RUN: Target $((t+1))/$target_count — $FOCUS_PATH ==="
+        if [[ -f "$LEDGER" ]]; then
+            local_status="$(jq -r --arg key "$FOCUS_PATH" '.areas[$key].status // "null"' "$LEDGER" 2>/dev/null || echo "null")"
+            if [[ "$local_status" == "graduated" ]]; then
+                log "  (graduated — would skip)"
+                continue
+            fi
         fi
-    fi
-    log "=== DRY RUN: Generated prompt ==="
-    build_prompt "$(get_pending_pr_summary)" "$(read_ledger_context)"
+        build_prompt "$(get_pending_pr_summary)" "$(read_ledger_context)"
+    done
     exit 0
 fi
 
@@ -803,6 +812,8 @@ for i, c in enumerate(text):
 
     local impact
     impact="$(echo "$json_block" | jq -r '.impact // "medium"' 2>/dev/null || echo "medium")"
+    local finding_type
+    finding_type="$(echo "$json_block" | jq -r '.type // ""' 2>/dev/null || echo "")"
     local skip_reason
     skip_reason="$(echo "$json_block" | jq -r '.skip_reason // ""' 2>/dev/null || echo "")"
 
@@ -824,22 +835,22 @@ for i, c in enumerate(text):
             handle_change "$wt_path" "$branch" "$summary"
             local pr_num
             pr_num="$(gh pr list --head "$branch" --json number --jq '.[0].number' 2>/dev/null || echo "0")"
-            update_ledger "change" "$impact" "$summary" "$pr_num" "" ""
+            update_ledger "change" "$impact" "$summary" "$pr_num" "" "$finding_type"
             ;;
         skip)
             log "Skipped: $summary ($skip_reason)"
             cleanup_worktree "$wt_path" "$branch"
-            update_ledger "skip" "$impact" "$summary" "" "$skip_reason" ""
+            update_ledger "skip" "$impact" "$summary" "" "$skip_reason" "$finding_type"
             ;;
         ticket)
             handle_ticket "$json_block" "$summary"
             cleanup_worktree "$wt_path" "$branch"
-            update_ledger "ticket" "$impact" "$summary"
+            update_ledger "ticket" "$impact" "$summary" "" "" "$finding_type"
             ;;
         clean)
             log "Focus area clean: $summary"
             cleanup_worktree "$wt_path" "$branch"
-            update_ledger "clean" "$impact" "$summary"
+            update_ledger "clean" "$impact" "$summary" "" "" "$finding_type"
             ;;
         *)
             log "WARNING: Unknown action '$action', treating as error"
@@ -854,21 +865,18 @@ for i, c in enumerate(text):
     echo "$action"
 }
 
-# ── Main loop ───────────────────────────────────────────────────────
+# ── Per-target refinement loop ────────────────────────────────────────
 
-main() {
-    log "=== Refinement loop starting ==="
-    log "Focus: $FOCUS_PATH"
-    log "Types: ${ENABLED_TYPES[*]}"
-    log "Idle limit: $IDLE_LIMIT"
+run_target() {
+    log "=== Refining: $FOCUS_PATH ==="
 
-    # Check if focus area is graduated
+    # Skip graduated targets
     if [[ -f "$LEDGER" ]]; then
         local area_status
         area_status="$(jq -r --arg key "$FOCUS_PATH" '.areas[$key].status // "null"' "$LEDGER" 2>/dev/null || echo "null")"
         if [[ "$area_status" == "graduated" ]]; then
-            log "Focus area $FOCUS_PATH is graduated. Set status to 'active' in refine-ledger.json to re-run."
-            exit 0
+            log "Skipping graduated target: $FOCUS_PATH"
+            return 0
         fi
     fi
 
@@ -897,7 +905,7 @@ main() {
                 pr_count=$((pr_count + 1))
                 log "PRs opened so far: $pr_count"
                 if [[ "$MAX_PRS" -gt 0 && "$pr_count" -ge "$MAX_PRS" ]]; then
-                    log "Reached max_prs=$MAX_PRS, stopping"
+                    log "Reached max_prs=$MAX_PRS for target, advancing"
                     break
                 fi
                 ;;
@@ -908,7 +916,7 @@ main() {
                 idle_count=$((idle_count + 1))
                 log "Idle count: $idle_count / $IDLE_LIMIT"
                 if [[ "$idle_count" -ge "$IDLE_LIMIT" ]]; then
-                    log "Reached idle_limit=$IDLE_LIMIT, focus area graduated"
+                    log "Reached idle_limit=$IDLE_LIMIT, graduating $FOCUS_PATH"
                     graduate_area
                     commit_ledger
                     break
@@ -922,8 +930,42 @@ main() {
         fi
     done
 
+    log "=== Target finished: $FOCUS_PATH ($pr_count PRs, $idle_count idle) ==="
+}
+
+# ── Main loop ───────────────────────────────────────────────────────
+
+main() {
+    log "=== Refinement loop starting ==="
+    log "Types: ${ENABLED_TYPES[*]}"
+
+    local target_count
+    target_count="$(yq -p toml -oy '.targets | length' "$CONFIG")"
+
+    if [[ "$target_count" -eq 0 ]]; then
+        log "ERROR: No targets configured in $CONFIG"
+        exit 1
+    fi
+
+    log "Targets: $target_count configured"
+
+    local targets_remaining=0
+    for ((t = 0; t < target_count; t++)); do
+        FOCUS_PATH="$(yq -p toml -oy ".targets[$t].path" "$CONFIG")"
+        run_target
+        # Check if we just graduated or it was already graduated
+        local status_after
+        status_after="$(jq -r --arg key "$FOCUS_PATH" '.areas[$key].status // "active"' "$LEDGER" 2>/dev/null || echo "active")"
+        if [[ "$status_after" != "graduated" ]]; then
+            targets_remaining=$((targets_remaining + 1))
+        fi
+    done
+
+    if [[ "$targets_remaining" -eq 0 ]]; then
+        log "All targets graduated. Add new targets to refine.toml or reset ledger entries to re-run."
+    fi
+
     log "=== Refinement loop finished ==="
-    log "Summary: $pr_count PRs opened, $idle_count consecutive idle results"
 }
 
 main


### PR DESCRIPTION
## Summary
- Fix `actions/checkout@v6` and `upload-artifact@v6` → `@v4` (v6 doesn't exist, workflow would fail immediately)
- Add `schedule: cron '0 */2 * * *'` for continuous operation (every 2h, 120m timeout, concurrency group prevents overlap)
- Replace single `[focus] path` with `[[targets]]` array — loop advances to next non-graduated target automatically
- Fix `log()` writing to stdout which corrupted `action="$(run_iteration)"` capture — now writes to stderr
- Extract `finding_type` from Claude's JSON response and pass through to all `update_ledger` calls (was always empty)
- Add `"type"` field to prompt output schema so Claude reports the category
- Seed 5 targets ranked by new code volume × trust-boundary exposure: `service/src/trust/`, `crates/tc-engine-api/`, `service/src/rooms/`, `service/src/sim/`, `crates/tc-engine-polling/`

## Test plan
- [ ] `bash -n scripts/refine.sh` — syntax OK
- [ ] `shellcheck scripts/refine.sh` — clean
- [ ] `yq -p toml -oy '.targets | length' refine.toml` returns 5
- [ ] `./scripts/refine.sh --dry-run` iterates all targets and generates prompts
- [ ] Manual `gh workflow run refine.yml` to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)