### PR TITLE
refine: validate invite envelope size (1–4096 bytes)

### DIFF
--- a/service/src/trust/http/mod.rs
+++ b/service/src/trust/http/mod.rs
@@ -349,6 +349,10 @@ async fn create_invite_handler(
         return bad_request("Invalid base64url encoding for envelope");
     };
 
+    if envelope_bytes.is_empty() || envelope_bytes.len() > 4096 {
+        return bad_request("envelope must be between 1 and 4096 bytes");
+    }
+
     if !VALID_DELIVERY_METHODS.contains(&body.delivery_method.as_str()) {
         return bad_request("delivery_method must be one of: qr, email, video, text, messaging");
     }

--- a/service/tests/trust_http_tests.rs
+++ b/service/tests/trust_http_tests.rs
@@ -602,6 +602,70 @@ async fn create_invite_rejects_invalid_base64url_envelope() {
 }
 
 #[shared_runtime_test]
+async fn create_invite_rejects_oversized_envelope() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("invitebigenvelop", db.pool()).await;
+
+    // 4097 bytes exceeds the 4096-byte maximum
+    let oversized = vec![0u8; 4097];
+    let envelope_b64 = tc_crypto::encode_base64url(&oversized);
+    let body = serde_json::json!({
+        "envelope": envelope_b64,
+        "delivery_method": "qr",
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("envelope"),
+        "error should mention envelope, got: {}",
+        json["error"]
+    );
+}
+
+#[shared_runtime_test]
+async fn create_invite_rejects_empty_envelope() {
+    let db = isolated_db().await;
+    let (app, keys, _account_id) = signup_and_get_account("inviteemptyenv", db.pool()).await;
+
+    let envelope_b64 = tc_crypto::encode_base64url(&[]);
+    let body = serde_json::json!({
+        "envelope": envelope_b64,
+        "delivery_method": "qr",
+        "attestation": {}
+    })
+    .to_string();
+
+    let request = build_authed_request(
+        Method::POST,
+        "/trust/invites",
+        &body,
+        &keys.device_signing_key,
+        &keys.device_kid,
+    );
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("envelope"),
+        "error should mention envelope, got: {}",
+        json["error"]
+    );
+}
+
+#[shared_runtime_test]
 async fn create_invite_rejects_invalid_delivery_method() {
     let db = isolated_db().await;
     let (app, keys, _account_id) = signup_and_get_account("invitedelivery", db.pool()).await;


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added 1–4096 byte size validation for the invite envelope in `create_invite_handler`, mirroring the backup envelope's `MAX_ENVELOPE_SIZE` convention; previously only the base64url encoding was checked, allowing arbitrarily large payloads to reach the database.

---
*Generated by [refine.sh](scripts/refine.sh)*