### PR TITLE
refine: test denounce worker rejects reason exceeding 500 chars

### DIFF
--- a/service/tests/trust_worker_tests.rs
+++ b/service/tests/trust_worker_tests.rs
@@ -434,6 +434,63 @@ async fn test_process_batch_endorse_missing_in_slot_fails() {
 // Test 7: denounce action with empty reason fails the action
 // ---------------------------------------------------------------------------
 #[shared_runtime_test]
+async fn test_process_batch_denounce_reason_too_long_fails() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let actor = AccountFactory::new()
+        .with_seed(1)
+        .create(&pool)
+        .await
+        .expect("create actor");
+
+    let target = AccountFactory::new()
+        .with_seed(2)
+        .create(&pool)
+        .await
+        .expect("create target");
+
+    // Seed a 'denounce' action with a reason that is 501 characters (upper bound is 500)
+    sqlx::query(
+        "INSERT INTO trust__action_queue (actor_id, action_type, payload) VALUES ($1, $2, $3)",
+    )
+    .bind(actor.id)
+    .bind("denounce")
+    .bind(json!({ "target_id": target.id, "reason": "a".repeat(501) }))
+    .execute(&pool)
+    .await
+    .expect("seed action");
+
+    let trust_repo = Arc::new(PgTrustRepo::new(pool.clone()));
+    let reputation_repo = Arc::new(PgReputationRepo::new(pool.clone()));
+    let engine = Arc::new(TrustEngine::new(pool.clone()));
+    let worker = Arc::new(TrustWorker::new(
+        trust_repo,
+        reputation_repo,
+        engine,
+        50,
+        30,
+    ));
+
+    let processed = worker.process_batch().await.expect("process_batch");
+    assert_eq!(processed, 1);
+
+    // Action should be marked failed with an error mentioning reason
+    let (status, error_message): (String, Option<String>) =
+        sqlx::query_as("SELECT status, error_message FROM trust__action_queue WHERE actor_id = $1")
+            .bind(actor.id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch action");
+
+    assert_eq!(status, "failed");
+    assert!(
+        error_message.as_deref().unwrap_or("").contains("reason"),
+        "error_message should mention 'reason', got: {error_message:?}"
+    );
+}
+
+#[shared_runtime_test]
 async fn test_process_batch_denounce_empty_reason_fails() {
     let db = isolated_db().await;
     let pool = db.pool().clone();


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Added `test_process_batch_denounce_reason_too_long_fails` covering the upper bound (>500 chars) of the denounce reason length validation in the worker — the lower bound (empty) was already tested but the upper bound was not.

---
*Generated by [refine.sh](scripts/refine.sh)*