### PR TITLE
refactor: move denouncements query from handler to TrustRepo (#774)

### DIFF
--- a/service/src/trust/http/mod.rs
+++ b/service/src/trust/http/mod.rs
@@ -9,9 +9,8 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::repo::{TrustRepo, TrustRepoError};
@@ -122,16 +121,6 @@ pub struct DenouncementResponse {
     pub created_at: String,
 }
 
-/// Row returned by the denouncements join query.
-#[derive(sqlx::FromRow)]
-struct DenouncementWithUsername {
-    pub id: Uuid,
-    pub target_id: Uuid,
-    pub target_username: String,
-    pub reason: String,
-    pub created_at: DateTime<Utc>,
-}
-
 // ─── Router ────────────────────────────────────────────────────────────────
 
 pub fn trust_router() -> Router {
@@ -238,21 +227,13 @@ async fn denounce_handler(
 }
 
 async fn list_my_denouncements_handler(
-    Extension(pool): Extension<PgPool>,
+    Extension(trust_repo): Extension<Arc<dyn TrustRepo>>,
     auth: AuthenticatedDevice,
 ) -> impl IntoResponse {
-    let result = sqlx::query_as::<_, DenouncementWithUsername>(
-        "SELECT d.id, d.target_id, a.username AS target_username, d.reason, d.created_at \
-         FROM trust__denouncements d \
-         JOIN accounts a ON a.id = d.target_id \
-         WHERE d.accuser_id = $1 \
-         ORDER BY d.created_at DESC",
-    )
-    .bind(auth.account_id)
-    .fetch_all(&pool)
-    .await;
-
-    match result {
+    match trust_repo
+        .list_denouncements_by_with_username(auth.account_id)
+        .await
+    {
         Ok(rows) => {
             let denouncements = rows
                 .into_iter()
@@ -266,10 +247,7 @@ async fn list_my_denouncements_handler(
                 .collect::<Vec<_>>();
             (StatusCode::OK, Json(denouncements)).into_response()
         }
-        Err(e) => {
-            tracing::error!("list_my_denouncements failed: {e}");
-            internal_error()
-        }
+        Err(ref e) => trust_repo_error_response(e),
     }
 }
 

--- a/service/src/trust/repo/denouncements.rs
+++ b/service/src/trust/repo/denouncements.rs
@@ -79,6 +79,23 @@ pub(super) async fn list_denouncements_by(
     Ok(records)
 }
 
+pub(super) async fn list_denouncements_by_with_username(
+    pool: &PgPool,
+    accuser_id: Uuid,
+) -> Result<Vec<super::DenouncementWithUsername>, TrustRepoError> {
+    let records = sqlx::query_as::<_, super::DenouncementWithUsername>(
+        "SELECT d.id, d.target_id, a.username AS target_username, d.reason, d.created_at \
+         FROM trust__denouncements d \
+         JOIN accounts a ON a.id = d.target_id \
+         WHERE d.accuser_id = $1 \
+         ORDER BY d.created_at DESC",
+    )
+    .bind(accuser_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(records)
+}
+
 /// Count total denouncements filed by `accuser_id` (permanent budget — no refunds).
 pub(super) async fn count_active_denouncements_by(
     pool: &PgPool,

--- a/service/src/trust/repo/mod.rs
+++ b/service/src/trust/repo/mod.rs
@@ -45,6 +45,16 @@ pub struct ActionRecord {
     pub processed_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// A denouncement filed by one user against another, joined with the target's username.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DenouncementWithUsername {
+    pub id: Uuid,
+    pub target_id: Uuid,
+    pub target_username: String,
+    pub reason: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// A denouncement filed by one user against another.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct DenouncementRecord {
@@ -131,6 +141,11 @@ pub trait TrustRepo: Send + Sync {
         &self,
         accuser_id: Uuid,
     ) -> Result<Vec<DenouncementRecord>, TrustRepoError>;
+
+    async fn list_denouncements_by_with_username(
+        &self,
+        accuser_id: Uuid,
+    ) -> Result<Vec<DenouncementWithUsername>, TrustRepoError>;
 
     async fn count_active_denouncements_by(&self, accuser_id: Uuid) -> Result<i64, TrustRepoError>;
 
@@ -267,6 +282,13 @@ impl TrustRepo for PgTrustRepo {
         accuser_id: Uuid,
     ) -> Result<Vec<DenouncementRecord>, TrustRepoError> {
         denouncements::list_denouncements_by(&self.pool, accuser_id).await
+    }
+
+    async fn list_denouncements_by_with_username(
+        &self,
+        accuser_id: Uuid,
+    ) -> Result<Vec<DenouncementWithUsername>, TrustRepoError> {
+        denouncements::list_denouncements_by_with_username(&self.pool, accuser_id).await
     }
 
     async fn count_active_denouncements_by(&self, accuser_id: Uuid) -> Result<i64, TrustRepoError> {


### PR DESCRIPTION
## Summary
- Moved raw SQL from `list_my_denouncements_handler` into the `TrustRepo` trait
- Handler now uses `Arc<dyn TrustRepo>` consistent with every other trust handler
- Closes #774

## Test plan
- [x] `just test-backend` passes
- [x] Handler behavior unchanged — same query, same response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)