### PR TITLE
fix(trust): warn and skip instead of hard error on negative path_diversity

### DIFF
--- a/service/src/trust/graph_reader.rs
+++ b/service/src/trust/graph_reader.rs
@@ -32,21 +32,26 @@ impl TrustGraphReader for TrustRepoGraphReader {
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let mapped = snapshot
-            .map(|s| -> Result<TrustScoreSnapshot, anyhow::Error> {
-                let raw = s.path_diversity.unwrap_or(0);
-                let path_diversity = u32::try_from(raw).map_err(|_| {
-                    anyhow::anyhow!(
-                        "negative path_diversity ({raw}) for subject {subject} — possible data corruption"
-                    )
-                })?;
-                Ok(TrustScoreSnapshot {
-                    trust_distance: f64::from(s.trust_distance.unwrap_or(0.0)),
-                    path_diversity,
-                    eigenvector_centrality: f64::from(s.eigenvector_centrality.unwrap_or(0.0)),
-                })
-            })
-            .transpose()?;
+        let mapped = snapshot.and_then(|s| {
+            let raw = s.path_diversity.unwrap_or(0);
+            u32::try_from(raw).map_or_else(
+                |_| {
+                    tracing::warn!(
+                        subject = %subject,
+                        path_diversity = raw,
+                        "negative path_diversity — possible data corruption; treating as no score"
+                    );
+                    None
+                },
+                |path_diversity| {
+                    Some(TrustScoreSnapshot {
+                        trust_distance: f64::from(s.trust_distance.unwrap_or(0.0)),
+                        path_diversity,
+                        eigenvector_centrality: f64::from(s.eigenvector_centrality.unwrap_or(0.0)),
+                    })
+                },
+            )
+        });
         Ok(mapped)
     }
 


### PR DESCRIPTION
## Summary
- PR #767 changed `get_score` in `graph_reader.rs` to return a hard `Err` on negative `path_diversity`, replacing the previous silent clamp to 0. This causes 500s on the vote path (`POST /polling/rooms/{room_id}/polls/{poll_id}/vote`) for any user whose score row has corrupt data.
- This PR changes the behavior to `Ok(None)` with a `tracing::warn!` — the user is treated as "no score / ineligible" (clean eligibility denial) rather than triggering a 500. The anomaly is logged for investigation.

## Test plan
- [ ] `cargo check -p service` passes
- [ ] Existing trust tests pass (`cargo test -p service --test trust_tests`)
- [ ] Verify tracing output includes subject and raw value on negative path_diversity (manual/log inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)