### PR TITLE
fix: prevent Rooms nav highlight sticking on sub-pages

### DIFF
--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -182,7 +182,7 @@ function RoomsAccordion({
     <NavLink
       label="Rooms"
       leftSection={<IconDoor size={18} stroke={1.5} />}
-      active={isActive('/rooms')}
+      active={false}
       defaultOpened={currentPath.startsWith('/rooms')}
       fw={500}
     >


### PR DESCRIPTION
## Summary
- The parent "Rooms" accordion NavLink used `isActive('/rooms')` which prefix-matched all `/rooms/*` paths, keeping the header highlighted when viewing any individual room
- Changed to `active={false}` since the accordion header is a grouping element, not a navigation destination — child items ("All Rooms" and individual rooms) already have correct active logic

## Test plan
- [ ] Navigate to /rooms — "All Rooms" child is highlighted, accordion header is not
- [ ] Navigate to /rooms/:id — only that room's NavLink is highlighted
- [ ] Navigate away from rooms — no rooms-related items highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)