### PR TITLE
refine: fail closed on missing in_slot in endorse worker

### DIFF
--- a/service/src/trust/worker.rs
+++ b/service/src/trust/worker.rs
@@ -103,7 +103,9 @@ impl TrustWorker {
                     serde_json::Value::Null => None,
                     v => Some(v.clone()),
                 };
-                let in_slot = action.payload["in_slot"].as_bool().unwrap_or(true);
+                let in_slot = action.payload["in_slot"].as_bool().ok_or_else(|| {
+                    anyhow::anyhow!("endorse payload missing or invalid 'in_slot'")
+                })?;
 
                 self.reputation_repo
                     .create_endorsement(

--- a/service/tests/trust_worker_tests.rs
+++ b/service/tests/trust_worker_tests.rs
@@ -39,7 +39,7 @@ async fn test_process_batch_endorse_action() {
     )
     .bind(actor.id)
     .bind("endorse")
-    .bind(json!({ "subject_id": subject.id, "weight": 0.8, "attestation": null }))
+    .bind(json!({ "subject_id": subject.id, "weight": 0.8, "attestation": null, "in_slot": true }))
     .execute(&pool)
     .await
     .expect("seed action");
@@ -371,7 +371,67 @@ async fn test_process_batch_endorse_invalid_weight_fails() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 6: denounce action with empty reason fails the action
+// Test 6: endorse action with missing in_slot fails the action
+// ---------------------------------------------------------------------------
+#[shared_runtime_test]
+async fn test_process_batch_endorse_missing_in_slot_fails() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let actor = AccountFactory::new()
+        .with_seed(1)
+        .create(&pool)
+        .await
+        .expect("create actor");
+
+    let subject = AccountFactory::new()
+        .with_seed(2)
+        .create(&pool)
+        .await
+        .expect("create subject");
+
+    // Seed an 'endorse' action without the required 'in_slot' field
+    sqlx::query(
+        "INSERT INTO trust__action_queue (actor_id, action_type, payload) VALUES ($1, $2, $3)",
+    )
+    .bind(actor.id)
+    .bind("endorse")
+    .bind(json!({ "subject_id": subject.id, "weight": 0.5, "attestation": null }))
+    .execute(&pool)
+    .await
+    .expect("seed action");
+
+    let trust_repo = Arc::new(PgTrustRepo::new(pool.clone()));
+    let reputation_repo = Arc::new(PgReputationRepo::new(pool.clone()));
+    let engine = Arc::new(TrustEngine::new(pool.clone()));
+    let worker = Arc::new(TrustWorker::new(
+        trust_repo,
+        reputation_repo,
+        engine,
+        50,
+        30,
+    ));
+
+    let processed = worker.process_batch().await.expect("process_batch");
+    assert_eq!(processed, 1);
+
+    // Action should be marked failed with an error mentioning in_slot
+    let (status, error_message): (String, Option<String>) =
+        sqlx::query_as("SELECT status, error_message FROM trust__action_queue WHERE actor_id = $1")
+            .bind(actor.id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch action");
+
+    assert_eq!(status, "failed");
+    assert!(
+        error_message.as_deref().unwrap_or("").contains("in_slot"),
+        "error_message should mention 'in_slot', got: {error_message:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: denounce action with empty reason fails the action
 // ---------------------------------------------------------------------------
 #[shared_runtime_test]
 async fn test_process_batch_denounce_empty_reason_fails() {


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Replaced `unwrap_or(true)` with `ok_or_else` on the `in_slot` field in the endorse worker branch, failing closed on missing or non-bool payloads, consistent with how `weight` and `reason` are already handled; added a test covering the new error path.

---
*Generated by [refine.sh](scripts/refine.sh)*