### PR TITLE
feat: add graceful shutdown for SIGTERM/SIGINT

### DIFF
--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -427,7 +427,30 @@ async fn main() -> Result<(), anyhow::Error> {
     );
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    tracing::info!("Graceful shutdown enabled — listening for SIGTERM/SIGINT");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
+    tracing::info!("Server shut down cleanly");
     Ok(())
+}
+
+/// Wait for SIGTERM or SIGINT and log when a signal is received.
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let Ok(mut sigterm) = signal(SignalKind::terminate()) else {
+        tracing::error!("failed to install SIGTERM handler");
+        return;
+    };
+    let Ok(mut sigint) = signal(SignalKind::interrupt()) else {
+        tracing::error!("failed to install SIGINT handler");
+        return;
+    };
+
+    tokio::select! {
+        _ = sigterm.recv() => tracing::info!("received SIGTERM, shutting down"),
+        _ = sigint.recv()  => tracing::info!("received SIGINT, shutting down"),
+    }
 }


### PR DESCRIPTION
Closes #294

## Summary
- Added `shutdown_signal()` async function listening for SIGTERM and SIGINT via `tokio::signal::unix`
- Wired into `axum::serve(...).with_graceful_shutdown(shutdown_signal())`
- Logs shutdown signal receipt and clean exit via tracing
- No new dependencies — tokio `signal` feature was already enabled

## Test plan
- [x] `cargo test` passes (253 tests)
- [x] `cargo clippy` clean
- [ ] Manual: `kill -TERM <pid>` triggers graceful drain instead of hard stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)