### PR TITLE
fix: add Permissions-Policy security header

### DIFF
--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -261,6 +261,10 @@ pub struct SecurityHeadersConfig {
     /// Referrer-Policy header value (default: "strict-origin-when-cross-origin").
     #[serde(default = "default_referrer_policy")]
     pub referrer_policy: String,
+
+    /// Permissions-Policy header value (default: restrict camera, microphone, geolocation).
+    #[serde(default = "default_permissions_policy")]
+    pub permissions_policy: String,
 }
 
 #[allow(clippy::missing_const_for_fn)]
@@ -285,6 +289,10 @@ fn default_referrer_policy() -> String {
     "strict-origin-when-cross-origin".to_string()
 }
 
+fn default_permissions_policy() -> String {
+    "camera=(), microphone=(), geolocation=()".to_string()
+}
+
 impl Default for SecurityHeadersConfig {
     fn default() -> Self {
         Self {
@@ -295,6 +303,7 @@ impl Default for SecurityHeadersConfig {
             frame_options: default_frame_options(),
             content_security_policy: default_csp(),
             referrer_policy: default_referrer_policy(),
+            permissions_policy: default_permissions_policy(),
         }
     }
 }

--- a/service/src/http/security.rs
+++ b/service/src/http/security.rs
@@ -12,7 +12,7 @@ use axum::{
             CONTENT_SECURITY_POLICY, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY,
             X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION,
         },
-        HeaderMap, HeaderValue,
+        HeaderMap, HeaderName, HeaderValue,
     },
     middleware::Next,
     response::Response,
@@ -48,6 +48,11 @@ pub fn build_security_headers(config: &SecurityHeadersConfig) -> Arc<HeaderMap> 
     // Referrer-Policy
     if let Ok(value) = HeaderValue::from_str(&config.referrer_policy) {
         headers.insert(REFERRER_POLICY, value);
+    }
+
+    // Permissions-Policy
+    if let Ok(value) = HeaderValue::from_str(&config.permissions_policy) {
+        headers.insert(HeaderName::from_static("permissions-policy"), value);
     }
 
     // HSTS (only if enabled - should only be used with HTTPS)
@@ -114,6 +119,12 @@ mod tests {
         assert!(headers.contains_key(X_XSS_PROTECTION));
         assert!(headers.contains_key(CONTENT_SECURITY_POLICY));
         assert!(headers.contains_key(REFERRER_POLICY));
+        assert!(headers.contains_key("permissions-policy"));
+
+        let pp = headers
+            .get("permissions-policy")
+            .map(|v| v.to_str().unwrap_or_default());
+        assert_eq!(pp, Some("camera=(), microphone=(), geolocation=()"));
     }
 
     #[test]
@@ -132,6 +143,19 @@ mod tests {
         assert!(hsts.is_some());
         assert!(hsts.unwrap().contains("max-age=31536000"));
         assert!(hsts.unwrap().contains("includeSubDomains"));
+    }
+
+    #[test]
+    fn test_build_security_headers_custom_permissions_policy() {
+        let mut config = SecurityHeadersConfig::default();
+        config.permissions_policy = "camera=(), microphone=()".to_string();
+
+        let headers = build_security_headers(&config);
+
+        let pp = headers
+            .get("permissions-policy")
+            .map(|v| v.to_str().unwrap_or_default());
+        assert_eq!(pp, Some("camera=(), microphone=()"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #303

## Summary
- Added `Permissions-Policy` header to the security headers middleware restricting camera, microphone, and geolocation
- Made the policy configurable via `SecurityHeadersConfig` with a sensible default (`camera=(), microphone=(), geolocation=()`)
- Added tests for both default and custom policy values

## Test plan
- [x] Unit tests pass (`test_build_security_headers_default`, `test_build_security_headers_custom_permissions_policy`)
- [ ] Verify header present in deployed response: `curl -sI <url> | grep -i permissions-policy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)