### PR TITLE
refine: single source of truth for denouncement reason max length

### DIFF
--- a/service/src/trust/http/mod.rs
+++ b/service/src/trust/http/mod.rs
@@ -15,7 +15,8 @@ use uuid::Uuid;
 
 use super::repo::{TrustRepo, TrustRepoError};
 use super::service::{
-    TrustService, TrustServiceError, DENOUNCEMENT_SLOT_LIMIT, ENDORSEMENT_SLOT_LIMIT,
+    TrustService, TrustServiceError, DENOUNCEMENT_REASON_MAX_LEN, DENOUNCEMENT_SLOT_LIMIT,
+    ENDORSEMENT_SLOT_LIMIT,
 };
 use super::weight::compute_endorsement_weight;
 use crate::http::{bad_request, conflict, internal_error, not_found, too_many_requests};
@@ -209,7 +210,7 @@ async fn denounce_handler(
         Err(e) => return e,
     };
 
-    if body.reason.is_empty() || body.reason.len() > 500 {
+    if body.reason.is_empty() || body.reason.len() > DENOUNCEMENT_REASON_MAX_LEN {
         return bad_request("reason must be between 1 and 500 characters");
     }
 

--- a/service/src/trust/service.rs
+++ b/service/src/trust/service.rs
@@ -15,6 +15,8 @@ pub const ENDORSEMENT_SLOT_LIMIT: u32 = 3;
 pub const DENOUNCEMENT_SLOT_LIMIT: u32 = 2;
 /// Max trust actions per user per day (resets at midnight UTC).
 pub const DAILY_ACTION_QUOTA: i64 = 5;
+/// Maximum byte length of a denouncement reason (matches migration CHECK constraint).
+pub const DENOUNCEMENT_REASON_MAX_LEN: usize = 500;
 
 /// Errors returned by [`TrustService`] operations.
 #[derive(Debug, thiserror::Error)]

--- a/service/src/trust/worker.rs
+++ b/service/src/trust/worker.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use crate::reputation::repo::ReputationRepo;
 use crate::trust::engine::TrustEngine;
 use crate::trust::repo::{ActionRecord, TrustRepo};
+use crate::trust::service::DENOUNCEMENT_REASON_MAX_LEN;
 
 /// Background worker that claims and processes trust action queue batches.
 pub struct TrustWorker {
@@ -143,9 +144,10 @@ impl TrustWorker {
                     .as_str()
                     .ok_or_else(|| anyhow::anyhow!("denounce payload missing 'reason'"))?
                     .to_string();
-                if reason.is_empty() || reason.len() > 500 {
+                if reason.is_empty() || reason.len() > DENOUNCEMENT_REASON_MAX_LEN {
                     return Err(anyhow::anyhow!(
-                        "denounce payload 'reason' length out of range [1, 500]: {}",
+                        "denounce payload 'reason' length out of range [1, {}]: {}",
+                        DENOUNCEMENT_REASON_MAX_LEN,
                         reason.len()
                     ));
                 }


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

Extracted DENOUNCEMENT_REASON_MAX_LEN=500 to a single constant in service.rs, replacing the magic number duplicated independently in http/mod.rs and worker.rs

---
*Generated by [refine.sh](scripts/refine.sh)*