### PR TITLE
fix: repair storybook + add build history index to reports

### DIFF
--- a/.github/templates/reports-landing.html
+++ b/.github/templates/reports-landing.html
@@ -234,11 +234,11 @@
   <section class="section">
     <h2>&#x1F4DA; API Documentation</h2>
     <div class="link-grid">
-      <a href="rust-docs/tinycongress_api/" class="link-card">
+      <a href="rust-docs/tinycongress_api/index.html" class="link-card">
         <span class="link-icon">&#x1F980;</span>
         <span class="link-label">Rust API Docs</span>
       </a>
-      <a href="ts-docs/" class="link-card">
+      <a href="ts-docs/index.html" class="link-card">
         <span class="link-icon">&#x1F4D8;</span>
         <span class="link-label">TypeScript Docs</span>
       </a>
@@ -263,37 +263,37 @@
           <td class="pct">${VITEST_LINES}%</td>
           <td class="pct">${VITEST_BRANCHES}%</td>
           <td class="pct">${VITEST_FUNCTIONS}%</td>
-          <td><a href="coverage/vitest/">View Report</a></td>
+          <td><a href="coverage/vitest/index.html">View Report</a></td>
         </tr>
         <tr>
           <td><span class="test-type">&#x1F3AD; Playwright E2E</span></td>
           <td class="pct">${PW_LINES}%</td>
           <td class="pct">${PW_BRANCHES}%</td>
           <td class="pct">${PW_FUNCTIONS}%</td>
-          <td><a href="coverage/playwright/">View Report</a></td>
+          <td><a href="coverage/playwright/index.html">View Report</a></td>
         </tr>
         <tr>
           <td><span class="test-type">&#x1F980; Rust Backend</span></td>
           <td class="pct">${RUST_LINES}%</td>
           <td class="pct">N/A</td>
           <td class="pct">${RUST_FUNCTIONS}%</td>
-          <td><a href="coverage/rust/">View Report</a></td>
+          <td><a href="coverage/rust/index.html">View Report</a></td>
         </tr>
       </tbody>
     </table>
     <div style="margin-top: 12px; text-align: right;">
-      <a href="coverage/" style="color: var(--link); font-size: 0.875rem;">View Full Coverage Report &#x2192;</a>
+      <a href="coverage/index.html" style="color: var(--link); font-size: 0.875rem;">View Full Coverage Report &#x2192;</a>
     </div>
   </section>
 
   <section class="section">
     <h2>&#x1F9EA; Test Reports</h2>
     <div class="link-grid">
-      <a href="storybook/" class="link-card">
+      <a href="storybook/index.html" class="link-card">
         <span class="link-icon">&#x1F4DA;</span>
         <span class="link-label">Storybook</span>
       </a>
-      <a href="playwright/" class="link-card">
+      <a href="playwright/index.html" class="link-card">
         <span class="link-icon">&#x1F3AD;</span>
         <span class="link-label">Playwright E2E</span>
       </a>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1609,6 +1609,23 @@ jobs:
           export COMMIT_SHORT BUILD_DATE
           envsubst < .github/templates/reports-landing.html > site/index.html
 
+      - name: Build root build-history index
+        env:
+          COVERAGE_PCT: ${{ steps.artifacts.outputs.coverage_pct }}
+        run: |
+          # Download existing root index (may 404 on first run)
+          curl -fsSL -o existing-index.html \
+            "https://reports.ibcook.com/index.html" 2>/dev/null || true
+          EXISTING_FLAG=""
+          if [ -s existing-index.html ]; then
+            EXISTING_FLAG="--existing existing-index.html"
+          fi
+          BUILD_DATE="$(date -u +"%Y-%m-%d %H:%M UTC")"
+          export BUILD_DATE
+          # shellcheck disable=SC2086
+          node scripts/build-reports-index.mjs $EXISTING_FLAG \
+            --output root-index.html
+
       - name: Upload reports to Dufs
         env:
           DUFS_PASSWORD: ${{ secrets.DUFS_UPLOAD_PASSWORD }}
@@ -1641,8 +1658,16 @@ jobs:
             echo "Uploaded ${count} files (${mb} MB) to ${target}/ in ${elapsed}ms (${speed} MB/s)"
           }
 
+          upload_file() {
+            local file="$1" target="$2"
+            curl --retry 2 --max-time 30 --silent --fail-with-body \
+              --user "ci:${DUFS_PASSWORD}" \
+              --upload-file "$file" \
+              "${BASE}/${target}"
+          }
+
           for attempt in 1 2 3; do
-            if upload_dir "$DEST" && upload_dir "latest"; then
+            if upload_dir "$DEST" && upload_file root-index.html index.html; then
               break
             fi
             if [ "$attempt" -lt 3 ]; then
@@ -1657,8 +1682,8 @@ jobs:
           {
             echo "### 📋 CI Reports"
             echo ""
-            echo "- [Latest](https://reports.ibcook.com/latest/)"
-            echo "- [This run](https://reports.ibcook.com/${DEST}/)"
+            echo "- [All builds](https://reports.ibcook.com/index.html)"
+            echo "- [This run](https://reports.ibcook.com/${DEST}/index.html)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Add PR comment with report links
@@ -1669,7 +1694,7 @@ jobs:
           message: |
             ## 🏛️ CI Reports
 
-            **[📋 All Reports](https://reports.ibcook.com/${{ github.sha }}/)**
+            **[📋 All Reports](https://reports.ibcook.com/${{ github.sha }}/index.html)** | [Build History](https://reports.ibcook.com/index.html)
 
             ### 📚 API Documentation
             | | |
@@ -1679,7 +1704,7 @@ jobs:
             ### 🧪 Test Artifacts
             | | |
             |---|---|
-            | 📊 [Coverage](https://reports.ibcook.com/${{ github.sha }}/coverage/) | 📚 [Storybook](https://reports.ibcook.com/${{ github.sha }}/storybook/) |
-            | 🎭 [Playwright](https://reports.ibcook.com/${{ github.sha }}/playwright/) | |
+            | 📊 [Coverage](https://reports.ibcook.com/${{ github.sha }}/coverage/index.html) | 📚 [Storybook](https://reports.ibcook.com/${{ github.sha }}/storybook/index.html) |
+            | 🎭 [Playwright](https://reports.ibcook.com/${{ github.sha }}/playwright/index.html) | |
 
             <sub>🤖 Generated from commit ${{ github.sha }}</sub>

--- a/scripts/build-reports-index.mjs
+++ b/scripts/build-reports-index.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// scripts/build-reports-index.mjs
+//
+// Generates/updates the root build-history index for reports.ibcook.com.
+// Reads an existing index.html to preserve history, prepends a new build
+// entry, and caps at MAX_ENTRIES.
+//
+// Usage: node scripts/build-reports-index.mjs [--existing path] --output path
+// Required env: GITHUB_SHA, GITHUB_REF_NAME, GITHUB_RUN_ID, GITHUB_RUN_NUMBER,
+//               COVERAGE_PCT, BUILD_DATE
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+const MAX_ENTRIES = 50;
+
+const { values } = parseArgs({
+  options: {
+    existing: { type: 'string' },
+    output: { type: 'string' },
+  },
+});
+
+if (!values.output) {
+  console.error('Usage: build-reports-index.mjs [--existing path] --output path');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Extract build entries from existing index (embedded JSON in HTML comment)
+// ---------------------------------------------------------------------------
+function extractBuilds(html) {
+  const match = html.match(/<!--BUILDS_DATA([\s\S]*?)BUILDS_DATA-->/);
+  if (!match) return [];
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build the new entry from env vars
+// ---------------------------------------------------------------------------
+const sha = process.env.GITHUB_SHA ?? '';
+const newBuild = {
+  sha,
+  short: sha.slice(0, 7) || '???????',
+  branch: process.env.GITHUB_REF_NAME ?? 'unknown',
+  date: process.env.BUILD_DATE ?? new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC',
+  coverage: process.env.COVERAGE_PCT ?? '?',
+  runId: process.env.GITHUB_RUN_ID ?? '',
+  runNumber: process.env.GITHUB_RUN_NUMBER ?? '',
+};
+
+// ---------------------------------------------------------------------------
+// Load existing builds, prepend new, deduplicate, cap
+// ---------------------------------------------------------------------------
+let builds = [];
+if (values.existing) {
+  try {
+    builds = extractBuilds(readFileSync(values.existing, 'utf-8'));
+  } catch {
+    // File doesn't exist or unreadable — start fresh
+  }
+}
+
+builds = [newBuild, ...builds.filter((b) => b.sha !== sha)].slice(0, MAX_ENTRIES);
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+function coverageClass(pct) {
+  const n = parseFloat(pct);
+  if (Number.isNaN(n)) return '';
+  if (n >= 80) return ' good';
+  if (n >= 50) return ' ok';
+  return ' low';
+}
+
+const rows = builds
+  .map(
+    (b, i) => `        <tr${i === 0 ? ' class="current"' : ''}>
+          <td class="mono"><a href="${b.sha}/index.html">${b.short}</a></td>
+          <td>${b.branch}</td>
+          <td class="pct${coverageClass(b.coverage)}">${b.coverage}%</td>
+          <td class="mono">${b.date}</td>
+          <td><a href="https://github.com/icook/tiny-congress/actions/runs/${b.runId}">#${b.runNumber}</a></td>
+        </tr>`
+  )
+  .join('\n');
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tiny Congress - Build Reports</title>
+  <meta name="color-scheme" content="light dark">
+  <style>
+    :root {
+      --bg: #f8fafc; --bg-card: #ffffff; --bg-hover: #f1f5f9;
+      --text: #0f172a; --text-secondary: #64748b; --text-muted: #94a3b8;
+      --link: #2563eb; --border: #e2e8f0; --accent: #3b82f6;
+      --shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --bg-card: #1e293b; --bg-hover: #334155;
+        --text: #f1f5f9; --text-secondary: #94a3b8; --text-muted: #64748b;
+        --link: #60a5fa; --border: #334155; --accent: #3b82f6;
+        --shadow: 0 1px 3px rgba(0,0,0,0.3);
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      max-width: 960px; margin: 0 auto; padding: 24px;
+      line-height: 1.6; background: var(--bg); color: var(--text);
+    }
+    .header {
+      background: var(--bg-card); border-radius: 12px; padding: 24px;
+      margin-bottom: 24px; box-shadow: var(--shadow); border: 1px solid var(--border);
+      display: flex; align-items: center; gap: 16px;
+    }
+    .header h1 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+    .header .subtitle { color: var(--text-muted); font-size: 0.875rem; }
+    .section {
+      background: var(--bg-card); border-radius: 12px; padding: 20px;
+      box-shadow: var(--shadow); border: 1px solid var(--border);
+    }
+    .section h2 {
+      margin: 0 0 16px 0; font-size: 1rem; font-weight: 600;
+      color: var(--text-secondary);
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    th {
+      text-align: left; padding: 10px 12px; background: var(--bg-hover);
+      color: var(--text-muted); font-weight: 500; text-transform: uppercase;
+      font-size: 0.75rem; letter-spacing: 0.05em;
+    }
+    td { padding: 10px 12px; border-bottom: 1px solid var(--border); }
+    tr:last-child td { border-bottom: none; }
+    tr.current td { background: color-mix(in srgb, var(--accent) 8%, transparent); }
+    a { color: var(--link); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .mono { font-family: ui-monospace, 'SF Mono', monospace; font-size: 0.8125rem; }
+    .pct { font-weight: 600; font-family: ui-monospace, monospace; }
+    .pct.good { color: #22c55e; }
+    .pct.ok { color: #eab308; }
+    .pct.low { color: #ef4444; }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div>
+      <h1>Tiny Congress</h1>
+      <div class="subtitle">Build Reports &mdash; last ${builds.length} builds</div>
+    </div>
+  </header>
+  <section class="section">
+    <h2>Recent Builds</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Commit</th>
+          <th>Branch</th>
+          <th>Coverage</th>
+          <th>Built</th>
+          <th>Workflow</th>
+        </tr>
+      </thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+  </section>
+  <!--BUILDS_DATA${JSON.stringify(builds)}BUILDS_DATA-->
+</body>
+</html>
+`;
+
+writeFileSync(values.output, html);
+console.log(`Wrote ${builds.length} builds to ${values.output}`);

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import '@mantine/core/styles.css';
 
 import React, { useCallback, useEffect } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DARK_MODE_EVENT_NAME } from '@vueless/storybook-dark-mode';
 import { addons } from 'storybook/preview-api';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
@@ -34,7 +35,14 @@ function ColorSchemeWrapper({ children }: { children: React.ReactNode }) {
   return children;
 }
 
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
 export const decorators = [
   (renderStory: any) => <ColorSchemeWrapper>{renderStory()}</ColorSchemeWrapper>,
   (renderStory: any) => <MantineProvider theme={mantineTheme}>{renderStory()}</MantineProvider>,
+  (renderStory: any) => (
+    <QueryClientProvider client={queryClient}>{renderStory()}</QueryClientProvider>
+  ),
 ];


### PR DESCRIPTION
## Summary

- **Storybook fix**: Add `QueryClientProvider` to `.storybook/preview.tsx` decorators — the Welcome story was crashing with "No QueryClient set" because `useVerificationStatus()` calls React Query
- **Directory links**: All report links now use explicit `index.html` (e.g., `storybook/index.html`) — dufs doesn't auto-serve `index.html` for directory URLs
- **Build history index (#588)**: New `scripts/build-reports-index.mjs` generates a root `index.html` listing the last 50 builds with commit, branch, coverage, date, and workflow link. Replaces the full `latest/` directory copy with a single root index upload

## Test plan

- [x] `build-reports-index.mjs` smoke tested locally (fresh + append)
- [x] Generated HTML renders correctly in browser (verified via Playwright)
- [x] `actionlint` passes on `ci.yml`
- [x] `shellcheck` passes on new shell blocks
- [x] ESLint passes on `preview.tsx`
- [ ] CI run confirms storybook builds without the QueryClient error
- [ ] First CI run seeds the root index at `reports.ibcook.com/index.html`

Closes #588

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>