### PR TITLE
chore: remove dead recompute_global stub from trust engine

### DIFF
--- a/service/src/trust/engine.rs
+++ b/service/src/trust/engine.rs
@@ -233,16 +233,4 @@ WHERE revoked_at IS NULL
         }
         Ok(count)
     }
-
-    /// Compute global eigenvector centrality across the entire graph.
-    ///
-    /// Stubbed for post-demo implementation — global eigenvector centrality
-    /// requires iterative power-method convergence and is not needed at demo scale.
-    ///
-    /// # Errors
-    ///
-    /// Always returns `Ok(0)` in the current stub implementation.
-    pub fn recompute_global(&self, _trust_repo: &dyn TrustRepo) -> Result<usize, anyhow::Error> {
-        Ok(0)
-    }
 }


### PR DESCRIPTION
## Summary
- Removes `recompute_global` pub method from trust engine
- Method always returned `Ok(0)` and had zero callers
- Confirmed no callers via grep across the codebase

## Test plan
- [x] `just test-backend` passes
- [x] No callers exist — confirmed via grep before removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)