### PR TITLE
refine: add denounce_returns_429_when_quota_exceeded HTTP integration test

### DIFF
--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -1452,3 +1452,53 @@ async fn revoke_returns_429_when_quota_exceeded() {
     let response = app.oneshot(request).await.expect("response");
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
 }
+
+// ─── Denounce quota ───────────────────────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn denounce_returns_429_when_quota_exceeded() {
+    let db = isolated_db().await;
+    let (app, keys, account_id) = signup_and_get_account("denouncequota", db.pool()).await;
+
+    // Seed 5 actions (daily quota) directly so we don't consume real API budget.
+    use tinycongress_api::trust::repo::{PgTrustRepo, TrustRepo};
+    let trust_repo = PgTrustRepo::new(db.pool().clone());
+    for _ in 0..5 {
+        trust_repo
+            .enqueue_action(account_id, "endorse", &serde_json::json!({}))
+            .await
+            .expect("enqueue");
+    }
+
+    // Sign up a second user to denounce.
+    let (json2, _) = valid_signup_with_keys("denouncequotasubject");
+    let resp2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/auth/signup")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(json2))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let body2 = axum::body::to_bytes(resp2.into_body(), 1024 * 1024)
+        .await
+        .expect("body2");
+    let j2: Value = serde_json::from_slice(&body2).expect("json2");
+    let target_id = j2["account_id"].as_str().expect("account_id");
+
+    let body = serde_json::json!({ "target_id": target_id, "reason": "spam" }).to_string();
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/denounce",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+}


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added `denounce_returns_429_when_quota_exceeded` HTTP integration test covering the previously untested `QuotaExceeded` error path for `POST /trust/denounce`, which returns 429 when the daily action limit is exhausted — the endorse and revoke handlers had this test but denounce did not.

---
*Generated by [refine.sh](scripts/refine.sh)*