### PR TITLE
fix: smoke test uses stale ibcook.com domain

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -6,7 +6,7 @@ on:
       url:
         description: "Target URL to test against"
         required: false
-        default: "https://tiny-congress-demo.ibcook.com"
+        default: "https://demo.tinycongress.com"
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -34,14 +34,14 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             BASE="${{ github.event.inputs.url }}"
           else
-            BASE="https://tiny-congress-demo.ibcook.com"
+            BASE="https://demo.tinycongress.com"
           fi
-          if [[ "$BASE" != *"tiny-congress-demo."* ]]; then
-            echo "Non-default URLs must follow the tiny-congress-demo.* pattern for API/verifier derivation"
+          if [[ "$BASE" != *"demo.tinycongress.com"* ]]; then
+            echo "Non-default URLs must follow the demo.tinycongress.com pattern for API/verifier derivation"
             exit 1
           fi
-          API="${BASE/https:\/\/tiny-congress-demo./https://tc-api-demo.}"
-          VERIFIER="${BASE/https:\/\/tiny-congress-demo./https://tc-verify-demo.}"
+          API="${BASE/demo.tinycongress.com/demo-api.tinycongress.com}"
+          VERIFIER="${BASE/demo.tinycongress.com/demo-verify.tinycongress.com}"
           {
             echo "frontend=$BASE"
             echo "api=$API"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A community governance platform where verified people vote on issues that matter
 
 Users generate Ed25519 key pairs client-side; the server never sees private keys. Multi-dimensional polls let communities express the *shape* of their opinion, not just a binary position.
 
-**Demo**: [tiny-congress-demo.ibcook.com](https://tiny-congress-demo.ibcook.com) | **Website**: [tinycongress.com](https://tinycongress.com)
+**Demo**: [demo.tinycongress.com](https://demo.tinycongress.com) | **Website**: [tinycongress.com](https://tinycongress.com)
 
 ## How It Works
 

--- a/docs/demo-readiness-checklist.md
+++ b/docs/demo-readiness-checklist.md
@@ -14,7 +14,7 @@ These are the things where, if missing, someone gets stuck or confused and close
 
 - [x] **Landing page that explains what this is in one sentence.** Handled by separate landing page — not part of the app flow.
 - [x] **Signup flow completes without errors.** E2E tests cover happy path including mobile Safari via smoke test. *(PR #503)*
-- [x] **Verification flow has clear instructions.** Demo verifier at `tc-verify-demo.ibcook.com` with method selection UI (Government ID, Phone, Email). Users are redirected to a separate site that explains the step. *(PR #456)*
+- [x] **Verification flow has clear instructions.** Demo verifier at `demo-verify.tinycongress.com` with method selection UI (Government ID, Phone, Email). Users are redirected to a separate site that explains the step. *(PR #456)*
 - [x] **Verification success is obvious.** Callback page shows green confirmation, navbar shows green "Verified" badge, settings page shows verification status and method. *(PR #456)*
 - [x] **Error states don't dead-end.** Signup/login show error messages with a way forward. *(PR #503)*
 - [x] **Login flow works end-to-end on mobile Safari.** Covered by smoke test `mobile-safari` Playwright project running against live demo URL. *(PR #527)*
@@ -42,7 +42,7 @@ These are the things where, if missing, someone gets stuck or confused and close
 ### Infrastructure
 
 - [x] **Demo environment is stable and publicly accessible.** Smoke test runs on every master merge to verify. *(PR #527)*
-- [x] **Demo verifier deployed and accessible.** Preflight health check validates `tc-verify-demo.ibcook.com` on every smoke run. *(PR #527)*
+- [x] **Demo verifier deployed and accessible.** Preflight health check validates `demo-verify.tinycongress.com` on every smoke run. *(PR #527)*
 - [x] **HTTPS works.** Preflight curls all three domains over HTTPS; failures block the smoke run. *(PR #527)*
 - [ ] **Page load is under 5 seconds.** Not explicitly measured — validate manually on a real device before Mar 20.
 


### PR DESCRIPTION
## Summary
- Smoke test pointed at `tiny-congress-demo.ibcook.com` (NXDOMAIN since domain migration)
- Updated to `demo.tinycongress.com` / `demo-api.tinycongress.com` / `demo-verify.tinycongress.com`
- Fixed URL derivation logic and validation pattern
- Updated README and demo-readiness-checklist stale references

This is why the demo has been 3h stale — smoke test fails on preflight DNS, blocking the deploy feedback loop.

## Test plan
- [ ] Smoke test preflight resolves all three URLs
- [ ] `workflow_dispatch` validation accepts new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)