### PR TITLE
fix(refine): fallback when Claude omits JSON output

### DIFF
--- a/scripts/refine-prompt.md
+++ b/scripts/refine-prompt.md
@@ -61,3 +61,5 @@ After you are done, your final text output MUST be valid JSON matching this sche
 - `"clean"`: Nothing worth improving in the focus area. No changes made.
 
 `type` and `impact` are REQUIRED on all actions (including `clean` — categorize and rate what was found, even if nothing was worth doing).
+
+**CRITICAL: Your very last output MUST be the JSON object above and nothing else. Do not write any text after the JSON. Do not wrap it in a code fence. Just output raw JSON as your final message.**

--- a/scripts/refine.sh
+++ b/scripts/refine.sh
@@ -799,10 +799,21 @@ for i, c in enumerate(text):
     fi
 
     if [[ -z "$json_block" ]]; then
-        log "WARNING: Could not parse JSON from Claude's response"
-        log "Response: $(echo "$response_text" | head -5)"
-        cleanup_worktree "$wt_path" "$branch"
-        return 1
+        # Fallback: if Claude made commits but forgot to output JSON,
+        # don't waste the work — treat it as a change with unknown metadata.
+        local fallback_commits
+        fallback_commits="$(git -C "$wt_path" rev-list --count master..HEAD 2>/dev/null || echo "0")"
+        if [[ "$fallback_commits" -gt 0 ]]; then
+            local fallback_summary
+            fallback_summary="$(git -C "$wt_path" log -1 --format=%s 2>/dev/null || echo "auto-detected change")"
+            log "WARNING: No JSON output but found $fallback_commits commit(s), treating as change"
+            json_block="{\"action\":\"change\",\"type\":\"unknown\",\"impact\":\"medium\",\"summary\":$(echo "$fallback_summary" | jq -Rs '.')}"
+        else
+            log "WARNING: Could not parse JSON from Claude's response"
+            log "Response: $(echo "$response_text" | head -5)"
+            cleanup_worktree "$wt_path" "$branch"
+            return 1
+        fi
     fi
 
     local action


### PR DESCRIPTION
## Summary
- Claude does the work (commits, tests) but outputs conversational text instead of required JSON — every iteration was failing despite successful changes
- Add commit-detection fallback: if JSON parsing fails but commits exist on the branch, treat as a `change` action using the commit message as summary
- Reinforce JSON requirement at end of prompt (recency bias improves compliance)

Evidence from first run: 4 consecutive iterations failed with `WARNING: Could not parse JSON from Claude's response` despite Claude making commits and pushing a branch (`refine/service-src-trust-20260319-161452`).

## Test plan
- [ ] `bash -n scripts/refine.sh && shellcheck scripts/refine.sh` — clean
- [ ] Next refine run should recover from non-JSON responses instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)