### PR TITLE
refactor: deduplicate trust query hooks and fix poll cache keys (#801)

### DIFF
--- a/web/src/api/trustQueries.ts
+++ b/web/src/api/trustQueries.ts
@@ -1,8 +1,11 @@
 /**
- * Endorsement query hooks — delegate to shared @/api layer.
+ * TanStack Query hooks for trust and endorsement data shared across features.
  *
- * Query keys use the trust naming convention ('trust-*') so all features share
- * the same cache entries and avoid stale-cache bugs.
+ * Lives in @/api so both the trust and endorsements features can import it
+ * without violating the no-cross-feature-import ESLint boundary rule.
+ *
+ * Query keys use the 'trust-*' naming convention so all features share the
+ * same cache entries and avoid stale-cache bugs.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getMyEndorsements } from '@/api/endorsements';

--- a/web/src/engines/polling/api/queries.ts
+++ b/web/src/engines/polling/api/queries.ts
@@ -50,7 +50,7 @@ export function usePolls(roomId: string) {
 
 export function usePollDetail(roomId: string, pollId: string) {
   return useQuery<PollDetail>({
-    queryKey: ['poll-detail', pollId],
+    queryKey: ['poll-detail', roomId, pollId],
     queryFn: () => getPollDetail(roomId, pollId),
     enabled: Boolean(roomId && pollId),
     refetchInterval: 20_000,
@@ -68,7 +68,7 @@ export function useAgenda(roomId: string) {
 
 export function usePollResults(roomId: string, pollId: string) {
   return useQuery<PollResults>({
-    queryKey: ['poll-results', pollId],
+    queryKey: ['poll-results', roomId, pollId],
     queryFn: () => getPollResults(roomId, pollId),
     enabled: Boolean(roomId && pollId),
     refetchInterval: 20_000,
@@ -77,7 +77,7 @@ export function usePollResults(roomId: string, pollId: string) {
 
 export function usePollDistribution(roomId: string, pollId: string) {
   return useQuery<PollDistribution>({
-    queryKey: ['poll-distribution', pollId],
+    queryKey: ['poll-distribution', roomId, pollId],
     queryFn: () => getPollDistribution(roomId, pollId),
     enabled: Boolean(roomId && pollId),
     refetchInterval: 20_000,
@@ -139,8 +139,8 @@ export function useCastVote(
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['my-votes', pollId] });
-      void queryClient.invalidateQueries({ queryKey: ['poll-results', pollId] });
-      void queryClient.invalidateQueries({ queryKey: ['poll-distribution', pollId] });
+      void queryClient.invalidateQueries({ queryKey: ['poll-results', roomId, pollId] });
+      void queryClient.invalidateQueries({ queryKey: ['poll-distribution', roomId, pollId] });
     },
   });
 }

--- a/web/src/features/endorsements/api/index.ts
+++ b/web/src/features/endorsements/api/index.ts
@@ -5,4 +5,4 @@ export {
   useCreateInvite,
   useAcceptInvite,
   useRevokeEndorsement,
-} from './queries';
+} from '@/api/trustQueries';

--- a/web/src/features/trust/api/queries.ts
+++ b/web/src/features/trust/api/queries.ts
@@ -1,25 +1,33 @@
 /**
- * TanStack Query hooks for trust API
+ * TanStack Query hooks for trust API.
+ *
+ * Shared hooks (useTrustBudget, useMyEndorsementsList, useMyInvites,
+ * useCreateInvite, useAcceptInvite, useRevokeEndorsement) are re-exported
+ * from @/api/trustQueries so the endorsements feature can import them too
+ * without violating the no-cross-feature-import ESLint boundary rule.
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { CryptoModule } from '@/providers/CryptoProvider';
 import {
-  acceptInvite,
-  createInvite,
   denounce,
   endorse,
-  getMyBudget,
-  getMyEndorsements,
   getMyScores,
   listMyDenouncements,
-  listMyInvites,
   lookupAccount,
-  revokeEndorsement,
-  type CreateInvitePayload,
   type DenouncementPayload,
   type EndorsePayload,
 } from './client';
+
+// Re-export shared hooks so feature consumers only need to import from trust.
+export {
+  useTrustBudget,
+  useMyEndorsementsList,
+  useMyInvites,
+  useCreateInvite,
+  useAcceptInvite,
+  useRevokeEndorsement,
+} from '@/api/trustQueries';
 
 export function useTrustScores(
   deviceKid: string | null,
@@ -36,93 +44,6 @@ export function useTrustScores(
     },
     enabled: Boolean(deviceKid && privateKey && wasmCrypto),
     staleTime: 30_000,
-  });
-}
-
-export function useTrustBudget(
-  deviceKid: string | null,
-  privateKey: CryptoKey | null,
-  wasmCrypto: CryptoModule | null
-) {
-  return useQuery({
-    queryKey: ['trust-budget', deviceKid],
-    queryFn: async () => {
-      if (!deviceKid || !privateKey || !wasmCrypto) {
-        throw new Error('Not authenticated');
-      }
-      return getMyBudget(deviceKid, privateKey, wasmCrypto);
-    },
-    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
-    staleTime: 30_000,
-  });
-}
-
-export function useMyEndorsementsList(
-  deviceKid: string | null,
-  privateKey: CryptoKey | null,
-  wasmCrypto: CryptoModule | null
-) {
-  return useQuery({
-    queryKey: ['trust-endorsements', deviceKid],
-    queryFn: async () => {
-      if (!deviceKid || !privateKey || !wasmCrypto) {
-        throw new Error('Not authenticated');
-      }
-      return getMyEndorsements(deviceKid, privateKey, wasmCrypto);
-    },
-    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
-    staleTime: 30_000,
-  });
-}
-
-export function useMyInvites(
-  deviceKid: string | null,
-  privateKey: CryptoKey | null,
-  wasmCrypto: CryptoModule | null
-) {
-  return useQuery({
-    queryKey: ['trust-invites', deviceKid],
-    queryFn: async () => {
-      if (!deviceKid || !privateKey || !wasmCrypto) {
-        throw new Error('Not authenticated');
-      }
-      return listMyInvites(deviceKid, privateKey, wasmCrypto);
-    },
-    enabled: Boolean(deviceKid && privateKey && wasmCrypto),
-    staleTime: 30_000,
-  });
-}
-
-export function useCreateInvite(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (payload: CreateInvitePayload) =>
-      createInvite(deviceKid, privateKey, wasmCrypto, payload),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
-    },
-  });
-}
-
-export function useAcceptInvite(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (inviteId: string) => acceptInvite(deviceKid, privateKey, wasmCrypto, inviteId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
-      void queryClient.invalidateQueries({ queryKey: ['trust-invites'] });
-      void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
-      void queryClient.invalidateQueries({ queryKey: ['trust-endorsements'] });
-      void queryClient.invalidateQueries({ queryKey: ['verification-status'] });
-    },
   });
 }
 
@@ -185,22 +106,5 @@ export function useLookupAccount(
     enabled: Boolean(deviceKid && privateKey && wasmCrypto && username.trim()),
     staleTime: 60_000,
     retry: false,
-  });
-}
-
-export function useRevokeEndorsement(
-  deviceKid: string,
-  privateKey: CryptoKey,
-  wasmCrypto: CryptoModule
-) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (subjectId: string) =>
-      revokeEndorsement(deviceKid, privateKey, wasmCrypto, subjectId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['trust-budget'] });
-      void queryClient.invalidateQueries({ queryKey: ['trust-scores'] });
-      void queryClient.invalidateQueries({ queryKey: ['trust-endorsements'] });
-    },
   });
 }


### PR DESCRIPTION
## Summary

### Part 1: Deduplicate trust/endorsement hooks
- Creates `web/src/api/trustQueries.ts` as single canonical source for 6 shared hooks
- Deletes duplicate `features/endorsements/api/queries.ts`
- Both feature dirs re-export from `@/api/trustQueries` — no ESLint cross-feature violations
- Fixes divergent cache invalidation (endorsements version was missing `trust-scores` invalidation on accept)

### Part 2: Fix poll query keys
- `usePollDetail`: `['poll-detail', pollId]` → `['poll-detail', roomId, pollId]`
- `usePollResults`: `['poll-results', pollId]` → `['poll-results', roomId, pollId]`
- `usePollDistribution`: `['poll-distribution', pollId]` → `['poll-distribution', roomId, pollId]`
- Updated `useCastVote` invalidation to match new key shape

Closes #801

## Test plan
- [ ] `yarn tsc --noEmit` passes
- [ ] `yarn lint` passes
- [ ] All affected feature tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)