### PR TITLE
docs: expand codebase sweep skill from 7 to 18 categories

### DIFF
--- a/docs/skills/codebase-sweep.md
+++ b/docs/skills/codebase-sweep.md
@@ -97,9 +97,139 @@ Look for:
 
 Search: `service/src/`, `service/tests/`, `crates/`, `web/src/`.
 
+### 8. Config & Environment Variable Hygiene
+
+Look for:
+- Required config fields with no validation in `Config::validate()` (silent empty strings)
+- `#[derive(Debug)]` on structs containing secrets (footgun if `{:?}` formatted)
+- Helm values not wired to configmap/env vars (app expects a value, deployment doesn't set it)
+- Duplicated constants across Rust defaults and Helm values (two sources of truth)
+- Hardcoded ports/URLs in templates that should reference values
+- `${VAR:-default}` in entrypoints where `${VAR:?}` is appropriate
+
+Search: `service/src/config.rs`, `kube/`, `skaffold.yaml`, `dockerfiles/`.
+
+### 9. API Contract & Schema Drift
+
+Look for:
+- Endpoints in code not in `web/openapi.json` (or vice versa)
+- Response struct field names that don't match frontend TypeScript types (snake_case mismatch, renamed fields)
+- Response wrapper mismatches: backend wraps in `{ items: [...] }`, frontend expects bare array
+- Dead frontend API functions calling removed endpoints
+- Dead backend endpoints with zero frontend callers
+
+Search: `web/openapi.json`, `web/schema.graphql`, `service/src/*/http/`, `web/src/api/`.
+
+### 10. Migration ↔ Code Sync
+
+Look for:
+- DB columns in migrations not represented in Rust `FromRow` structs
+- Rust struct fields referencing columns that don't exist in any migration
+- CHECK constraints in SQL not enforced in Rust validation (opaque DB errors vs clean 400s)
+- NOT NULL columns with no Rust-side presence check
+- Dead columns from removed features still in the schema
+- Enum/status CHECK values that don't match Rust string literals
+
+Search: `service/migrations/*.sql`, `service/src/*/repo/`, `crates/*/src/repo/`.
+
+### 11. Middleware & Request Pipeline
+
+Look for:
+- Security headers missing on some routes (applied before merge instead of after)
+- No `DefaultBodyLimit` on unauthenticated endpoints
+- Unauthenticated mutation endpoints (missing `AuthenticatedDevice` extractor)
+- Rate limiting gaps (endpoints that should be limited but aren't)
+- Extension availability ordering issues
+
+Search: `service/src/main.rs`, `service/src/http/`, `service/src/*/http/mod.rs`.
+
+### 12. DRY Violations & Consolidation
+
+Look for:
+- Copy-pasted handler patterns (same extract→validate→call→map-error structure)
+- Duplicated error mapping across handlers (same repo error → same HTTP response in 3+ places)
+- Near-identical SQL queries differing by one clause
+- Duplicated validation logic in both service and HTTP layers
+- Frontend: duplicated query guard boilerplate, duplicated component logic
+
+Focus on findings where consolidation removes 10+ lines. Estimate lines removable per finding.
+
+Search: `service/src/`, `crates/`, `web/src/`.
+
+### 13. Concurrency & Race Conditions
+
+Look for:
+- Shared mutable state: `Arc<Mutex<>>`, `Arc<RwLock<>>` — locks held across `.await`?
+- Background worker idempotency: stuck `processing` rows, no requeue mechanism
+- `std::thread::sleep` or synchronous file I/O in async code
+- TOCTOU between concurrent handlers (double-vote, double-signup)
+- Connection pool exhaustion under concurrent load
+
+Search: `service/src/`, `crates/`.
+
+### 14. Resilience & Graceful Degradation
+
+Look for:
+- Missing timeouts on `reqwest::Client` calls (external HTTP hangs indefinitely)
+- No exponential backoff on worker retries
+- Background workers not joined on shutdown (fire-and-forget `tokio::spawn`)
+- No circuit breaker on DB pool exhaustion
+- Frontend: no request timeout via `AbortController`, no global "API unreachable" indicator
+
+Search: `service/src/main.rs`, `service/src/trust/worker.rs`, `web/src/api/fetchClient.ts`.
+
+### 15. Logging Hygiene
+
+Look for:
+- Sensitive data in logs: PII, tokens, secrets, connection strings
+- `#[derive(Debug)]` on config structs containing secrets
+- No request correlation middleware (can't link log lines to a request)
+- Freeform error messages vs structured key=value fields
+- Missing startup context (host, port, db name not logged)
+
+Search: `service/src/`, grep for `tracing::` calls.
+
+### 16. Frontend State Management
+
+Look for:
+- Mutations that don't invalidate affected query keys
+- Memory leaks: `setInterval`/`setTimeout` without cleanup, event listeners not removed
+- React key props using array index instead of stable ID
+- Stale closures in `useCallback`/`useMemo` with missing dependencies
+- No global handler for 401 responses (expired auth mid-session)
+
+Search: `web/src/`.
+
+### 17. Performance Anti-patterns
+
+Look for:
+- Unnecessary `.clone()` on hot paths (handlers, service calls)
+- Blocking in async: `std::thread::sleep`, `std::fs::*` without `spawn_blocking`
+- N+1 at frontend: list components where each item triggers own `useQuery`
+- Queries using `COUNT(*)` where `EXISTS` would suffice
+- Missing pagination on list endpoints
+
+Search: `service/src/`, `crates/`, `web/src/`.
+
+### 18. Test-Production Parity
+
+Look for:
+- Mock implementations that skip validation the real code enforces
+- Test config that disables features enabled in production (beyond rate limiting)
+- Frontend mock response shapes that don't match real API responses
+- Mock `Ok(())` defaults that mask error path regressions
+
+Search: `service/src/`, `service/tests/`, `web/src/`.
+
 ## Agent Dispatch Template
 
-Launch 7 sonnet subagents in parallel, one per category. Each agent prompt should include:
+For a full sweep, launch all 18 categories. For a targeted sweep, pick the categories most relevant to recent changes. Recommended groupings:
+
+- **Post-feature-burst**: 1–7 (core quality)
+- **Pre-release hardening**: 3, 8, 10, 11, 13, 14, 15 (security & resilience)
+- **De-slop / consolidation**: 5, 6, 9, 12, 16, 17 (cleanup & consistency)
+
+Launch sonnet subagents in parallel, one per category. Each agent prompt should include:
 
 1. The category checklist above
 2. "This is a research-only task — do NOT edit any files"


### PR DESCRIPTION
## Summary
Expands the codebase sweep skill with 11 new categories discovered during the comprehensive 2026-03-19 audit session. Also adds recommended groupings for targeted sweeps:

- **Post-feature-burst**: core quality (1–7)
- **Pre-release hardening**: security & resilience (3, 8, 10, 11, 13, 14, 15)
- **De-slop / consolidation**: cleanup & consistency (5, 6, 9, 12, 16, 17)

## Test plan
- [ ] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)