### PR TITLE
fix: rooms nav accordion UX — match Docs pattern

### DIFF
--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react';
 import {
   IconBook2,
-  IconChevronRight,
   IconCode,
   IconDoor,
   IconHome2,
   IconInfoCircle,
   IconKey,
+  IconList,
   IconLogin,
   IconUserPlus,
 } from '@tabler/icons-react';
@@ -178,47 +177,33 @@ function RoomsAccordion({
   const currentPath = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const [opened, setOpened] = useState(() => currentPath.startsWith('/rooms'));
 
   return (
-    <>
+    <NavLink
+      label="Rooms"
+      leftSection={<IconDoor size={18} stroke={1.5} />}
+      active={isActive('/rooms')}
+      defaultOpened={currentPath.startsWith('/rooms')}
+      fw={500}
+    >
       <NavLink
         component={Link}
         to="/rooms"
-        label="Rooms"
-        leftSection={<IconDoor size={18} stroke={1.5} />}
-        rightSection={
-          <IconChevronRight
-            size={14}
-            stroke={1.5}
-            style={{
-              transform: opened ? 'rotate(90deg)' : undefined,
-              transition: 'transform 200ms ease',
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setOpened((o) => !o);
-            }}
-          />
-        }
-        active={isActive('/rooms')}
+        label="All Rooms"
+        leftSection={<IconList size={16} stroke={1.5} />}
+        active={currentPath === '/rooms'}
         onClick={onNavigate}
-        fw={500}
       />
-      {opened
-        ? rooms?.map((room) => (
-            <NavLink
-              key={room.id}
-              component={Link}
-              to={`/rooms/${room.id}`}
-              label={room.name}
-              active={isActive(`/rooms/${room.id}`)}
-              onClick={onNavigate}
-              pl="lg"
-            />
-          ))
-        : null}
-    </>
+      {rooms?.map((room) => (
+        <NavLink
+          key={room.id}
+          component={Link}
+          to={`/rooms/${room.id}`}
+          label={room.name}
+          active={isActive(`/rooms/${room.id}`)}
+          onClick={onNavigate}
+        />
+      ))}
+    </NavLink>
   );
 }

--- a/web/tests/e2e/rooms.spec.ts
+++ b/web/tests/e2e/rooms.spec.ts
@@ -23,9 +23,14 @@ test('rooms page is accessible from navbar', async ({ page }) => {
     /* burger not present on desktop — expected */
   });
 
-  const roomsLink = page.getByRole('link', { name: /^Rooms$/i });
-  await expect(roomsLink).toBeVisible({ timeout: 5_000 });
-  await roomsLink.click();
+  // "Rooms" is an accordion NavLink — click to expand, then click "All Rooms" to navigate
+  const roomsAccordion = page.locator('.mantine-NavLink-root', { hasText: /^Rooms$/ });
+  await expect(roomsAccordion).toBeVisible({ timeout: 5_000 });
+  await roomsAccordion.click();
+
+  const allRoomsLink = page.getByRole('link', { name: /All Rooms/i });
+  await expect(allRoomsLink).toBeVisible({ timeout: 5_000 });
+  await allRoomsLink.click();
 
   // Should navigate to rooms page
   await expect(page).toHaveURL(/\/rooms/);


### PR DESCRIPTION
## Summary
- Rooms accordion now matches Docs pattern: click toggles open/close
- "All Rooms" child link navigates to `/rooms` index
- Individual rooms listed below
- E2E test updated for accordion behavior

Follow-up to #721.

## Test plan
- [ ] Click "Rooms" toggles accordion (does not navigate)
- [ ] "All Rooms" navigates to `/rooms`
- [ ] Individual room links work
- [ ] Indentation matches Docs accordion

🤖 Generated with [Claude Code](https://claude.com/claude-code)