### PR TITLE
refine: fix error conversion in create_denouncement_and_revoke_endorsement

### DIFF
--- a/service/src/trust/repo/denouncements.rs
+++ b/service/src/trust/repo/denouncements.rs
@@ -53,7 +53,14 @@ pub(super) async fn create_denouncement_and_revoke_endorsement(
         &mut *tx, accuser_id, target_id, "trust",
     )
     .await
-    .map_err(|e| TrustRepoError::Database(sqlx::Error::Protocol(e.to_string())))?;
+    .map_err(|e| match e {
+        crate::reputation::repo::endorsements::EndorsementRepoError::Database(db_err) => {
+            TrustRepoError::Database(db_err)
+        }
+        crate::reputation::repo::endorsements::EndorsementRepoError::NotFound => {
+            TrustRepoError::NotFound
+        }
+    })?;
 
     tx.commit().await?;
 


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Replaced fake `sqlx::Error::Protocol(e.to_string())` error conversion in `create_denouncement_and_revoke_endorsement` with a proper match on `EndorsementRepoError` variants, preserving the actual database error and correctly mapping `NotFound`.

---
*Generated by [refine.sh](scripts/refine.sh)*