### PR TITLE
refine: reject NaN/Inf weight in trust worker, matching HTTP handler validation

### DIFF
--- a/service/src/trust/worker.rs
+++ b/service/src/trust/worker.rs
@@ -94,7 +94,7 @@ impl TrustWorker {
                     .as_f64()
                     .ok_or_else(|| anyhow::anyhow!("endorse payload missing 'weight'"))?
                     as f32;
-                if weight <= 0.0 || weight > 1.0 {
+                if !weight.is_finite() || weight <= 0.0 || weight > 1.0 {
                     return Err(anyhow::anyhow!(
                         "endorse payload 'weight' out of range (0.0, 1.0]: {weight}"
                     ));


### PR DESCRIPTION
Automated refinement of `service/src/trust/`

refine: reject NaN/Inf weight in trust worker, matching HTTP handler validation

---
*Generated by [refine.sh](scripts/refine.sh)*