### PR TITLE
refactor: move evidence and poll reset operations to PollingService trait (#798)

### DIFF
--- a/crates/tc-engine-polling/src/repo/polls.rs
+++ b/crates/tc-engine-polling/src/repo/polls.rs
@@ -415,3 +415,55 @@ where
 
     Ok(row.map(poll_row_to_record))
 }
+
+/// Check whether a dimension belongs to the given poll.
+///
+/// # Errors
+///
+/// Returns `Database` on connection failure.
+pub async fn dimension_belongs_to_poll<'e, E>(
+    executor: E,
+    dimension_id: Uuid,
+    poll_id: Uuid,
+) -> Result<bool, PollRepoError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let row: Option<(Uuid,)> =
+        sqlx::query_as("SELECT id FROM rooms__poll_dimensions WHERE id = $1 AND poll_id = $2")
+            .bind(dimension_id)
+            .bind(poll_id)
+            .fetch_optional(executor)
+            .await?;
+    Ok(row.is_some())
+}
+
+/// Reset a poll back to draft status, clearing all timing fields.
+/// Used by the ring buffer refill logic to recycle polls for a new cycle.
+///
+/// # Errors
+///
+/// Returns `NotFound` if no poll with the given ID exists in the given room.
+pub async fn reset_poll<'e, E>(
+    executor: E,
+    room_id: Uuid,
+    poll_id: Uuid,
+) -> Result<(), PollRepoError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let result = sqlx::query(
+        "UPDATE rooms__polls \
+         SET status = 'draft', closes_at = NULL, activated_at = NULL, closed_at = NULL \
+         WHERE id = $1 AND room_id = $2",
+    )
+    .bind(poll_id)
+    .bind(room_id)
+    .execute(executor)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(PollRepoError::NotFound);
+    }
+    Ok(())
+}

--- a/crates/tc-engine-polling/src/service.rs
+++ b/crates/tc-engine-polling/src/service.rs
@@ -10,8 +10,8 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::repo::{
-    lifecycle_queue, polls, votes, DimensionDistribution, DimensionRecord, DimensionStats,
-    PollRecord, PollRepoError, VoteRecord,
+    evidence, lifecycle_queue, polls, votes, DimensionDistribution, DimensionRecord,
+    DimensionStats, EvidenceRecord, PollRecord, PollRepoError, VoteRecord,
 };
 use tc_engine_api::constraints::build_constraint;
 use tc_engine_api::trust::TrustGraphReader;
@@ -27,6 +27,14 @@ pub struct CastVoteRequest {
 pub struct DimensionVote {
     pub dimension_id: Uuid,
     pub value: f32,
+}
+
+/// Owned evidence item used when creating evidence through the service layer.
+#[derive(Debug)]
+pub struct CreateEvidenceItem {
+    pub stance: String,
+    pub claim: String,
+    pub source: Option<String>,
 }
 
 // ─── Error types ───────────────────────────────────────────────────────────
@@ -126,6 +134,22 @@ pub trait PollingService: Send + Sync {
         poll_id: Uuid,
         user_id: Uuid,
     ) -> Result<Vec<VoteRecord>, PollError>;
+
+    // Evidence operations
+    async fn get_evidence_for_dimensions(
+        &self,
+        dimension_ids: &[Uuid],
+    ) -> Result<Vec<EvidenceRecord>, PollError>;
+    async fn create_evidence(
+        &self,
+        poll_id: Uuid,
+        dimension_id: Uuid,
+        items: Vec<CreateEvidenceItem>,
+    ) -> Result<u64, PollError>;
+    async fn delete_evidence_for_poll(&self, poll_id: Uuid) -> Result<u64, PollError>;
+
+    /// Sim-only: reset a poll back to draft status, clearing all timing fields.
+    async fn reset_poll(&self, room_id: Uuid, poll_id: Uuid) -> Result<(), PollError>;
 }
 
 // ─── Implementation ────────────────────────────────────────────────────────
@@ -610,6 +634,76 @@ impl PollingService for DefaultPollingService {
             .map_err(|e| {
                 tracing::error!("User votes lookup failed: {e}");
                 PollError::Internal("Internal server error".to_string())
+            })
+    }
+
+    async fn get_evidence_for_dimensions(
+        &self,
+        dimension_ids: &[Uuid],
+    ) -> Result<Vec<EvidenceRecord>, PollError> {
+        evidence::get_evidence_for_dimensions(&self.pool, dimension_ids)
+            .await
+            .map_err(|e| {
+                tracing::error!("Evidence fetch failed: {e}");
+                PollError::Internal("Internal server error".to_string())
+            })
+    }
+
+    async fn create_evidence(
+        &self,
+        poll_id: Uuid,
+        dimension_id: Uuid,
+        items: Vec<CreateEvidenceItem>,
+    ) -> Result<u64, PollError> {
+        let belongs = polls::dimension_belongs_to_poll(&self.pool, dimension_id, poll_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Dimension ownership check failed: {e}");
+                PollError::Internal("Internal server error".to_string())
+            })?;
+
+        if !belongs {
+            return Err(PollError::Validation(
+                "Dimension not found for this poll".to_string(),
+            ));
+        }
+
+        let new_evidence: Vec<evidence::NewEvidence<'_>> = items
+            .iter()
+            .map(|item| evidence::NewEvidence {
+                stance: &item.stance,
+                claim: &item.claim,
+                source: item.source.as_deref(),
+            })
+            .collect();
+
+        evidence::insert_evidence(&self.pool, dimension_id, &new_evidence)
+            .await
+            .map_err(|e| {
+                tracing::error!("Evidence insert failed: {e}");
+                PollError::Internal("Internal server error".to_string())
+            })
+    }
+
+    async fn delete_evidence_for_poll(&self, poll_id: Uuid) -> Result<u64, PollError> {
+        evidence::delete_evidence_for_poll(&self.pool, poll_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Evidence delete failed: {e}");
+                PollError::Internal("Internal server error".to_string())
+            })
+    }
+
+    async fn reset_poll(&self, room_id: Uuid, poll_id: Uuid) -> Result<(), PollError> {
+        polls::reset_poll(&self.pool, room_id, poll_id)
+            .await
+            .map_err(|e| {
+                if matches!(e, PollRepoError::NotFound) {
+                    PollError::PollNotFound
+                } else {
+                    tracing::error!("Poll reset failed: {e}");
+                    PollError::Internal("Internal server error".to_string())
+                }
             })
     }
 }

--- a/service/src/rooms/http/polling.rs
+++ b/service/src/rooms/http/polling.rs
@@ -10,13 +10,13 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::http::{internal_error, not_found, ErrorResponse};
 use crate::identity::http::auth::AuthenticatedDevice;
-use crate::rooms::repo::evidence;
-use crate::rooms::service::{CastVoteRequest, PollError, PollingService, VoteError};
+use crate::rooms::service::{
+    CastVoteRequest, CreateEvidenceItem, PollError, PollingService, VoteError,
+};
 
 // ─── Response types ────────────────────────────────────────────────────────
 
@@ -189,7 +189,6 @@ pub async fn list_polls(
 
 pub async fn get_poll_detail(
     Extension(polling): Extension<Arc<dyn PollingService>>,
-    Extension(pool): Extension<PgPool>,
     Path((_room_id, poll_id)): Path<(Uuid, Uuid)>,
 ) -> impl IntoResponse {
     let poll = match polling.get_poll(poll_id).await {
@@ -202,13 +201,9 @@ pub async fn get_poll_detail(
     };
 
     let dimension_ids: Vec<Uuid> = dimensions.iter().map(|d| d.id).collect();
-    let evidence_records = match evidence::get_evidence_for_dimensions(&pool, &dimension_ids).await
-    {
+    let evidence_records = match polling.get_evidence_for_dimensions(&dimension_ids).await {
         Ok(ev) => ev,
-        Err(e) => {
-            tracing::error!("Failed to fetch evidence: {e}");
-            return internal_error();
-        }
+        Err(e) => return poll_error_response(e),
     };
 
     let mut evidence_by_dim: HashMap<Uuid, Vec<EvidenceResponse>> = HashMap::new();
@@ -320,90 +315,55 @@ pub async fn add_dimension(
 // ─── Evidence handlers ─────────────────────────────────────────────────────
 
 pub async fn create_evidence(
-    Extension(pool): Extension<PgPool>,
+    Extension(polling): Extension<Arc<dyn PollingService>>,
     Path((_room_id, poll_id, dimension_id)): Path<(Uuid, Uuid, Uuid)>,
     Json(body): Json<CreateEvidenceBody>,
 ) -> impl IntoResponse {
-    // Validate dimension belongs to the poll
-    let belongs: Option<(Uuid,)> = match sqlx::query_as(
-        "SELECT id FROM rooms__poll_dimensions WHERE id = $1 AND poll_id = $2",
-    )
-    .bind(dimension_id)
-    .bind(poll_id)
-    .fetch_optional(&pool)
-    .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::error!("DB error checking dimension ownership: {e}");
-            return internal_error();
-        }
-    };
-
-    if belongs.is_none() {
-        return not_found("Dimension not found for this poll");
-    }
-
-    let new_evidence: Vec<evidence::NewEvidence<'_>> = body
+    let items: Vec<CreateEvidenceItem> = body
         .evidence
-        .iter()
-        .map(|item| evidence::NewEvidence {
-            stance: &item.stance,
-            claim: &item.claim,
-            source: item.source.as_deref(),
+        .into_iter()
+        .map(|item| CreateEvidenceItem {
+            stance: item.stance,
+            claim: item.claim,
+            source: item.source,
         })
         .collect();
 
-    match evidence::insert_evidence(&pool, dimension_id, &new_evidence).await {
+    match polling.create_evidence(poll_id, dimension_id, items).await {
         Ok(count) => (
             StatusCode::CREATED,
             Json(serde_json::json!({ "count": count })),
         )
             .into_response(),
-        Err(e) => {
-            tracing::error!("Failed to insert evidence: {e}");
-            internal_error()
-        }
+        Err(PollError::Validation(msg)) => not_found(&msg),
+        Err(e) => poll_error_response(e),
     }
 }
 
 pub async fn delete_evidence(
-    Extension(pool): Extension<PgPool>,
+    Extension(polling): Extension<Arc<dyn PollingService>>,
     Path((_room_id, poll_id)): Path<(Uuid, Uuid)>,
 ) -> impl IntoResponse {
-    match evidence::delete_evidence_for_poll(&pool, poll_id).await {
+    match polling.delete_evidence_for_poll(poll_id).await {
         Ok(deleted) => (
             StatusCode::OK,
             Json(serde_json::json!({ "deleted": deleted })),
         )
             .into_response(),
-        Err(e) => {
-            tracing::error!("Failed to delete evidence: {e}");
-            internal_error()
-        }
+        Err(e) => poll_error_response(e),
     }
 }
 
 /// Sim-only: reset a poll back to draft status, clearing all timing fields.
 /// Used by the ring buffer refill logic to recycle polls for a new cycle.
 pub async fn reset_poll(
-    Extension(pool): Extension<PgPool>,
+    Extension(polling): Extension<Arc<dyn PollingService>>,
     Path((room_id, poll_id)): Path<(Uuid, Uuid)>,
-) -> Result<impl IntoResponse, StatusCode> {
-    let result = sqlx::query(
-        "UPDATE rooms__polls \
-         SET status = 'draft', closes_at = NULL, activated_at = NULL, closed_at = NULL \
-         WHERE id = $1 AND room_id = $2",
-    )
-    .bind(poll_id)
-    .bind(room_id)
-    .execute(&pool)
-    .await;
-
-    match result {
-        Ok(r) if r.rows_affected() == 0 => Err(StatusCode::NOT_FOUND),
-        Ok(_) => Ok(StatusCode::OK),
-        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+) -> impl IntoResponse {
+    match polling.reset_poll(room_id, poll_id).await {
+        Ok(()) => StatusCode::OK.into_response(),
+        Err(PollError::PollNotFound) => not_found("Poll not found"),
+        Err(e) => poll_error_response(e),
     }
 }
 

--- a/service/src/rooms/service.rs
+++ b/service/src/rooms/service.rs
@@ -12,8 +12,8 @@ use super::repo::{RoomRecord, RoomRepoError, RoomsRepo};
 
 // Re-export polling types for backward compatibility (used by HTTP handlers & tests)
 pub use tc_engine_polling::service::{
-    CastVoteRequest, DimensionVote, PollDistribution, PollError, PollResults, PollingService,
-    VoteError,
+    CastVoteRequest, CreateEvidenceItem, DimensionVote, PollDistribution, PollError, PollResults,
+    PollingService, VoteError,
 };
 
 // ─── Error types ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Removes all raw `Extension<PgPool>` from polling HTTP handlers by lifting operations to the `PollingService` trait.

**4 methods added to `PollingService`:**
- `get_evidence_for_dimensions` — evidence fetch for poll detail
- `create_evidence` — with dimension ownership validation
- `delete_evidence_for_poll` — bulk evidence deletion
- `reset_poll` — draft reset (clears timing fields)

**2 repo helpers added:**
- `polls::dimension_belongs_to_poll` — ownership check
- `polls::reset_poll` — UPDATE with NotFound handling

**Handler cleanup:**
- Removed `Extension<PgPool>`, `use sqlx::PgPool`, and direct evidence module imports from `polling.rs`
- All 4 handlers now route through `Arc<dyn PollingService>`

After this PR, `just lint-patterns` should report zero PgPool violations in polling handlers.

Closes #798

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy` clean
- [ ] Existing polling tests pass
- [ ] `just lint-patterns` clean for polling.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)