### PR TITLE
refine: add HTTP tests for create_invite weight validation

### DIFF
--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -602,6 +602,64 @@ async fn create_invite_rejects_invalid_relationship_depth() {
         .contains("relationship_depth"));
 }
 
+// ─── Create invite weight validation ─────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn create_invite_rejects_weight_zero() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("inviteweightzero", db.pool()).await;
+
+    let envelope_b64 = tc_crypto::encode_base64url(b"dummy");
+    let body = serde_json::json!({
+        "envelope": envelope_b64,
+        "delivery_method": "qr",
+        "weight": 0.0,
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(json["error"].as_str().unwrap_or("").contains("weight"));
+}
+
+#[shared_runtime_test]
+async fn create_invite_rejects_weight_above_one() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("inviteweightabove", db.pool()).await;
+
+    let envelope_b64 = tc_crypto::encode_base64url(b"dummy");
+    let body = serde_json::json!({
+        "envelope": envelope_b64,
+        "delivery_method": "qr",
+        "weight": 1.5,
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(json["error"].as_str().unwrap_or("").contains("weight"));
+}
+
 // ─── Denounce validation ──────────────────────────────────────────────────────
 
 #[shared_runtime_test]


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added two HTTP integration tests covering the untested error paths in create_invite_handler for explicit out-of-range weight values (0.0 and >1.0), matching the existing test pattern for the endorse handler.

---
*Generated by [refine.sh](scripts/refine.sh)*