### PR TITLE
refactor: consolidate trust API clients and types (#779)

### DIFF
--- a/web/src/api/endorsements.ts
+++ b/web/src/api/endorsements.ts
@@ -1,6 +1,5 @@
 /**
- * Verification API client
- * Queries endorsement status for the authenticated user
+ * Endorsements API client — shared across trust, endorsements, and verification features.
  */
 
 import { signedFetchJson } from '@/api/signing';

--- a/web/src/api/trust.ts
+++ b/web/src/api/trust.ts
@@ -1,0 +1,90 @@
+/**
+ * Trust REST API functions — shared across trust and endorsements features.
+ *
+ * Types and low-level fetch functions live here so both features can import
+ * without violating the no-cross-feature-import ESLint rule.
+ */
+
+import { signedFetchJson } from '@/api/signing';
+import type { CryptoModule } from '@/providers/CryptoProvider';
+
+export interface TrustBudget {
+  slots_total: number;
+  slots_used: number;
+  slots_available: number;
+  out_of_slot_count: number;
+  denouncements_total: number;
+  denouncements_used: number;
+  denouncements_available: number;
+}
+
+export interface Invite {
+  id: string;
+  delivery_method: string;
+  accepted_by: string | null;
+  expires_at: string;
+  accepted_at: string | null;
+}
+
+export interface AcceptInviteResult {
+  endorser_id: string;
+  accepted_at: string;
+}
+
+export interface CreateInvitePayload {
+  envelope: string;
+  delivery_method: string;
+  relationship_depth?: string;
+  attestation: Record<string, unknown>;
+}
+
+export async function getMyBudget(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<TrustBudget> {
+  return signedFetchJson('/trust/budget', 'GET', deviceKid, privateKey, wasmCrypto);
+}
+
+export async function createInvite(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  payload: CreateInvitePayload
+): Promise<Invite> {
+  return signedFetchJson('/trust/invites', 'POST', deviceKid, privateKey, wasmCrypto, payload);
+}
+
+export async function listMyInvites(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<Invite[]> {
+  return signedFetchJson('/trust/invites/mine', 'GET', deviceKid, privateKey, wasmCrypto);
+}
+
+export async function acceptInvite(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  inviteId: string
+): Promise<AcceptInviteResult> {
+  return signedFetchJson(
+    `/trust/invites/${inviteId}/accept`,
+    'POST',
+    deviceKid,
+    privateKey,
+    wasmCrypto
+  );
+}
+
+export async function revokeEndorsement(
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  subjectId: string
+): Promise<void> {
+  await signedFetchJson('/trust/revoke', 'POST', deviceKid, privateKey, wasmCrypto, {
+    subject_id: subjectId,
+  });
+}

--- a/web/src/features/endorsements/api/client.ts
+++ b/web/src/features/endorsements/api/client.ts
@@ -1,69 +1,12 @@
-import { signedFetchJson } from '@/api/signing';
-import type { CryptoModule } from '@/providers/CryptoProvider';
-import type {
-  AcceptInviteResponse,
-  BudgetResponse,
-  CreateInvitePayload,
-  CreateInviteResponse,
-  EndorsementsListResponse,
-  InvitesListResponse,
-} from '../types';
-
-export async function getMyEndorsements(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-): Promise<EndorsementsListResponse> {
-  return signedFetchJson('/me/endorsements', 'GET', deviceKid, privateKey, wasmCrypto);
-}
-
-export async function getTrustBudget(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-): Promise<BudgetResponse> {
-  return signedFetchJson('/trust/budget', 'GET', deviceKid, privateKey, wasmCrypto);
-}
-
-export async function getMyInvites(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-): Promise<InvitesListResponse> {
-  return signedFetchJson('/trust/invites/mine', 'GET', deviceKid, privateKey, wasmCrypto);
-}
-
-export async function createInvite(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule,
-  payload: CreateInvitePayload
-): Promise<CreateInviteResponse> {
-  return signedFetchJson('/trust/invites', 'POST', deviceKid, privateKey, wasmCrypto, payload);
-}
-
-export async function acceptInvite(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule,
-  inviteId: string
-): Promise<AcceptInviteResponse> {
-  return signedFetchJson(
-    `/trust/invites/${inviteId}/accept`,
-    'POST',
-    deviceKid,
-    privateKey,
-    wasmCrypto
-  );
-}
-
-export async function revokeEndorsement(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule,
-  subjectId: string
-): Promise<void> {
-  await signedFetchJson('/trust/revoke', 'POST', deviceKid, privateKey, wasmCrypto, {
-    subject_id: subjectId,
-  });
-}
+/**
+ * Endorsements API client — thin re-exports from shared @/api layer.
+ * The canonical implementations live in @/api/endorsements and @/api/trust.
+ */
+export { getMyEndorsements } from '@/api/endorsements';
+export {
+  getMyBudget as getTrustBudget,
+  listMyInvites as getMyInvites,
+  createInvite,
+  acceptInvite,
+  revokeEndorsement,
+} from '@/api/trust';

--- a/web/src/features/endorsements/api/queries.ts
+++ b/web/src/features/endorsements/api/queries.ts
@@ -1,19 +1,25 @@
+/**
+ * Endorsement query hooks — delegate to shared @/api layer.
+ *
+ * Query keys use the trust naming convention ('trust-*') so all features share
+ * the same cache entries and avoid stale-cache bugs.
+ */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { CryptoModule } from '@/providers/CryptoProvider';
-import type { CreateInvitePayload } from '../types';
+import { getMyEndorsements } from '@/api/endorsements';
 import {
   acceptInvite,
   createInvite,
-  getMyEndorsements,
-  getMyInvites,
-  getTrustBudget,
+  getMyBudget,
+  listMyInvites,
   revokeEndorsement,
-} from './client';
+  type CreateInvitePayload,
+} from '@/api/trust';
+import type { CryptoModule } from '@/providers/CryptoProvider';
 
 export function useTrustBudget(
   deviceKid: string | null,
   privateKey: CryptoKey | null,
-  crypto: CryptoModule | undefined
+  crypto: CryptoModule | null | undefined
 ) {
   return useQuery({
     queryKey: ['trust-budget', deviceKid],
@@ -21,7 +27,7 @@ export function useTrustBudget(
       if (!deviceKid || !privateKey || !crypto) {
         throw new Error('Not authenticated');
       }
-      return getTrustBudget(deviceKid, privateKey, crypto);
+      return getMyBudget(deviceKid, privateKey, crypto);
     },
     enabled: Boolean(deviceKid && privateKey && crypto),
     staleTime: 30_000,
@@ -31,10 +37,10 @@ export function useTrustBudget(
 export function useMyEndorsementsList(
   deviceKid: string | null,
   privateKey: CryptoKey | null,
-  crypto: CryptoModule | undefined
+  crypto: CryptoModule | null | undefined
 ) {
   return useQuery({
-    queryKey: ['my-endorsements', deviceKid],
+    queryKey: ['trust-endorsements', deviceKid],
     queryFn: async () => {
       if (!deviceKid || !privateKey || !crypto) {
         throw new Error('Not authenticated');
@@ -49,15 +55,15 @@ export function useMyEndorsementsList(
 export function useMyInvites(
   deviceKid: string | null,
   privateKey: CryptoKey | null,
-  crypto: CryptoModule | undefined
+  crypto: CryptoModule | null | undefined
 ) {
   return useQuery({
-    queryKey: ['my-invites', deviceKid],
+    queryKey: ['trust-invites', deviceKid],
     queryFn: async () => {
       if (!deviceKid || !privateKey || !crypto) {
         throw new Error('Not authenticated');
       }
-      return getMyInvites(deviceKid, privateKey, crypto);
+      return listMyInvites(deviceKid, privateKey, crypto);
     },
     enabled: Boolean(deviceKid && privateKey && crypto),
     staleTime: 30_000,
@@ -70,7 +76,7 @@ export function useCreateInvite(deviceKid: string, privateKey: CryptoKey, crypto
     mutationFn: (payload: CreateInvitePayload) =>
       createInvite(deviceKid, privateKey, crypto, payload),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['my-invites'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
     },
   });
 }
@@ -80,9 +86,10 @@ export function useAcceptInvite(deviceKid: string, privateKey: CryptoKey, crypto
   return useMutation({
     mutationFn: (inviteId: string) => acceptInvite(deviceKid, privateKey, crypto, inviteId),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['my-endorsements'] });
-      void queryClient.invalidateQueries({ queryKey: ['my-invites'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-endorsements'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
       void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
       void queryClient.invalidateQueries({ queryKey: ['verification-status'] });
     },
   });
@@ -97,8 +104,9 @@ export function useRevokeEndorsement(
   return useMutation({
     mutationFn: (subjectId: string) => revokeEndorsement(deviceKid, privateKey, crypto, subjectId),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['my-endorsements'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-endorsements'] });
       void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
     },
   });
 }

--- a/web/src/features/endorsements/types.ts
+++ b/web/src/features/endorsements/types.ts
@@ -1,51 +1,19 @@
-export interface Endorsement {
-  id: string;
-  subject_id: string;
-  topic: string;
-  issuer_id: string | null;
-  created_at: string;
-  revoked: boolean;
-}
+// InvitesListResponse: endorsements had { invites: InviteResponse[] }.
+// No direct equivalent in @/api/trust (listMyInvites returns Invite[]).
+import type { Invite } from '@/api/trust';
 
-export interface EndorsementsListResponse {
-  endorsements: Endorsement[];
-}
+/**
+ * Re-exports from shared @/api layer — single source of truth for endorsement types.
+ */
+export type { Endorsement, EndorsementsListResponse } from '@/api/endorsements';
+export type { TrustBudget as BudgetResponse } from '@/api/trust';
+export type { Invite as InviteResponse } from '@/api/trust';
+export type { CreateInvitePayload } from '@/api/trust';
+export type { AcceptInviteResult as AcceptInviteResponse } from '@/api/trust';
 
-export interface BudgetResponse {
-  slots_total: number;
-  slots_used: number;
-  slots_available: number;
-  out_of_slot_count: number;
-  denouncements_total: number;
-  denouncements_used: number;
-  denouncements_available: number;
-}
-
-export interface CreateInviteResponse {
-  id: string;
-  expires_at: string;
-}
-
-export interface InviteResponse {
-  id: string;
-  delivery_method: string;
-  accepted_by: string | null;
-  expires_at: string;
-  accepted_at: string | null;
-}
+// createInvite returns Invite (same shape as InviteResponse); alias for backward compat.
+export type { Invite as CreateInviteResponse } from '@/api/trust';
 
 export interface InvitesListResponse {
-  invites: InviteResponse[];
-}
-
-export interface AcceptInviteResponse {
-  endorser_id: string;
-  accepted_at: string;
-}
-
-export interface CreateInvitePayload {
-  envelope: string;
-  delivery_method: string;
-  relationship_depth?: string;
-  attestation: Record<string, unknown>;
+  invites: Invite[];
 }

--- a/web/src/features/trust/api/client.ts
+++ b/web/src/features/trust/api/client.ts
@@ -1,12 +1,29 @@
 /**
  * Trust API client
- * Type-safe REST client for trust scores, budget, endorsements, and invites
+ * Type-safe REST client for trust scores, budget, endorsements, and invites.
+ *
+ * Shared API functions (budget, invites, endorsements) live in @/api/trust and
+ * @/api/endorsements so the endorsements feature can also import them without
+ * violating the no-cross-feature-import ESLint rule.
  */
 
 import { signedFetchJson } from '@/api/signing';
 import type { CryptoModule } from '@/providers/CryptoProvider';
 
-// === Types ===
+// Re-export shared types and functions so feature consumers can import from
+// the trust feature barrel without knowing the internal split.
+export type { Endorsement, EndorsementsListResponse } from '@/api/endorsements';
+export { getMyEndorsements } from '@/api/endorsements';
+export type { TrustBudget, Invite, AcceptInviteResult, CreateInvitePayload } from '@/api/trust';
+export {
+  getMyBudget,
+  createInvite,
+  listMyInvites,
+  acceptInvite,
+  revokeEndorsement,
+} from '@/api/trust';
+
+// === Trust-feature-only types ===
 
 export interface Denouncement {
   id: string;
@@ -33,46 +50,13 @@ export interface ScoreSnapshot {
   computed_at: string;
 }
 
-export interface TrustBudget {
-  slots_total: number;
-  slots_used: number;
-  slots_available: number;
-  denouncements_total: number;
-  denouncements_used: number;
-  denouncements_available: number;
-}
-
-export interface Invite {
-  id: string;
-  delivery_method: string;
-  accepted_by: string | null;
-  expires_at: string;
-  accepted_at: string | null;
-}
-
-export interface AcceptInviteResult {
-  endorser_id: string;
-  accepted_at: string;
-}
-
 export interface EndorsePayload {
   subject_id: string;
   weight: number;
   attestation: Record<string, unknown>;
 }
 
-export interface RevokePayload {
-  subject_id: string;
-}
-
-export interface CreateInvitePayload {
-  envelope: string;
-  delivery_method: string;
-  relationship_depth?: string;
-  attestation: Record<string, unknown>;
-}
-
-// === API functions ===
+// === Trust-feature-only API functions ===
 
 export async function getMyScores(
   deviceKid: string,
@@ -80,46 +64,6 @@ export async function getMyScores(
   wasmCrypto: CryptoModule
 ): Promise<ScoreSnapshot[]> {
   return signedFetchJson('/trust/scores/me', 'GET', deviceKid, privateKey, wasmCrypto);
-}
-
-export async function getMyBudget(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-): Promise<TrustBudget> {
-  return signedFetchJson('/trust/budget', 'GET', deviceKid, privateKey, wasmCrypto);
-}
-
-export async function createInvite(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule,
-  payload: CreateInvitePayload
-): Promise<Invite> {
-  return signedFetchJson('/trust/invites', 'POST', deviceKid, privateKey, wasmCrypto, payload);
-}
-
-export async function listMyInvites(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-): Promise<Invite[]> {
-  return signedFetchJson('/trust/invites/mine', 'GET', deviceKid, privateKey, wasmCrypto);
-}
-
-export async function acceptInvite(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule,
-  inviteId: string
-): Promise<AcceptInviteResult> {
-  return signedFetchJson(
-    `/trust/invites/${inviteId}/accept`,
-    'POST',
-    deviceKid,
-    privateKey,
-    wasmCrypto
-  );
 }
 
 export async function endorse(
@@ -161,14 +105,4 @@ export async function lookupAccount(
     privateKey,
     wasmCrypto
   );
-}
-
-export async function revokeEndorsement(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule,
-  subjectId: string
-): Promise<void> {
-  const payload: RevokePayload = { subject_id: subjectId };
-  await signedFetchJson('/trust/revoke', 'POST', deviceKid, privateKey, wasmCrypto, payload);
 }

--- a/web/src/features/trust/api/index.ts
+++ b/web/src/features/trust/api/index.ts
@@ -1,6 +1,7 @@
 export {
   getMyScores,
   getMyBudget,
+  getMyEndorsements,
   createInvite,
   listMyInvites,
   acceptInvite,
@@ -20,10 +21,13 @@ export type {
   Denouncement,
   DenouncementPayload,
   AccountLookup,
+  Endorsement,
+  EndorsementsListResponse,
 } from './client';
 export {
   useTrustScores,
   useTrustBudget,
+  useMyEndorsementsList,
   useMyInvites,
   useCreateInvite,
   useAcceptInvite,

--- a/web/src/features/trust/api/queries.ts
+++ b/web/src/features/trust/api/queries.ts
@@ -10,6 +10,7 @@ import {
   denounce,
   endorse,
   getMyBudget,
+  getMyEndorsements,
   getMyScores,
   listMyDenouncements,
   listMyInvites,
@@ -50,6 +51,24 @@ export function useTrustBudget(
         throw new Error('Not authenticated');
       }
       return getMyBudget(deviceKid, privateKey, wasmCrypto);
+    },
+    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
+    staleTime: 30_000,
+  });
+}
+
+export function useMyEndorsementsList(
+  deviceKid: string | null,
+  privateKey: CryptoKey | null,
+  wasmCrypto: CryptoModule | null
+) {
+  return useQuery({
+    queryKey: ['trust-endorsements', deviceKid],
+    queryFn: async () => {
+      if (!deviceKid || !privateKey || !wasmCrypto) {
+        throw new Error('Not authenticated');
+      }
+      return getMyEndorsements(deviceKid, privateKey, wasmCrypto);
     },
     enabled: Boolean(deviceKid && privateKey && wasmCrypto),
     staleTime: 30_000,
@@ -101,6 +120,8 @@ export function useAcceptInvite(
       void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
       void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
       void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-endorsements'] });
+      void queryClient.invalidateQueries({ queryKey: ['verification-status'] });
     },
   });
 }
@@ -179,6 +200,7 @@ export function useRevokeEndorsement(
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
       void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
+      void queryClient.invalidateQueries({ queryKey: ['trust-endorsements'] });
     },
   });
 }

--- a/web/src/features/trust/components/DenouncementSection.test.tsx
+++ b/web/src/features/trust/components/DenouncementSection.test.tsx
@@ -43,6 +43,7 @@ function makeBudget(overrides?: Partial<TrustBudget>): TrustBudget {
     slots_total: 3,
     slots_used: 0,
     slots_available: 3,
+    out_of_slot_count: 0,
     denouncements_total: 2,
     denouncements_used: 0,
     denouncements_available: 2,

--- a/web/src/features/trust/index.ts
+++ b/web/src/features/trust/index.ts
@@ -1,6 +1,7 @@
 export {
   getMyScores,
   getMyBudget,
+  getMyEndorsements,
   createInvite,
   listMyInvites,
   acceptInvite,
@@ -11,6 +12,7 @@ export {
   lookupAccount,
   useTrustScores,
   useTrustBudget,
+  useMyEndorsementsList,
   useMyInvites,
   useCreateInvite,
   useAcceptInvite,
@@ -30,6 +32,8 @@ export type {
   Denouncement,
   DenouncementPayload,
   AccountLookup,
+  Endorsement,
+  EndorsementsListResponse,
 } from './api';
 export { TrustScoreCard, DenouncementSection } from './components';
 export { getTierInfo } from './tierInfo';

--- a/web/src/features/verification/api/index.ts
+++ b/web/src/features/verification/api/index.ts
@@ -1,4 +1,4 @@
-export { getMyEndorsements } from './client';
-export type { Endorsement, EndorsementsListResponse } from './client';
+export { getMyEndorsements } from '@/api/endorsements';
+export type { Endorsement, EndorsementsListResponse } from '@/api/endorsements';
 export { useVerificationStatus } from './queries';
 export type { VerificationStatus } from './queries';

--- a/web/src/features/verification/api/queries.ts
+++ b/web/src/features/verification/api/queries.ts
@@ -3,8 +3,8 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { getMyEndorsements } from '@/api/endorsements';
 import type { CryptoModule } from '@/providers/CryptoProvider';
-import { getMyEndorsements } from './client';
 
 export interface VerificationStatus {
   isVerified: boolean;

--- a/web/src/pages/Endorse.page.tsx
+++ b/web/src/pages/Endorse.page.tsx
@@ -1,15 +1,11 @@
 import { IconHandGrab, IconQrcode } from '@tabler/icons-react';
 import { useSearch } from '@tanstack/react-router';
 import { Alert, Card, Loader, Stack, Tabs, Title } from '@mantine/core';
-import {
-  useMyEndorsementsList,
-  useRevokeEndorsement,
-  useTrustBudget,
-} from '@/features/endorsements';
 import { AcceptTab } from '@/features/endorsements/components/AcceptTab';
 import { EndorsementList } from '@/features/endorsements/components/EndorsementList';
 import { GiveTab } from '@/features/endorsements/components/GiveTab';
 import { SlotCounter } from '@/features/endorsements/components/SlotCounter';
+import { useMyEndorsementsList, useRevokeEndorsement, useTrustBudget } from '@/features/trust';
 import { useCryptoRequired } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
 


### PR DESCRIPTION
## Summary

Closes #779. Also fixes #780 (query key mismatch, supersedes #789).

- Lifted shared API functions (`getMyBudget`, `createInvite`, `listMyInvites`, `acceptInvite`, `revokeEndorsement`, `getMyEndorsements`) to `web/src/api/` shared layer
- Trust feature imports from shared layer + keeps trust-only functions (scores, denouncements, endorse, lookup)
- Endorsements feature becomes a thin shim re-exporting from shared layer
- Deleted third copy of `getMyEndorsements` from `verification/api/client.ts`
- All query keys aligned to `trust-*` namespace — no more `my-invites` vs `trust-invites` mismatch
- `useAcceptInvite` now invalidates `['verification-status']` (previously only the endorsements version did this)

### Why shared layer instead of cross-feature imports?

ESLint prohibits `@/features/X` imports inside `src/features/Y`. Lifting to `@/api/` keeps both features compliant while eliminating duplication.

### Callers confirmed

- `Endorse.page.tsx`: imports hooks from `@/features/trust` directly (pages are allowed)
- `AcceptTab`, `GiveTab`, `EndorsementList`, `DenouncementSection`, `SlotCounter`: import via endorsements shims (no changes needed)
- `verification/api/queries.ts`: imports from `@/api/endorsements`

## Test plan

- [x] `yarn lint` — 0 warnings
- [x] `yarn vitest` — 151/151 tests pass
- [x] TypeScript clean
- [ ] CI validates full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)