### PR TITLE
refine: add HTTP tests for invite delivery_method and relationship_depth validation

### DIFF
--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -538,3 +538,66 @@ async fn endorse_rejects_weight_above_one() {
     let response = app.oneshot(request).await.expect("response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+// ─── Create invite validation ─────────────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn create_invite_rejects_invalid_delivery_method() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("invitedelivery", db.pool()).await;
+
+    let envelope_b64 = tc_crypto::encode_base64url(b"dummy");
+    let body = serde_json::json!({
+        "envelope": envelope_b64,
+        "delivery_method": "fax",
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(json["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains("delivery_method"));
+}
+
+#[shared_runtime_test]
+async fn create_invite_rejects_invalid_relationship_depth() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("invitedepth", db.pool()).await;
+
+    let envelope_b64 = tc_crypto::encode_base64url(b"dummy");
+    let body = serde_json::json!({
+        "envelope": envelope_b64,
+        "delivery_method": "qr",
+        "relationship_depth": "decades",
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(json["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains("relationship_depth"));
+}


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added two HTTP integration tests for invite boundary validation: `create_invite_rejects_invalid_delivery_method` and `create_invite_rejects_invalid_relationship_depth`, covering error paths for the validation added in the previous refinement PR.

---
*Generated by [refine.sh](scripts/refine.sh)*