### PR TITLE
fix: replace expect() panics with error returns in repo row mapping

### DIFF
--- a/service/src/identity/repo/backups.rs
+++ b/service/src/identity/repo/backups.rs
@@ -116,11 +116,7 @@ where
 /// # Errors
 ///
 /// Returns `BackupRepoError::NotFound` if no backup exists for this KID.
-///
-/// # Panics
-///
-/// Panics if a KID stored in the database fails to parse — this indicates data corruption.
-#[allow(clippy::expect_used)]
+/// Returns `BackupRepoError::Database` if the stored KID value fails to parse (data corruption).
 pub(crate) async fn get_backup_by_kid<'e, E>(
     executor: E,
     kid: &Kid,
@@ -140,14 +136,18 @@ where
     .await?
     .ok_or(BackupRepoError::NotFound)?;
 
+    let raw_kid = row.get::<String, _>("kid");
+    let parsed_kid = raw_kid.parse().map_err(|_| {
+        tracing::error!(raw_kid = %raw_kid, "invalid KID in account_backups — data corruption");
+        BackupRepoError::Database(sqlx::Error::Decode(
+            "invalid KID value in account_backups".into(),
+        ))
+    })?;
+
     Ok(BackupRecord {
         id: row.get("id"),
         account_id: row.get("account_id"),
-        // A malformed KID in the DB is a data corruption bug, not a user error
-        kid: row
-            .get::<String, _>("kid")
-            .parse()
-            .expect("invalid KID in database"),
+        kid: parsed_kid,
         encrypted_backup: row.get("encrypted_backup"),
         salt: row.get("salt"),
         version: row.get("version"),

--- a/service/src/identity/repo/device_keys.rs
+++ b/service/src/identity/repo/device_keys.rs
@@ -146,23 +146,27 @@ pub async fn create_device_key_with_executor(
     .await
 }
 
-#[allow(clippy::expect_used, clippy::needless_pass_by_value)]
-fn map_device_key_row(row: sqlx::postgres::PgRow) -> DeviceKeyRecord {
-    DeviceKeyRecord {
+#[allow(clippy::needless_pass_by_value)]
+fn map_device_key_row(row: sqlx::postgres::PgRow) -> Result<DeviceKeyRecord, DeviceKeyRepoError> {
+    let raw_kid = row.get::<String, _>("device_kid");
+    let device_kid = raw_kid.parse().map_err(|_| {
+        tracing::error!(raw_kid = %raw_kid, "invalid KID in device_keys — data corruption");
+        DeviceKeyRepoError::Database(sqlx::Error::Decode(
+            "invalid KID value in device_keys".into(),
+        ))
+    })?;
+
+    Ok(DeviceKeyRecord {
         id: row.get("id"),
         account_id: row.get("account_id"),
-        // A malformed KID in the DB is a data corruption bug, not a user error
-        device_kid: row
-            .get::<String, _>("device_kid")
-            .parse()
-            .expect("invalid KID in database"),
+        device_kid,
         device_pubkey: row.get("device_pubkey"),
         device_name: row.get("device_name"),
         certificate: row.get("certificate"),
         last_used_at: row.get("last_used_at"),
         revoked_at: row.get("revoked_at"),
         created_at: row.get("created_at"),
-    }
+    })
 }
 
 /// List all device keys for an account (including revoked).
@@ -190,7 +194,7 @@ where
     .fetch_all(executor)
     .await?;
 
-    Ok(rows.into_iter().map(map_device_key_row).collect())
+    rows.into_iter().map(map_device_key_row).collect()
 }
 
 /// Get a device key by KID.
@@ -218,7 +222,7 @@ where
     .await?
     .ok_or(DeviceKeyRepoError::NotFound)?;
 
-    Ok(map_device_key_row(row))
+    map_device_key_row(row)
 }
 
 /// Check whether a device key exists but is revoked, or doesn't exist at all.


### PR DESCRIPTION
## Summary
- Replaces `.expect("invalid KID in database")` with proper `map_err` + `tracing::error!` in two repo files
- `backups.rs`: `get_backup_by_kid` now returns `BackupRepoError::Database` on corrupt KID instead of panicking
- `device_keys.rs`: `map_device_key_row` signature changed to return `Result<DeviceKeyRecord, DeviceKeyRepoError>`, callers updated

A corrupt database row now returns a 500 to the caller instead of crashing the async runtime thread.

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes
- [ ] Existing backup and device key tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)