### PR TITLE
refine: single source of truth for trust slot limits

### DIFF
--- a/service/src/trust/http/mod.rs
+++ b/service/src/trust/http/mod.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::repo::{TrustRepo, TrustRepoError};
-use super::service::{TrustService, TrustServiceError};
+use super::service::{
+    TrustService, TrustServiceError, DENOUNCEMENT_SLOT_LIMIT, ENDORSEMENT_SLOT_LIMIT,
+};
 use super::weight::compute_endorsement_weight;
 use crate::http::{bad_request, conflict, internal_error, not_found, too_many_requests};
 use crate::identity::http::auth::AuthenticatedDevice;
@@ -273,10 +275,6 @@ async fn scores_me_handler(
     }
 }
 
-/// Demo endorsement slot count (k=3).
-const ENDORSEMENT_SLOTS: u32 = 3;
-/// Permanent denouncement budget per user (d=2, ADR-020).
-const DENOUNCEMENT_SLOTS: u32 = 2;
 /// Valid delivery methods for invites (must match migration 18 CHECK constraint).
 const VALID_DELIVERY_METHODS: &[&str] = &["qr", "email", "video", "text", "messaging"];
 /// Valid relationship depths for invites (must match migration 18 CHECK constraint).
@@ -324,13 +322,13 @@ async fn budget_handler(
     (
         StatusCode::OK,
         Json(BudgetResponse {
-            slots_total: ENDORSEMENT_SLOTS,
+            slots_total: ENDORSEMENT_SLOT_LIMIT,
             slots_used: endorsements_used,
-            slots_available: i64::from(ENDORSEMENT_SLOTS) - endorsements_used,
+            slots_available: i64::from(ENDORSEMENT_SLOT_LIMIT) - endorsements_used,
             out_of_slot_count,
-            denouncements_total: DENOUNCEMENT_SLOTS,
+            denouncements_total: DENOUNCEMENT_SLOT_LIMIT,
             denouncements_used,
-            denouncements_available: i64::from(DENOUNCEMENT_SLOTS) - denouncements_used,
+            denouncements_available: i64::from(DENOUNCEMENT_SLOT_LIMIT) - denouncements_used,
         }),
     )
         .into_response()

--- a/service/src/trust/service.rs
+++ b/service/src/trust/service.rs
@@ -9,6 +9,13 @@ use uuid::Uuid;
 use crate::reputation::repo::ReputationRepo;
 use crate::trust::repo::{TrustRepo, TrustRepoError};
 
+/// Demo endorsement slot limit per user (k=3).
+pub const ENDORSEMENT_SLOT_LIMIT: u32 = 3;
+/// Permanent denouncement budget per user (d=2, ADR-020).
+pub const DENOUNCEMENT_SLOT_LIMIT: u32 = 2;
+/// Max trust actions per user per day (resets at midnight UTC).
+pub const DAILY_ACTION_QUOTA: i64 = 5;
+
 /// Errors returned by [`TrustService`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum TrustServiceError {
@@ -81,9 +88,9 @@ impl DefaultTrustService {
         Self {
             trust_repo,
             reputation_repo,
-            endorsement_slots: 3,
-            max_denouncement_slots: 2,
-            daily_quota: 5,
+            endorsement_slots: ENDORSEMENT_SLOT_LIMIT,
+            max_denouncement_slots: DENOUNCEMENT_SLOT_LIMIT,
+            daily_quota: DAILY_ACTION_QUOTA,
         }
     }
 }


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Consolidated duplicated slot limit constants (k=3 endorsements, d=2 denouncements, quota=5) into pub consts in service.rs, removing the parallel definitions in http/mod.rs that could drift independently.

---
*Generated by [refine.sh](scripts/refine.sh)*