### PR TITLE
refine: add HTTP test for endorse self-action rejection

### DIFF
--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -353,6 +353,32 @@ async fn test_create_invite_returns_201() {
     assert!(json["expires_at"].is_string());
 }
 
+// ─── Endorse self-action validation ──────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn endorse_rejects_self_endorsement() {
+    let db = isolated_db().await;
+    let (app, keys, account_id) = signup_and_get_account("selfendorser", db.pool()).await;
+
+    let body = serde_json::json!({ "subject_id": account_id, "weight": 1.0 }).to_string();
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/endorse",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(json["error"]
+        .as_str()
+        .unwrap_or("")
+        .to_lowercase()
+        .contains("yourself"));
+}
+
 // ─── Endorse weight validation ────────────────────────────────────────────────
 
 #[shared_runtime_test]


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added `endorse_rejects_self_endorsement` HTTP integration test covering the previously untested `SelfAction` error path, which returns 400 BAD_REQUEST when a user attempts to endorse themselves.

---
*Generated by [refine.sh](scripts/refine.sh)*