### PR TITLE
dx: add mock router and crypto providers for storybook

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -1,10 +1,17 @@
 import '@mantine/core/styles.css';
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router';
 import { DARK_MODE_EVENT_NAME } from '@vueless/storybook-dark-mode';
 import { addons } from 'storybook/preview-api';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
+import { CryptoContext, type CryptoModule } from '../src/providers/CryptoProvider';
 import { mantineTheme } from '../src/theme/mantineTheme';
 
 export const parameters = {
@@ -39,10 +46,45 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
 
+// Stub crypto module for components that call useCrypto/useCryptoRequired.
+// WASM is not available in Storybook (no Rust toolchain in CI).
+const stubCrypto: CryptoModule = {
+  derive_kid: () => 'AAAAAAAAAAAAAAAAAAAAAA',
+  encode_base64url: () => '',
+  decode_base64url: () => new Uint8Array(),
+};
+
+// Wrapper that provides TanStack Router context so Link/useNavigate don't throw.
+// Creates a single-route router whose root component renders children via a ref
+// so it always shows the latest story content without recreating the router.
+function StorybookRouter({ children }: { children: React.ReactNode }) {
+  const childrenRef = useRef<React.ReactNode>(children);
+  childrenRef.current = children;
+
+  const [router] = useState(() => {
+    const root = createRootRouteWithContext<{ auth: { deviceKid: string | null } }>()({
+      component: () => <>{childrenRef.current}</>,
+    });
+    return createRouter({
+      routeTree: root,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      context: { auth: { deviceKid: null } },
+    });
+  });
+
+  return <RouterProvider router={router} />;
+}
+
 export const decorators = [
   (renderStory: any) => <ColorSchemeWrapper>{renderStory()}</ColorSchemeWrapper>,
   (renderStory: any) => <MantineProvider theme={mantineTheme}>{renderStory()}</MantineProvider>,
   (renderStory: any) => (
     <QueryClientProvider client={queryClient}>{renderStory()}</QueryClientProvider>
   ),
+  (renderStory: any) => (
+    <CryptoContext.Provider value={{ crypto: stubCrypto, isLoading: false, error: null }}>
+      {renderStory()}
+    </CryptoContext.Provider>
+  ),
+  (renderStory: any) => <StorybookRouter>{renderStory()}</StorybookRouter>,
 ];

--- a/web/src/providers/CryptoProvider.tsx
+++ b/web/src/providers/CryptoProvider.tsx
@@ -22,7 +22,7 @@ interface CryptoContextValue {
   error: Error | null;
 }
 
-const CryptoContext = createContext<CryptoContextValue>({
+export const CryptoContext = createContext<CryptoContextValue>({
   crypto: null,
   isLoading: true,
   error: null,


### PR DESCRIPTION
## Summary

- Export `CryptoContext` from `CryptoProvider.tsx` so decorators can provide stub values directly
- Add `StorybookRouter` wrapper component using `createMemoryHistory` + `createRootRouteWithContext` — components using `Link`, `useNavigate`, `useRouterState` render without crashing
- Add `CryptoContext.Provider` decorator with stub WASM functions (`derive_kid`, `encode_base64url`, `decode_base64url`) — components using `useCrypto`/`useCryptoRequired` render without real WASM

No new dependencies. Storybook build verified locally.

Closes #849

## Test plan

- [x] `just lint-frontend` passes
- [x] `just lint-typecheck` passes  
- [x] `npx storybook build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)