### PR TITLE
fix(ci): skip deploy-gitops for docs/ledger-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
       chart: ${{ steps.filter.outputs.chart }}
       dashboards: ${{ steps.filter.outputs.dashboards }}
       ci: ${{ inputs.force_all == true && 'true' || steps.filter.outputs.ci }}
+      deployable: ${{ inputs.force_all == true && 'true' || steps.filter.outputs.deployable }}
       # Runner tier outputs — set all at once, each job picks the right size.
       # Toggle: gh variable set USE_ARC_RUNNERS --body "false" --repo icook/tiny-congress
       runner-small: ${{ steps.runner.outputs.small }}
@@ -438,6 +439,21 @@ jobs:
               - 'kube/dashboards/**'
               - 'kube/app/files/dashboards/**'
             ci:
+              - '.github/workflows/**'
+              - '!.github/workflows/build-arc-runner.yml'
+              - 'skaffold.yaml'
+              - 'justfile'
+            # Union of all paths that should trigger a deploy. Used by
+            # deploy-gitops to skip docs/ledger-only pushes. Keep this
+            # in sync when adding new deployable path categories above.
+            deployable:
+              - 'service/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'web/**'
+              - 'dockerfiles/**'
+              - 'kube/**'
               - '.github/workflows/**'
               - '!.github/workflows/build-arc-runner.yml'
               - 'skaffold.yaml'
@@ -1334,9 +1350,11 @@ jobs:
   # ── Update gitops image digests (master only) ────────────
   deploy-gitops:
     name: Update gitops image digests
+    # Skip deploy for docs/ledger-only pushes (no deployable paths changed).
     if: >-
       always() && github.event_name == 'push' && github.ref == 'refs/heads/master' &&
-      needs.ci-gate.result == 'success'
+      needs.ci-gate.result == 'success' &&
+      needs.detect-changes.outputs.deployable == 'true'
     needs: [ci-gate, detect-changes]
     runs-on: ${{ needs.detect-changes.outputs.runner-small }}
     permissions:


### PR DESCRIPTION
## Summary
- Refine bot's ledger commits to master were triggering `deploy-gitops`, causing unnecessary Flux reconciliations with identical images
- Add a `deployable` union path filter to `detect-changes` covering all deploy-worthy paths (service, web, crates, kube, dockerfiles, workflows, skaffold, justfile)
- `deploy-gitops` now gates on `deployable == 'true'` — docs, ledger, and `.plan/` changes skip deploy
- New deployable paths only need to be added in one place (the `deployable` filter)

## Test plan
- [ ] Verify `actionlint` passes (included in `just lint-static`)
- [ ] Confirm a code-changing push to master still triggers deploy
- [ ] Confirm a ledger-only push (from refine bot) skips deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)