### PR TITLE
refine: test invalid base64url envelope in create_invite_handler

### DIFF
--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -568,6 +568,40 @@ async fn endorse_rejects_weight_above_one() {
 // ─── Create invite validation ─────────────────────────────────────────────────
 
 #[shared_runtime_test]
+async fn create_invite_rejects_invalid_base64url_envelope() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("invitebadb64", db.pool()).await;
+
+    let body = serde_json::json!({
+        "envelope": "not!!valid%%base64url",
+        "delivery_method": "qr",
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .to_lowercase()
+            .contains("base64"),
+        "error should mention base64, got: {}",
+        json["error"]
+    );
+}
+
+#[shared_runtime_test]
 async fn create_invite_rejects_invalid_delivery_method() {
     let db = isolated_db().await;
     let (app, keys, _account_id) = signup_and_get_account("invitedelivery", db.pool()).await;


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added `create_invite_rejects_invalid_base64url_envelope` HTTP integration test covering the previously untested error path where an invalid base64url string for the `envelope` field in POST /trust/invites returns 400 BAD_REQUEST.

---
*Generated by [refine.sh](scripts/refine.sh)*