### PR TITLE
refactor: replace poll status string with serde enum

### DIFF
--- a/service/src/rooms/http/polling.rs
+++ b/service/src/rooms/http/polling.rs
@@ -136,8 +136,15 @@ const fn default_max_value() -> f32 {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PollStatusTransition {
+    Active,
+    Closed,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct PollStatusRequest {
-    pub status: String,
+    pub status: PollStatusTransition,
 }
 
 #[derive(Debug, Deserialize)]
@@ -273,12 +280,9 @@ pub async fn update_poll_status(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    let result = match req.status.as_str() {
-        "active" => polling.activate_poll(poll_id).await,
-        "closed" => polling.close_poll(poll_id).await,
-        _ => {
-            return crate::http::bad_request("Status must be 'active' or 'closed'");
-        }
+    let result = match req.status {
+        PollStatusTransition::Active => polling.activate_poll(poll_id).await,
+        PollStatusTransition::Closed => polling.close_poll(poll_id).await,
     };
     match result {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),


### PR DESCRIPTION
Closes #778

## Summary
- Replaced `PollStatusRequest.status: String` with a `PollStatusTransition` enum (`Active`, `Closed`)
- Invalid status values now rejected at deserialization (422) instead of via a `_ =>` catch-all (400)
- Exhaustive match eliminates the unreachable default arm

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [ ] Manual: `PUT /rooms/:id/polls/:id/status` with `{"status": "active"}` / `{"status": "closed"}` still works
- [ ] Manual: `{"status": "bogus"}` returns 422 instead of previous 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)