### PR TITLE
refine: propagate error from verifier check in endorse

### DIFF
--- a/service/src/trust/service.rs
+++ b/service/src/trust/service.rs
@@ -120,8 +120,7 @@ impl TrustService for DefaultTrustService {
         let is_verifier = self
             .reputation_repo
             .has_endorsement(endorser_id, "authorized_verifier")
-            .await
-            .unwrap_or(false);
+            .await?;
 
         if !is_verifier {
             let active_count = self


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

refine: propagate error from verifier check in endorse

---
*Generated by [refine.sh](scripts/refine.sh)*