### PR TITLE
fix: validate username in account_lookup handler

### DIFF
--- a/service/src/identity/http/mod.rs
+++ b/service/src/identity/http/mod.rs
@@ -17,7 +17,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::service::{IdentityService, RootPubkey, SignupError, SignupRequest};
+use super::service::{validate_username, IdentityService, RootPubkey, SignupError, SignupRequest};
 // Re-export shared error helpers so submodules and external callers can use them.
 pub use crate::http::{bad_request, internal_error, not_found, unauthorized, ErrorResponse};
 use crate::identity::http::auth::AuthenticatedDevice;
@@ -74,6 +74,9 @@ async fn account_lookup(
     let username = params.username.trim().to_string();
     if username.is_empty() {
         return bad_request("username is required");
+    }
+    if let Err(e) = validate_username(&username) {
+        return bad_request(&e.to_string());
     }
 
     match repo.get_account_by_username(&username).await {


### PR DESCRIPTION
## Summary
- Adds `validate_username()` call in `account_lookup` handler before DB query
- Matches validation pattern used by signup, login, and backup handlers
- Prevents unbounded query strings from reaching the database

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes
- [ ] Existing account lookup tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)