### PR TITLE
refine: validate denouncement reason length at HTTP boundary

### DIFF
--- a/service/src/trust/http/mod.rs
+++ b/service/src/trust/http/mod.rs
@@ -223,6 +223,16 @@ async fn denounce_handler(
         Err(e) => return e,
     };
 
+    if body.reason.is_empty() || body.reason.len() > 500 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "reason must be between 1 and 500 characters".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
     match trust_service
         .denounce(auth.account_id, body.target_id, &body.reason)
         .await


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added length validation (1–500 chars) for the denouncement reason field in the HTTP handler, which previously accepted empty strings and arbitrarily large payloads against a TEXT column with no DB-level constraint.

---
*Generated by [refine.sh](scripts/refine.sh)*