### PR TITLE
refine: add is_finite() guard to weight validation in trust handlers

### DIFF
--- a/service/src/trust/http/mod.rs
+++ b/service/src/trust/http/mod.rs
@@ -150,7 +150,7 @@ async fn endorse_handler(
         Err(e) => return e,
     };
 
-    if body.weight <= 0.0 || body.weight > 1.0 {
+    if !body.weight.is_finite() || body.weight <= 0.0 || body.weight > 1.0 {
         return bad_request("weight must be in range (0.0, 1.0]");
     }
 
@@ -357,7 +357,7 @@ async fn create_invite_handler(
     let weight = body.weight.unwrap_or_else(|| {
         compute_endorsement_weight(&body.delivery_method, body.relationship_depth.as_deref())
     });
-    if weight <= 0.0 || weight > 1.0 {
+    if !weight.is_finite() || weight <= 0.0 || weight > 1.0 {
         return bad_request("weight must be in range (0.0, 1.0]");
     }
 


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added `is_finite()` guard to weight validation in both `endorse_handler` and `create_invite_handler` so NaN values (which silently pass IEEE 754 range comparisons) are rejected at the HTTP boundary before reaching trust graph storage.

---
*Generated by [refine.sh](scripts/refine.sh)*