### PR TITLE
fix: show correct copy for draft polls on vote page

### DIFF
--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -308,9 +308,15 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
         </Card>
       ) : (
         <Card shadow="sm" padding="lg" radius="md" withBorder>
-          <Alert icon={<IconLock size={16} />} color="gray" title="Poll closed">
-            This poll is no longer accepting votes.
-          </Alert>
+          {poll.status === 'draft' ? (
+            <Alert icon={<IconLock size={16} />} color="blue" title="Voting not open yet">
+              This poll hasn&apos;t opened yet. Check back when it&apos;s active.
+            </Alert>
+          ) : (
+            <Alert icon={<IconLock size={16} />} color="gray" title="Poll closed">
+              This poll is no longer accepting votes.
+            </Alert>
+          )}
         </Card>
       )}
 


### PR DESCRIPTION
## Summary

- Draft polls showed "This poll is no longer accepting votes" — same message as closed polls
- Added a `poll.status === 'draft'` branch in the non-active card: shows a blue "Voting not open yet" alert with copy "This poll hasn't opened yet. Check back when it's active."
- Closed polls retain the existing gray "Poll closed / no longer accepting votes" message

Closes #748

## Test plan

- [ ] Navigate to a draft poll's vote page — confirm blue alert "Voting not open yet / This poll hasn't opened yet. Check back when it's active." is shown
- [ ] Navigate to a closed poll's vote page — confirm gray alert "Poll closed / This poll is no longer accepting votes." is unchanged
- [ ] Active polls still show the voting card
- [ ] `npx tsc --noEmit` passes (no TypeScript errors)
- [ ] `just test-frontend` passes (151 tests, 0 failures)

Generated with [Claude Code](https://claude.com/claude-code)