### PR TITLE
fix: quiet duplicate signup postgres errors

### DIFF
--- a/service/src/identity/repo/accounts.rs
+++ b/service/src/identity/repo/accounts.rs
@@ -49,6 +49,7 @@ where
         r"
         INSERT INTO accounts (id, username, root_pubkey, root_kid)
         VALUES ($1, $2, $3, $4)
+        ON CONFLICT (username) DO NOTHING
         ",
     )
     .bind(id)
@@ -59,17 +60,20 @@ where
     .await;
 
     match result {
-        Ok(_) => Ok(CreatedAccount {
-            id,
-            root_kid: root_kid.clone(),
-        }),
+        Ok(r) => {
+            if r.rows_affected() == 0 {
+                return Err(AccountRepoError::DuplicateUsername);
+            }
+            Ok(CreatedAccount {
+                id,
+                root_kid: root_kid.clone(),
+            })
+        }
         Err(e) => {
             if let sqlx::Error::Database(db_err) = &e {
                 if let Some(constraint) = db_err.constraint() {
-                    match constraint {
-                        "accounts_username_key" => return Err(AccountRepoError::DuplicateUsername),
-                        "accounts_root_kid_key" => return Err(AccountRepoError::DuplicateKey),
-                        _ => {}
+                    if constraint == "accounts_root_kid_key" {
+                        return Err(AccountRepoError::DuplicateKey);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Use `ON CONFLICT (username) DO NOTHING` in the accounts INSERT instead of catching the constraint violation after the fact
- Detects duplicate usernames via `rows_affected() == 0` — same `DuplicateUsername` error, same 409 response, but postgres no longer logs an ERROR for each attempt
- The sim CronJob re-signs-up 20 deterministic accounts every 30 min; this eliminates ~20 postgres ERROR lines per run that were drowning real signals on the Grafana health dashboard

## Test plan
- [x] `cargo test --test identity_repo_tests` — 8 passed
- [x] `cargo test --test identity_handler_tests` — 17 passed
- [x] `cargo test --test proptest_signup_tests` — 24 passed
- [x] `cargo test -p tinycongress-api -- identity::service` — 56 passed
- [x] `cargo clippy -p tinycongress-api -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)