### PR TITLE
fix: replace SELECT * with explicit columns in score snapshot queries (#862)

### DIFF
--- a/service/src/trust/repo/scores.rs
+++ b/service/src/trust/repo/scores.rs
@@ -57,7 +57,9 @@ pub(super) async fn get_score(
     context_user_id: Option<Uuid>,
 ) -> Result<Option<ScoreSnapshot>, TrustRepoError> {
     let record = sqlx::query_as::<_, ScoreSnapshot>(
-        "SELECT * FROM trust__score_snapshots \
+        "SELECT user_id, context_user_id, trust_distance, path_diversity, \
+         eigenvector_centrality, computed_at \
+         FROM trust__score_snapshots \
          WHERE user_id = $1 AND context_user_id IS NOT DISTINCT FROM $2",
     )
     .bind(user_id)
@@ -73,7 +75,9 @@ pub(super) async fn get_all_scores(
     user_id: Uuid,
 ) -> Result<Vec<ScoreSnapshot>, TrustRepoError> {
     let records = sqlx::query_as::<_, ScoreSnapshot>(
-        "SELECT * FROM trust__score_snapshots \
+        "SELECT user_id, context_user_id, trust_distance, path_diversity, \
+         eigenvector_centrality, computed_at \
+         FROM trust__score_snapshots \
          WHERE user_id = $1 \
          ORDER BY computed_at DESC",
     )


### PR DESCRIPTION
## Context

`trust__score_snapshots` has an `id UUID PRIMARY KEY` column. The `ScoreSnapshot` Rust struct in `service/src/trust/repo/mod.rs` does not include `id` (by design — it's a surrogate key unused by the application). Both `SELECT *` queries in `service/src/trust/repo/scores.rs` caused sqlx to fail at runtime trying to map the `id` column onto a struct that has no such field.

Closes #862

## Changes made

- `service/src/trust/repo/scores.rs` — replaced `SELECT *` with explicit column list `(user_id, context_user_id, trust_distance, path_diversity, eigenvector_centrality, computed_at)` in both `get_score` and `get_all_scores`. No struct changes, no migration needed.

Zero callers outside this file were affected — both functions are `pub(super)`, called only from `PgTrustRepo` in `mod.rs`.

## Risks & Caveats

N/A — change is additive/narrowing only; column list matches the struct exactly.

## Screenshots

N/A — backend-only change.

## Testing

- [x] `cargo check -p tinycongress-api` passes
- [x] `just lint` (clippy + fmt) passes via pre-commit hook
- [ ] `just test` (backend + frontend unit)
- [ ] E2E (CI)

## Plan Graduation

N/A

## Linked Issue
- Closes #862

## AI tooling used

Claude Code (claude-sonnet-4-6) via CLI