### PR TITLE
fix: eliminate TOCTOU race in device revoke/rename

### DIFF
--- a/service/src/identity/http/devices.rs
+++ b/service/src/identity/http/devices.rs
@@ -215,13 +215,7 @@ pub async fn revoke_device(
             .into_response();
     }
 
-    // Verify the target device belongs to this account
-    match get_owned_device(&*repo, &kid, auth.account_id).await {
-        Ok(_) => {}
-        Err(resp) => return resp,
-    }
-
-    match repo.revoke_device_key(&kid).await {
+    match repo.revoke_device_key(&kid, auth.account_id).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(DeviceKeyRepoError::AlreadyRevoked) => (
             StatusCode::CONFLICT,
@@ -259,12 +253,10 @@ pub async fn rename_device(
         Err(e) => return super::bad_request(&e.to_string()),
     };
 
-    match get_owned_device(&*repo, &kid, auth.account_id).await {
-        Ok(_) => {}
-        Err(resp) => return resp,
-    }
-
-    match repo.rename_device_key(&kid, new_name.as_str()).await {
+    match repo
+        .rename_device_key(&kid, auth.account_id, new_name.as_str())
+        .await
+    {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(DeviceKeyRepoError::AlreadyRevoked) => (
             StatusCode::CONFLICT,
@@ -411,8 +403,6 @@ mod tests {
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
-    // ── get_owned_device ────────────────────────────────────────────────────
-
     fn make_device_record(account_id: Uuid) -> DeviceKeyRecord {
         DeviceKeyRecord {
             id: Uuid::new_v4(),
@@ -425,63 +415,6 @@ mod tests {
             revoked_at: None,
             created_at: Utc::now(),
         }
-    }
-
-    #[tokio::test]
-    async fn test_get_owned_device_not_found() {
-        let repo = MockIdentityRepo::new(); // default: get_device_key_by_kid returns NotFound
-        let kid = Kid::derive(&[0u8; 32]);
-        let err = get_owned_device(&repo, &kid, Uuid::new_v4())
-            .await
-            .err()
-            .expect("expected error");
-        assert_eq!(err.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn test_get_owned_device_wrong_account_returns_not_found() {
-        // Security: cross-account access must return 404, not 403 — no device enumeration.
-        let owner_id = Uuid::new_v4();
-        let caller_id = Uuid::new_v4();
-        let record = make_device_record(owner_id);
-        let kid = record.device_kid.clone();
-
-        let repo = MockIdentityRepo::new();
-        repo.set_get_device_key_by_kid_result(Ok(record));
-
-        let err = get_owned_device(&repo, &kid, caller_id)
-            .await
-            .err()
-            .expect("expected error");
-        assert_eq!(err.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn test_get_owned_device_database_error_returns_internal() {
-        let repo = MockIdentityRepo::new();
-        repo.set_get_device_key_by_kid_result(Err(DeviceKeyRepoError::Database(
-            sqlx::Error::Protocol("db error".to_string()),
-        )));
-        let kid = Kid::derive(&[0u8; 32]);
-        let err = get_owned_device(&repo, &kid, Uuid::new_v4())
-            .await
-            .err()
-            .expect("expected error");
-        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    #[tokio::test]
-    async fn test_get_owned_device_matching_account_returns_record() {
-        let account_id = Uuid::new_v4();
-        let record = make_device_record(account_id);
-        let kid = record.device_kid.clone();
-
-        let repo = MockIdentityRepo::new();
-        repo.set_get_device_key_by_kid_result(Ok(record.clone()));
-
-        let result = get_owned_device(&repo, &kid, account_id).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().device_kid, kid);
     }
 
     #[tokio::test]
@@ -672,20 +605,14 @@ mod tests {
         );
     }
 
-    /// Build an `AuthenticatedDevice` and a repo where `get_owned_device` succeeds
-    /// (so we reach the `revoke_device_key` call), then inject an error there.
+    /// Build an `AuthenticatedDevice` and a repo for revoke handler tests.
     fn setup_revoke_preconditions(
         account_id: Uuid,
         target_kid: &Kid,
     ) -> (std::sync::Arc<MockIdentityRepo>, AuthenticatedDevice) {
         // auth device has a different KID so the "cannot revoke self" check passes
         let auth_kid = Kid::derive(&[0xAAu8; 32]);
-        let record = make_device_record(account_id);
-
         let repo = std::sync::Arc::new(MockIdentityRepo::new());
-        // `get_owned_device` calls `get_device_key_by_kid` — return a record owned by this account
-        repo.set_get_device_key_by_kid_result(Ok(record));
-
         let auth = AuthenticatedDevice::for_test(account_id, auth_kid, axum::body::Bytes::new());
         let _ = target_kid; // used by caller for the Path argument
         (repo, auth)
@@ -738,8 +665,8 @@ mod tests {
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
-    /// TOCTOU race: device confirmed owned by `get_owned_device`, then deleted
-    /// before `revoke_device_key` executes — must return 404, not 500.
+    /// `revoke_device_key` returns `NotFound` when no matching active row exists
+    /// (device absent, already deleted, or belongs to a different account).
     #[tokio::test]
     async fn test_revoke_device_not_found_returns_404() {
         use axum::response::IntoResponse;
@@ -834,11 +761,7 @@ mod tests {
         target_kid: &Kid,
     ) -> (std::sync::Arc<MockIdentityRepo>, AuthenticatedDevice) {
         let auth_kid = Kid::derive(&[0xAAu8; 32]);
-        let record = make_device_record(account_id);
-
         let repo = std::sync::Arc::new(MockIdentityRepo::new());
-        repo.set_get_device_key_by_kid_result(Ok(record));
-
         let body = axum::body::Bytes::from(r#"{"name":"Renamed Device"}"#);
         let auth = AuthenticatedDevice::for_test(account_id, auth_kid, body);
         let _ = target_kid;
@@ -895,8 +818,8 @@ mod tests {
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
-    /// TOCTOU race: device confirmed owned by `get_owned_device`, then deleted
-    /// before `rename_device_key` executes — must return 404, not 500.
+    /// `rename_device_key` returns `NotFound` when no matching active row exists
+    /// (device absent, already deleted, or belongs to a different account).
     #[tokio::test]
     async fn test_rename_device_not_found_returns_404() {
         use axum::response::IntoResponse;
@@ -971,29 +894,4 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
-}
-
-/// Verify a device exists and belongs to the given account.
-#[allow(clippy::result_large_err)]
-async fn get_owned_device(
-    repo: &dyn IdentityRepo,
-    kid: &Kid,
-    account_id: Uuid,
-) -> Result<DeviceKeyRecord, axum::response::Response> {
-    let device = match repo.get_device_key_by_kid(kid).await {
-        Ok(d) => d,
-        Err(DeviceKeyRepoError::NotFound) => {
-            return Err(super::not_found("Device not found"));
-        }
-        Err(e) => {
-            tracing::error!("Failed to look up device: {e}");
-            return Err(super::internal_error());
-        }
-    };
-
-    if device.account_id != account_id {
-        return Err(super::not_found("Device not found"));
-    }
-
-    Ok(device)
 }

--- a/service/src/identity/repo/device_keys.rs
+++ b/service/src/identity/repo/device_keys.rs
@@ -253,18 +253,26 @@ async fn ensure_active_device_updated(
 
 /// Revoke a device key (sets `revoked_at`).
 ///
+/// The `account_id` is included in the WHERE clause so ownership check and
+/// mutation happen atomically in a single query, eliminating the TOCTOU race
+/// that existed when a separate preflight lookup confirmed ownership.
+///
 /// # Errors
 ///
-/// Returns `DeviceKeyRepoError::NotFound` if no device key matches the given KID.
+/// Returns `DeviceKeyRepoError::NotFound` if no device key matches the given KID
+/// (including if the device exists but belongs to a different account).
 /// Returns `DeviceKeyRepoError::AlreadyRevoked` if the device key was already revoked.
 pub(crate) async fn revoke_device_key(
     pool: &PgPool,
     device_kid: &Kid,
+    account_id: Uuid,
 ) -> Result<(), DeviceKeyRepoError> {
     let result = sqlx::query(
-        "UPDATE device_keys SET revoked_at = now() WHERE device_kid = $1 AND revoked_at IS NULL",
+        "UPDATE device_keys SET revoked_at = now() \
+         WHERE device_kid = $1 AND account_id = $2 AND revoked_at IS NULL",
     )
     .bind(device_kid.as_str())
+    .bind(account_id)
     .execute(pool)
     .await?;
 
@@ -273,20 +281,28 @@ pub(crate) async fn revoke_device_key(
 
 /// Rename a device.
 ///
+/// The `account_id` is included in the WHERE clause so ownership check and
+/// mutation happen atomically in a single query, eliminating the TOCTOU race
+/// that existed when a separate preflight lookup confirmed ownership.
+///
 /// # Errors
 ///
-/// Returns `DeviceKeyRepoError::NotFound` if no device key matches the given KID.
+/// Returns `DeviceKeyRepoError::NotFound` if no device key matches the given KID
+/// (including if the device exists but belongs to a different account).
 /// Returns `DeviceKeyRepoError::AlreadyRevoked` if the device key has been revoked.
 pub(crate) async fn rename_device_key(
     pool: &PgPool,
     device_kid: &Kid,
+    account_id: Uuid,
     new_name: &str,
 ) -> Result<(), DeviceKeyRepoError> {
     let result = sqlx::query(
-        "UPDATE device_keys SET device_name = $1 WHERE device_kid = $2 AND revoked_at IS NULL",
+        "UPDATE device_keys SET device_name = $1 \
+         WHERE device_kid = $2 AND account_id = $3 AND revoked_at IS NULL",
     )
     .bind(new_name)
     .bind(device_kid.as_str())
+    .bind(account_id)
     .execute(pool)
     .await?;
 

--- a/service/src/identity/repo/identity.rs
+++ b/service/src/identity/repo/identity.rs
@@ -157,11 +157,16 @@ pub trait IdentityRepo: Send + Sync {
         device_kid: &Kid,
     ) -> Result<DeviceKeyRecord, DeviceKeyRepoError>;
 
-    async fn revoke_device_key(&self, device_kid: &Kid) -> Result<(), DeviceKeyRepoError>;
+    async fn revoke_device_key(
+        &self,
+        device_kid: &Kid,
+        account_id: Uuid,
+    ) -> Result<(), DeviceKeyRepoError>;
 
     async fn rename_device_key(
         &self,
         device_kid: &Kid,
+        account_id: Uuid,
         new_name: &str,
     ) -> Result<(), DeviceKeyRepoError>;
 
@@ -277,16 +282,21 @@ impl IdentityRepo for PgIdentityRepo {
         get_device_key_by_kid(&self.pool, device_kid).await
     }
 
-    async fn revoke_device_key(&self, device_kid: &Kid) -> Result<(), DeviceKeyRepoError> {
-        revoke_device_key(&self.pool, device_kid).await
+    async fn revoke_device_key(
+        &self,
+        device_kid: &Kid,
+        account_id: Uuid,
+    ) -> Result<(), DeviceKeyRepoError> {
+        revoke_device_key(&self.pool, device_kid, account_id).await
     }
 
     async fn rename_device_key(
         &self,
         device_kid: &Kid,
+        account_id: Uuid,
         new_name: &str,
     ) -> Result<(), DeviceKeyRepoError> {
-        rename_device_key(&self.pool, device_kid, new_name).await
+        rename_device_key(&self.pool, device_kid, account_id, new_name).await
     }
 
     async fn touch_device_key(&self, device_kid: &Kid) -> Result<(), DeviceKeyRepoError> {
@@ -621,7 +631,11 @@ pub mod mock {
                 .unwrap_or(Err(DeviceKeyRepoError::NotFound))
         }
 
-        async fn revoke_device_key(&self, _device_kid: &Kid) -> Result<(), DeviceKeyRepoError> {
+        async fn revoke_device_key(
+            &self,
+            _device_kid: &Kid,
+            _account_id: Uuid,
+        ) -> Result<(), DeviceKeyRepoError> {
             self.revoke_device_key_result
                 .lock()
                 .expect("lock poisoned")
@@ -632,6 +646,7 @@ pub mod mock {
         async fn rename_device_key(
             &self,
             _device_kid: &Kid,
+            _account_id: Uuid,
             _new_name: &str,
         ) -> Result<(), DeviceKeyRepoError> {
             self.rename_device_key_result


### PR DESCRIPTION
Closes #517

## Summary
- `revoke_device` and `rename_device` handlers had a TOCTOU race: they called `get_owned_device` (SELECT) to check ownership, then ran the mutation in a separate query
- Fixed by adding `account_id` to the UPDATE WHERE clause (`WHERE device_kid = $1 AND account_id = $2 AND revoked_at IS NULL`), making ownership check + mutation atomic
- Removed the now-dead `get_owned_device` helper and its tests
- Existing disambiguation logic (`ensure_active_device_updated` / `not_found_or_revoked`) handles 0-row updates correctly

## Confirmed zero callers
`get_owned_device` was only called by the two handlers that now embed the check — grep confirms no other references.

## Test plan
- [x] 249 backend tests pass
- [x] clippy clean
- [ ] Manual: revoke/rename still works for owned devices
- [ ] Manual: revoke/rename returns 404 for devices owned by other accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)