### PR TITLE
refactor: replace inline styles with Mantine style props (ADR-005)

### DIFF
--- a/web/src/Router.tsx
+++ b/web/src/Router.tsx
@@ -223,7 +223,7 @@ export function Router() {
 
   if (isLoading) {
     return (
-      <Center style={{ height: '100vh' }}>
+      <Center h="100vh">
         <Loader size="sm" />
       </Center>
     );
@@ -242,7 +242,7 @@ function RoomDetailPageWrapper() {
 
   if (isLoading) {
     return (
-      <Center style={{ height: '100vh' }}>
+      <Center h="100vh">
         <Loader size="sm" />
       </Center>
     );

--- a/web/src/components/DocsList.tsx
+++ b/web/src/components/DocsList.tsx
@@ -25,7 +25,8 @@ export function DocsList({ docs }: DocsListProps) {
           padding="md"
           radius="md"
           withBorder
-          style={{ textDecoration: 'none', cursor: 'pointer' }}
+          td="none"
+          style={{ cursor: 'pointer' }}
         >
           <Group gap="xs" wrap="nowrap">
             <IconBook2 size={16} style={{ flexShrink: 0 }} />

--- a/web/src/engines/polling/PollEngineView.tsx
+++ b/web/src/engines/polling/PollEngineView.tsx
@@ -104,7 +104,8 @@ function ClosedPollCard({ roomId, poll }: { roomId: string; poll: Poll }) {
       padding="sm"
       radius="sm"
       withBorder
-      style={{ cursor: 'pointer', textDecoration: 'none', color: 'inherit' }}
+      td="none"
+      style={{ cursor: 'pointer', color: 'inherit' }}
     >
       <Group justify="space-between" wrap="nowrap">
         <Text size="sm">{poll.question}</Text>

--- a/web/src/engines/polling/components/UpcomingPollPreview.tsx
+++ b/web/src/engines/polling/components/UpcomingPollPreview.tsx
@@ -27,9 +27,9 @@ export function UpcomingPollPreview({ poll, roomId }: Props) {
       withBorder
       padding="sm"
       radius="md"
+      td="none"
       style={{
         borderStyle: 'dashed',
-        textDecoration: 'none',
         cursor: 'pointer',
       }}
     >

--- a/web/src/features/identity/components/DeviceList.tsx
+++ b/web/src/features/identity/components/DeviceList.tsx
@@ -94,7 +94,7 @@ export function DeviceList({
                           cancelEditing();
                         }
                       }}
-                      style={{ width: 150 }}
+                      w={150}
                     />
                     <ActionIcon
                       size="sm"

--- a/web/src/pages/Poll.page.tsx
+++ b/web/src/pages/Poll.page.tsx
@@ -9,6 +9,7 @@ import { BarChart } from '@mantine/charts';
 import {
   Alert,
   Badge,
+  Box,
   Button,
   Card,
   Group,
@@ -142,7 +143,7 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
   return (
     <Stack gap="md" maw={800} mx="auto" mt="xl" px="md">
       <Group gap={6}>
-        <Text component={Link} to="/rooms" size="sm" c="dimmed" style={{ textDecoration: 'none' }}>
+        <Text component={Link} to="/rooms" size="sm" c="dimmed" td="none">
           Rooms
         </Text>
         <Text size="sm" c="dimmed">
@@ -150,13 +151,7 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
         </Text>
         {roomName ? (
           <>
-            <Text
-              component={Link}
-              to={`/rooms/${roomId}`}
-              size="sm"
-              c="dimmed"
-              style={{ textDecoration: 'none' }}
-            >
+            <Text component={Link} to={`/rooms/${roomId}`} size="sm" c="dimmed" td="none">
               {roomName}
             </Text>
             <Text size="sm" c="dimmed">
@@ -164,16 +159,7 @@ export function PollPage({ roomId, pollId }: PollPageProps) {
             </Text>
           </>
         ) : null}
-        <Text
-          size="sm"
-          c="dimmed"
-          style={{
-            maxWidth: 200,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
+        <Text size="sm" c="dimmed" truncate maw={200}>
           {poll.question}
         </Text>
       </Group>
@@ -386,7 +372,7 @@ function VoteSlider({
         </Text>
       ) : null}
       <EvidenceCards evidence={dimension.evidence} />
-      <div style={{ paddingBottom: 8, paddingLeft: 8, paddingRight: 8 }}>
+      <Box pb={8} px={8}>
         <Slider
           value={value}
           onChange={onChange}
@@ -412,7 +398,7 @@ function VoteSlider({
             },
           }}
         />
-      </div>
+      </Box>
     </div>
   );
 }

--- a/web/src/pages/Rooms.page.tsx
+++ b/web/src/pages/Rooms.page.tsx
@@ -63,7 +63,8 @@ function PollListItem({ roomId, poll }: { roomId: string; poll: Poll }) {
       padding="sm"
       radius="sm"
       withBorder
-      style={{ cursor: 'pointer', textDecoration: 'none' }}
+      td="none"
+      style={{ cursor: 'pointer' }}
     >
       <Group justify="space-between" wrap="nowrap">
         <Text size="sm">{poll.question}</Text>
@@ -87,7 +88,8 @@ function RoomCard({ room }: { room: Room }) {
       padding="lg"
       radius="md"
       withBorder
-      style={{ cursor: 'pointer', textDecoration: 'none', color: 'inherit' }}
+      td="none"
+      style={{ cursor: 'pointer', color: 'inherit' }}
     >
       <Stack gap="sm">
         <Group justify="space-between">

--- a/web/src/providers/CryptoProvider.tsx
+++ b/web/src/providers/CryptoProvider.tsx
@@ -88,7 +88,7 @@ export function CryptoProvider({ children }: CryptoProviderProps) {
   // This ensures crypto is always available when useCryptoRequired is called
   if (state.isLoading) {
     return (
-      <Center style={{ height: '100vh' }}>
+      <Center h="100vh">
         <Loader size="sm" />
       </Center>
     );


### PR DESCRIPTION
## Summary

- Replaces `style={{ height: '100vh' }}` with `h="100vh"` in `Router.tsx` (2 occurrences) and `CryptoProvider.tsx`
- Replaces `style={{ width: 150 }}` with `w={150}` in `DeviceList.tsx`
- Replaces multi-property inline style on `Text` with `truncate maw={200}` in `Poll.page.tsx`
- Replaces `style={{ paddingBottom: 8, paddingLeft: 8, paddingRight: 8 }}` on `<div>` with `<Box pb={8} px={8}>` in `Poll.page.tsx` (imports `Box`)
- Replaces `textDecoration: 'none'` with `td="none"` on Mantine components in `Poll.page.tsx` (2), `Rooms.page.tsx` (2), `DocsList.tsx`, `PollEngineView.tsx`, `UpcomingPollPreview.tsx`

## Excluded (per issue spec)

`cursor: 'pointer'`, `color: 'inherit'`, `borderStyle: 'dashed'` remain in style props — no Mantine equivalents. Native HTML elements (`<a>`, `<Link>`) and dynamic CSS variables (`Navbar.tsx`) were not touched.

## Test plan

- [x] `yarn typecheck` — passes
- [x] `yarn eslint --cache src/` — passes (0 warnings, 0 errors)
- [x] `yarn vitest run src/` — 131 tests pass; 4 pre-existing WASM failures unrelated to this change

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)