### PR TITLE
fix(refine): batch ledger commits and capture PR numbers reliably

### DIFF
--- a/scripts/refine.sh
+++ b/scripts/refine.sh
@@ -647,6 +647,9 @@ $summary
             log "WARNING: Exhausted $CI_MAX_FIX_ATTEMPTS CI fix attempts for $pr_url"
         fi
     fi
+
+    # Output PR number to stdout for the caller to capture
+    echo "${pr_url##*/}"
 }
 
 handle_ticket() {
@@ -843,9 +846,8 @@ for i, c in enumerate(text):
 
     case "$action" in
         change)
-            handle_change "$wt_path" "$branch" "$summary"
             local pr_num
-            pr_num="$(gh pr list --head "$branch" --json number --jq '.[0].number' 2>/dev/null || echo "0")"
+            pr_num="$(handle_change "$wt_path" "$branch" "$summary")"
             update_ledger "change" "$impact" "$summary" "$pr_num" "" "$finding_type"
             ;;
         skip)
@@ -869,9 +871,6 @@ for i, c in enumerate(text):
             return 1
             ;;
     esac
-
-    # Commit ledger after each iteration
-    commit_ledger
 
     echo "$action"
 }
@@ -929,7 +928,6 @@ run_target() {
                 if [[ "$idle_count" -ge "$IDLE_LIMIT" ]]; then
                     log "Reached idle_limit=$IDLE_LIMIT, graduating $FOCUS_PATH"
                     graduate_area
-                    commit_ledger
                     break
                 fi
                 ;;
@@ -940,6 +938,9 @@ run_target() {
             sleep "$COOLDOWN"
         fi
     done
+
+    # Commit ledger once per target (batches all iteration updates)
+    commit_ledger
 
     log "=== Target finished: $FOCUS_PATH ($pr_count PRs, $idle_count idle) ==="
 }


### PR DESCRIPTION
## Summary
- **Batch ledger commits:** Moves `commit_ledger` from per-iteration to per-target, reducing bare "refine: update ledger" commits from ~10 per run to 1. These were 25% of recent master history.
- **Fix pr:0 bug:** Captures PR number directly from `gh pr create` output instead of re-querying via `gh pr list --head`, which races with auto-merge (PR may already be merged and branch deleted by the time the query runs).

## Test plan
- [ ] Trigger a manual refine run and verify only one ledger commit per target
- [ ] Verify the ledger entry for a `change` action has the correct PR number (not 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)