### PR TITLE
fix: add browser capability pre-flight and surface signup errors (#893)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import '@mantine/notifications/styles.css';
 
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import { BrowserCapabilityGate } from './components/BrowserCapabilityGate';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { CryptoProvider } from './providers/CryptoProvider';
 import { DeviceProvider } from './providers/DeviceProvider';
@@ -15,13 +16,15 @@ export default function App() {
     <ErrorBoundary context="Application">
       <MantineProvider theme={mantineTheme} defaultColorScheme="dark">
         <Notifications />
-        <CryptoProvider>
-          <DeviceProvider>
-            <QueryProvider>
-              <Router />
-            </QueryProvider>
-          </DeviceProvider>
-        </CryptoProvider>
+        <BrowserCapabilityGate>
+          <CryptoProvider>
+            <DeviceProvider>
+              <QueryProvider>
+                <Router />
+              </QueryProvider>
+            </DeviceProvider>
+          </CryptoProvider>
+        </BrowserCapabilityGate>
       </MantineProvider>
     </ErrorBoundary>
   );

--- a/web/src/components/BrowserCapabilityGate.tsx
+++ b/web/src/components/BrowserCapabilityGate.tsx
@@ -1,0 +1,75 @@
+/**
+ * BrowserCapabilityGate - Probes for Ed25519 Web Crypto support on mount.
+ * If the browser does not support Ed25519 key generation, renders a friendly
+ * "unsupported browser" message instead of children.
+ */
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { Alert, Center, List, Loader, Stack, Text } from '@mantine/core';
+
+interface BrowserCapabilityGateProps {
+  children: ReactNode;
+}
+
+type CapabilityState = 'checking' | 'supported' | 'unsupported';
+
+const BROWSER_REQUIREMENTS = ['Chrome 113+', 'Firefox 130+', 'Safari 17+', 'Edge 113+'];
+
+export function BrowserCapabilityGate({ children }: BrowserCapabilityGateProps) {
+  const [state, setState] = useState<CapabilityState>('checking');
+
+  useEffect(() => {
+    async function checkCapabilities() {
+      try {
+        await crypto.subtle.generateKey('Ed25519', false, ['sign']);
+        setState('supported');
+      } catch {
+        setState('unsupported');
+      }
+    }
+
+    void checkCapabilities();
+  }, []);
+
+  if (state === 'checking') {
+    return (
+      <Center h="100vh">
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  if (state === 'unsupported') {
+    return (
+      <Center h="100vh" p="xl">
+        <Stack maw={500} gap="md">
+          <Alert
+            icon={<IconAlertTriangle size={20} />}
+            title="Browser not supported"
+            color="red"
+            variant="filled"
+          >
+            Your browser does not support the cryptographic features TinyCongress requires. Please
+            upgrade to a supported browser.
+          </Alert>
+          <Text size="sm">
+            TinyCongress uses Ed25519 public-key cryptography to generate and manage your identity
+            keys directly in your browser. This requires a modern browser with Web Crypto API
+            support.
+          </Text>
+          <Text size="sm" fw={600}>
+            Minimum supported versions:
+          </Text>
+          <List size="sm" withPadding>
+            {BROWSER_REQUIREMENTS.map((req) => (
+              <List.Item key={req}>{req}</List.Item>
+            ))}
+          </List>
+        </Stack>
+      </Center>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/pages/Signup.page.tsx
+++ b/web/src/pages/Signup.page.tsx
@@ -26,6 +26,7 @@ export function SignupPage() {
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [isGeneratingKeys, setIsGeneratingKeys] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
   const [createdAccount, setCreatedAccount] = useState<{
     account_id: string;
     root_kid: string;
@@ -34,6 +35,7 @@ export function SignupPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setLocalError(null);
 
     if (!username.trim() || !password || password !== passwordConfirm) {
       return;
@@ -74,8 +76,8 @@ export function SignupPage() {
       setDevice(response.device_kid, deviceKeyPair.privateKey, username.trim());
 
       setCreatedAccount(response);
-    } catch {
-      // Error is handled by TanStack Query mutation state
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'An unexpected error occurred');
     } finally {
       setIsGeneratingKeys(false);
     }
@@ -94,7 +96,7 @@ export function SignupPage() {
       }}
       isLoading={signup.isPending || isGeneratingKeys}
       loadingText={isGeneratingKeys ? 'Generating keys and encrypting backup...' : undefined}
-      error={signup.isError ? signup.error.message : null}
+      error={localError ?? (signup.isError ? signup.error.message : null)}
       successData={createdAccount}
       verifierUrl={buildVerifierUrl(username)}
     />

--- a/web/src/providers/CryptoProvider.tsx
+++ b/web/src/providers/CryptoProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { Center, Loader } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { Alert, Center, List, Loader, Stack, Text } from '@mantine/core';
 
 /**
  * Interface for the crypto module functions exposed by WASM
@@ -95,8 +96,34 @@ export function CryptoProvider({ children }: CryptoProviderProps) {
   }
 
   if (state.error) {
-    // Let ErrorBoundary handle it or show inline error
-    throw state.error;
+    return (
+      <Center h="100vh" p="xl">
+        <Stack maw={500} gap="md">
+          <Alert
+            icon={<IconAlertTriangle size={20} />}
+            title="Browser not supported"
+            color="red"
+            variant="filled"
+          >
+            Failed to load the cryptography module. Your browser may not support the features
+            TinyCongress requires.
+          </Alert>
+          <Text size="sm">
+            TinyCongress uses Ed25519 public-key cryptography compiled to WebAssembly. Please
+            upgrade to a supported browser.
+          </Text>
+          <Text size="sm" fw={600}>
+            Minimum supported versions:
+          </Text>
+          <List size="sm" withPadding>
+            <List.Item>Chrome 113+</List.Item>
+            <List.Item>Firefox 130+</List.Item>
+            <List.Item>Safari 17+</List.Item>
+            <List.Item>Edge 113+</List.Item>
+          </List>
+        </Stack>
+      </Center>
+    );
   }
 
   return <CryptoContext.Provider value={state}>{children}</CryptoContext.Provider>;


### PR DESCRIPTION
## Context

Fixes #893. Three compounding failures caused signup to silently fail on unsupported browsers:

1. The `SignupPage` catch block was silent — Ed25519 key generation and envelope building errors happen *before* `mutateAsync()`, so TanStack Query never saw them and no error was displayed.
2. No pre-flight check: browsers without Ed25519 Web Crypto support hit opaque WASM errors with no guidance.
3. WASM load failures in `CryptoProvider` re-threw to the generic `ErrorBoundary`, which shows nothing useful.

## Changes made

**Part 1 — Surface signup errors (`Signup.page.tsx`)**
- Added `localError` state (same pattern as `Login.page.tsx`).
- `handleSubmit` clears `localError` at the start, then sets it in the catch block for any pre-mutation error.
- `error` prop now uses `localError ?? (signup.isError ? signup.error.message : null)`.

**Part 2 — Browser capability gate (`BrowserCapabilityGate.tsx`)**
- New component that probes `crypto.subtle.generateKey('Ed25519', false, ['sign'])` on mount.
- Shows a loading spinner while checking, a friendly "unsupported browser" page with minimum versions (Chrome 113+, Firefox 130+, Safari 17+, Edge 113+) if unsupported, or renders children normally if supported.
- Mounted in `App.tsx` wrapping `CryptoProvider` — inside `MantineProvider`, outside `CryptoProvider`.

**Part 3 — Friendly WASM fallback (`CryptoProvider.tsx`)**
- Instead of `throw state.error` (which goes to the generic `ErrorBoundary`), renders a targeted "browser not supported" inline message with the same version requirements.

## Risks & Caveats

- `BrowserCapabilityGate` adds one async round-trip before the app renders. The probe is fast (sub-millisecond on supported browsers) and the spinner is already shown during WASM load, so perceived latency is unchanged for supported browsers.
- Both the gate and the CryptoProvider fallback show the same browser requirements. This is intentional: the gate fires before WASM loads (covers `crypto.subtle` absence), while the CryptoProvider fallback covers WASM load failures specifically (network error, corrupted binary, etc.).

## Screenshots

<!-- Screenshots will be added via Playwright MCP before review. The changed components (BrowserCapabilityGate unsupported message, CryptoProvider error message, SignupPage error display) are only visible in specific error states that require a controlled environment to capture. -->

## Testing
- [x] `yarn tsc --noEmit` — no type errors
- [x] `yarn vitest --run` — 132 tests pass; 4 pre-existing WASM fixture failures (same as master)
- [x] ESLint + Prettier clean on all changed files
- [ ] E2E (CI)
- [ ] Manual verification on a browser with Ed25519 disabled (pending)

## Plan Graduation

N/A — no `.plan/` files on this branch.

## Linked Issue
- Closes #893

## AI tooling used
Claude Sonnet 4.6 (Claude Code)