### PR TITLE
refine: add HTTP integration test for revoke quota exceeded (429)

### DIFF
--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -1321,3 +1321,55 @@ async fn endorse_succeeds_as_out_of_slot_when_slots_full() {
         "4th endorsement should succeed as out-of-slot"
     );
 }
+
+// ─── Revoke quota exhaustion ──────────────────────────────────────────────────
+
+/// When a user has exhausted the daily action quota, a revoke attempt must
+/// return 429 Too Many Requests.
+#[shared_runtime_test]
+async fn revoke_returns_429_when_quota_exceeded() {
+    let db = isolated_db().await;
+    let (app, keys, account_id) = signup_and_get_account("revokequota", db.pool()).await;
+
+    // Seed 5 actions (daily quota) directly so we don't consume real API budget.
+    use tinycongress_api::trust::repo::{PgTrustRepo, TrustRepo};
+    let trust_repo = PgTrustRepo::new(db.pool().clone());
+    for _ in 0..5 {
+        trust_repo
+            .enqueue_action(account_id, "endorse", &serde_json::json!({}))
+            .await
+            .expect("enqueue");
+    }
+
+    // Sign up a second user to revoke (subject_id must be a valid UUID).
+    let (json2, _) = valid_signup_with_keys("revokequotasubject");
+    let resp2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/auth/signup")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(json2))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let body2 = axum::body::to_bytes(resp2.into_body(), 1024 * 1024)
+        .await
+        .expect("body2");
+    let j2: Value = serde_json::from_slice(&body2).expect("json2");
+    let subject_id = j2["account_id"].as_str().expect("account_id");
+
+    let body = serde_json::json!({ "subject_id": subject_id }).to_string();
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/revoke",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+}


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added `revoke_returns_429_when_quota_exceeded` HTTP integration test covering the untested QuotaExceeded error path for `POST /trust/revoke`, which maps to 429 Too Many Requests when the daily action limit is exhausted — the endorse path had this test but revoke did not.

---
*Generated by [refine.sh](scripts/refine.sh)*