### PR TITLE
fix: align invite query keys to prevent stale cache (#780)

### DIFF
--- a/web/src/features/endorsements/api/queries.ts
+++ b/web/src/features/endorsements/api/queries.ts
@@ -52,7 +52,7 @@ export function useMyInvites(
   crypto: CryptoModule | undefined
 ) {
   return useQuery({
-    queryKey: ['my-invites', deviceKid],
+    queryKey: ['trust-invites', deviceKid],
     queryFn: async () => {
       if (!deviceKid || !privateKey || !crypto) {
         throw new Error('Not authenticated');
@@ -70,7 +70,7 @@ export function useCreateInvite(deviceKid: string, privateKey: CryptoKey, crypto
     mutationFn: (payload: CreateInvitePayload) =>
       createInvite(deviceKid, privateKey, crypto, payload),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['my-invites'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
     },
   });
 }
@@ -81,7 +81,7 @@ export function useAcceptInvite(deviceKid: string, privateKey: CryptoKey, crypto
     mutationFn: (inviteId: string) => acceptInvite(deviceKid, privateKey, crypto, inviteId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['my-endorsements'] });
-      void queryClient.invalidateQueries({ queryKey: ['my-invites'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
       void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
       void queryClient.invalidateQueries({ queryKey: ['verification-status'] });
     },


### PR DESCRIPTION
## Summary
- endorsements and trust features used different query keys (`my-invites` vs `trust-invites`) for the same endpoint
- Stale cache caused invites to not reflect after actions in one feature area
- Aligned both to `trust-invites`
- Closes #780

## Test plan
- [x] `just test-frontend` passes
- [x] Verified both call sites now use consistent `trust-invites` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)