### PR TITLE
feat: add meme ranking engine (tc-engine-ranking)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ crates/tc-crypto/pkg/
 
 # Skaffold build output
 artifacts.json
+
+# Local file upload storage (development only)
+uploads/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +2326,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,6 +3704,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "chrono-tz",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,6 +3663,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tc-engine-ranking"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "chrono",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tc-engine-api",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tc-llm"
 version = "0.1.0"
 dependencies = [
@@ -3838,6 +3857,7 @@ dependencies = [
  "tc-crypto",
  "tc-engine-api",
  "tc-engine-polling",
+ "tc-engine-ranking",
  "tc-llm",
  "tc-test-macros",
  "testcontainers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 # Keep members on single line - web/Dockerfile sed pattern depends on this format
-members = ["service", "crates/tc-crypto", "crates/tc-engine-api", "crates/tc-engine-polling", "crates/tc-llm", "crates/test-macros"]
+members = ["service", "crates/tc-crypto", "crates/tc-engine-api", "crates/tc-engine-polling", "crates/tc-engine-ranking", "crates/tc-llm", "crates/test-macros"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/tc-engine-ranking/Cargo.toml
+++ b/crates/tc-engine-ranking/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "derive"] }

--- a/crates/tc-engine-ranking/Cargo.toml
+++ b/crates/tc-engine-ranking/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tc-engine-ranking"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "Ranking engine implementation for TinyCongress rooms"
+
+[dependencies]
+tc-engine-api = { path = "../tc-engine-api", version = "0.1.0" }
+anyhow = "1.0"
+async-trait = "0.1"
+axum = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "derive"] }
+thiserror = "2"
+tokio = { version = "1", features = ["rt", "time"] }
+tracing = "0.1"
+uuid = { version = "1.16", features = ["v4", "serde"] }
+rand = "0.8"
+
+[lints]
+workspace = true

--- a/crates/tc-engine-ranking/src/config.rs
+++ b/crates/tc-engine-ranking/src/config.rs
@@ -1,0 +1,156 @@
+//! Engine configuration for ranking rooms.
+
+use chrono::{NaiveTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ─── Defaults ───────────────────────────────────────────────────────────────
+
+const fn default_submit_duration() -> i64 {
+    86400
+}
+
+const fn default_rank_duration() -> i64 {
+    86400
+}
+
+const fn default_hall_of_fame_depth() -> i32 {
+    3
+}
+
+// ─── Config struct ──────────────────────────────────────────────────────────
+
+/// Engine configuration stored in `rooms__rooms.engine_config` for ranking rooms.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RankingConfig {
+    /// Daily anchor time in `HH:MM:SS` format.
+    pub anchor_time: String,
+    /// IANA timezone string (e.g. `"America/New_York"`).
+    pub anchor_timezone: String,
+    /// How long the submission phase lasts in seconds. Defaults to 86400 (1 day).
+    #[serde(default = "default_submit_duration")]
+    pub submit_duration_secs: i64,
+    /// How long the ranking phase lasts in seconds. Defaults to 86400 (1 day).
+    #[serde(default = "default_rank_duration")]
+    pub rank_duration_secs: i64,
+    /// Number of top submissions to promote to the hall of fame each round.
+    /// Defaults to 3.
+    #[serde(default = "default_hall_of_fame_depth")]
+    pub hall_of_fame_depth: i32,
+}
+
+impl RankingConfig {
+    /// Compute the number of seconds until the next occurrence of `anchor_time`
+    /// in `anchor_timezone`.
+    ///
+    /// If `anchor_time` is in the future today (in the configured timezone),
+    /// returns the delta to that time. If it has already passed, returns the
+    /// delta to the same time tomorrow.
+    ///
+    /// Returns 0 if the timezone or time cannot be parsed (callers validate
+    /// these before calling this method).
+    #[must_use]
+    pub fn seconds_until_next_anchor(&self) -> i64 {
+        use chrono::TimeZone as _;
+
+        let Ok(anchor) = NaiveTime::parse_from_str(&self.anchor_time, "%H:%M:%S") else {
+            return 0;
+        };
+
+        let Ok(tz) = self.anchor_timezone.parse::<chrono_tz::Tz>() else {
+            return 0;
+        };
+
+        let now_utc = Utc::now();
+        let now_local = now_utc.with_timezone(&tz);
+        let today = now_local.date_naive();
+
+        // Build candidate datetime for anchor_time today
+        let candidate_naive = today.and_time(anchor);
+        let candidate = match tz.from_local_datetime(&candidate_naive) {
+            chrono::LocalResult::Single(dt) => dt,
+            chrono::LocalResult::Ambiguous(earliest, _) => earliest,
+            chrono::LocalResult::None => {
+                // Clocks skipped this time (DST gap); advance by 1 hour
+                let adjusted = candidate_naive + chrono::Duration::hours(1);
+                match tz.from_local_datetime(&adjusted) {
+                    chrono::LocalResult::Single(dt) => dt,
+                    chrono::LocalResult::Ambiguous(earliest, _) => earliest,
+                    chrono::LocalResult::None => return 0,
+                }
+            }
+        };
+
+        let delta = candidate.with_timezone(&Utc) - now_utc;
+        if delta.num_seconds() > 0 {
+            delta.num_seconds()
+        } else {
+            // Anchor has already passed today; compute delta to tomorrow
+            let tomorrow = today + chrono::Duration::days(1);
+            let tomorrow_naive = tomorrow.and_time(anchor);
+            let tomorrow_candidate = match tz.from_local_datetime(&tomorrow_naive) {
+                chrono::LocalResult::Single(dt) => dt,
+                chrono::LocalResult::Ambiguous(earliest, _) => earliest,
+                chrono::LocalResult::None => return 86400,
+            };
+            let delta2 = tomorrow_candidate.with_timezone(&Utc) - now_utc;
+            delta2.num_seconds().max(0)
+        }
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config(anchor_time: &str, anchor_timezone: &str) -> RankingConfig {
+        RankingConfig {
+            anchor_time: anchor_time.to_string(),
+            anchor_timezone: anchor_timezone.to_string(),
+            submit_duration_secs: default_submit_duration(),
+            rank_duration_secs: default_rank_duration(),
+            hall_of_fame_depth: default_hall_of_fame_depth(),
+        }
+    }
+
+    #[test]
+    fn seconds_until_anchor_is_positive() {
+        // Any valid config should return a non-negative delay.
+        let cfg = make_config("12:00:00", "UTC");
+        let secs = cfg.seconds_until_next_anchor();
+        assert!(secs >= 0, "delay must not be negative");
+    }
+
+    #[test]
+    fn seconds_until_anchor_is_at_most_one_day() {
+        let cfg = make_config("00:00:00", "UTC");
+        let secs = cfg.seconds_until_next_anchor();
+        // Should be at most 86400 seconds (one full day)
+        assert!(secs <= 86400, "delay should be at most one day, got {secs}");
+    }
+
+    #[test]
+    fn bad_timezone_returns_zero() {
+        let cfg = make_config("12:00:00", "Not/A/Timezone");
+        assert_eq!(cfg.seconds_until_next_anchor(), 0);
+    }
+
+    #[test]
+    fn bad_time_returns_zero() {
+        let cfg = make_config("25:00:00", "UTC");
+        assert_eq!(cfg.seconds_until_next_anchor(), 0);
+    }
+
+    #[test]
+    fn defaults_applied_on_partial_deserialize() {
+        let v = serde_json::json!({
+            "anchor_time": "12:00:00",
+            "anchor_timezone": "UTC"
+        });
+        let cfg: RankingConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(cfg.submit_duration_secs, 86400);
+        assert_eq!(cfg.rank_duration_secs, 86400);
+        assert_eq!(cfg.hall_of_fame_depth, 3);
+    }
+}

--- a/crates/tc-engine-ranking/src/engine.rs
+++ b/crates/tc-engine-ranking/src/engine.rs
@@ -1,9 +1,22 @@
 //! Ranking engine — implements [`tc_engine_api::RoomEngine`] for ranking-type rooms.
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::NaiveTime;
 use tc_engine_api::engine::{EngineContext, EngineMetadata, PlatformState};
 use tc_engine_api::error::EngineError;
 use tc_engine_api::RoomEngine;
 use uuid::Uuid;
+
+use crate::config::RankingConfig;
+use crate::lifecycle::{
+    enqueue_ranking_event, spawn_ranking_lifecycle_consumer, RankingLifecyclePayload,
+};
+use crate::service::DefaultRankingService;
+
+/// Default lifecycle consumer poll interval (seconds).
+const LIFECYCLE_POLL_INTERVAL_SECS: u64 = 5;
 
 /// Ranking engine plugin.
 ///
@@ -46,26 +59,187 @@ impl RoomEngine for RankingEngine {
         serde_json::json!({})
     }
 
-    fn validate_config(&self, _config: &serde_json::Value) -> Result<(), EngineError> {
-        // Will be implemented in Task 9.
+    fn validate_config(&self, config: &serde_json::Value) -> Result<(), EngineError> {
+        let config: RankingConfig = serde_json::from_value(config.clone())
+            .map_err(|e| EngineError::InvalidInput(format!("invalid ranking config: {e}")))?;
+
+        // Validate anchor_time parses as HH:MM:SS
+        NaiveTime::parse_from_str(&config.anchor_time, "%H:%M:%S")
+            .map_err(|_| EngineError::InvalidInput("anchor_time must be HH:MM:SS".into()))?;
+
+        // Validate timezone is a valid IANA string
+        config
+            .anchor_timezone
+            .parse::<chrono_tz::Tz>()
+            .map_err(|_| EngineError::InvalidInput("invalid timezone".into()))?;
+
+        // Validate durations are at least 1 hour
+        if config.submit_duration_secs < 3600 {
+            return Err(EngineError::InvalidInput(
+                "submit_duration_secs must be >= 3600 (1 hour)".into(),
+            ));
+        }
+        if config.rank_duration_secs < 3600 {
+            return Err(EngineError::InvalidInput(
+                "rank_duration_secs must be >= 3600 (1 hour)".into(),
+            ));
+        }
+
+        // Validate hall_of_fame_depth is in 1–10
+        if config.hall_of_fame_depth < 1 || config.hall_of_fame_depth > 10 {
+            return Err(EngineError::InvalidInput(
+                "hall_of_fame_depth must be between 1 and 10".into(),
+            ));
+        }
+
         Ok(())
     }
 
     async fn on_room_created(
         &self,
-        _room_id: Uuid,
-        _config: &serde_json::Value,
-        _ctx: &EngineContext,
+        room_id: Uuid,
+        config: &serde_json::Value,
+        ctx: &EngineContext,
     ) -> Result<(), EngineError> {
-        // Will be implemented in a later task.
+        let config: RankingConfig = serde_json::from_value(config.clone())
+            .map_err(|e| EngineError::InvalidInput(format!("invalid ranking config: {e}")))?;
+
+        // Calculate delay until the next configured anchor time.
+        let delay_secs = config.seconds_until_next_anchor();
+
+        enqueue_ranking_event(
+            &ctx.pool,
+            RankingLifecyclePayload::OpenSubmit { room_id },
+            delay_secs,
+        )
+        .await
+        .map_err(|e| EngineError::Internal(e.into()))?;
+
+        tracing::info!(
+            room_id = %room_id,
+            delay_secs,
+            "ranking room created; OpenSubmit enqueued"
+        );
+
         Ok(())
     }
 
-    fn start(
-        &self,
-        _ctx: EngineContext,
-    ) -> Result<Vec<tokio::task::JoinHandle<()>>, anyhow::Error> {
-        // Background tasks will be added in a later task.
-        Ok(vec![])
+    fn start(&self, ctx: EngineContext) -> Result<Vec<tokio::task::JoinHandle<()>>, anyhow::Error> {
+        let ranking_service = Arc::new(DefaultRankingService::new(ctx.pool.clone()));
+
+        let handle = spawn_ranking_lifecycle_consumer(
+            ctx.pool.clone(),
+            ranking_service,
+            ctx.room_lifecycle.clone(),
+            Duration::from_secs(LIFECYCLE_POLL_INTERVAL_SECS),
+        );
+
+        Ok(vec![handle])
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_config() {
+        let engine = RankingEngine;
+        let config = serde_json::json!({
+            "anchor_time": "18:00:00",
+            "anchor_timezone": "America/New_York",
+            "submit_duration_secs": 86400,
+            "rank_duration_secs": 86400,
+            "hall_of_fame_depth": 3
+        });
+        assert!(engine.validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_defaults_applied() {
+        let engine = RankingEngine;
+        let config = serde_json::json!({
+            "anchor_time": "12:00:00",
+            "anchor_timezone": "UTC"
+        });
+        assert!(engine.validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_bad_timezone() {
+        let engine = RankingEngine;
+        let config = serde_json::json!({
+            "anchor_time": "18:00:00",
+            "anchor_timezone": "Not/A/Timezone"
+        });
+        let err = engine.validate_config(&config).unwrap_err();
+        assert!(matches!(err, EngineError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_bad_time_format() {
+        let engine = RankingEngine;
+        let config = serde_json::json!({
+            "anchor_time": "25:00:00",
+            "anchor_timezone": "UTC"
+        });
+        let err = engine.validate_config(&config).unwrap_err();
+        assert!(matches!(err, EngineError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_duration_too_short() {
+        let engine = RankingEngine;
+        let config = serde_json::json!({
+            "anchor_time": "18:00:00",
+            "anchor_timezone": "UTC",
+            "submit_duration_secs": 60
+        });
+        let err = engine.validate_config(&config).unwrap_err();
+        assert!(matches!(err, EngineError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_rank_duration_too_short() {
+        let engine = RankingEngine;
+        let config = serde_json::json!({
+            "anchor_time": "18:00:00",
+            "anchor_timezone": "UTC",
+            "submit_duration_secs": 86400,
+            "rank_duration_secs": 1800
+        });
+        let err = engine.validate_config(&config).unwrap_err();
+        assert!(matches!(err, EngineError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_hall_of_fame_depth_out_of_range() {
+        let engine = RankingEngine;
+
+        let too_low = serde_json::json!({
+            "anchor_time": "18:00:00",
+            "anchor_timezone": "UTC",
+            "hall_of_fame_depth": 0
+        });
+        assert!(engine.validate_config(&too_low).is_err());
+
+        let too_high = serde_json::json!({
+            "anchor_time": "18:00:00",
+            "anchor_timezone": "UTC",
+            "hall_of_fame_depth": 11
+        });
+        assert!(engine.validate_config(&too_high).is_err());
+    }
+
+    #[test]
+    fn test_missing_required_fields() {
+        let engine = RankingEngine;
+        // anchor_time is required
+        let config = serde_json::json!({
+            "anchor_timezone": "UTC"
+        });
+        assert!(engine.validate_config(&config).is_err());
     }
 }

--- a/crates/tc-engine-ranking/src/engine.rs
+++ b/crates/tc-engine-ranking/src/engine.rs
@@ -1,0 +1,71 @@
+//! Ranking engine — implements [`tc_engine_api::RoomEngine`] for ranking-type rooms.
+
+use tc_engine_api::engine::{EngineContext, EngineMetadata, PlatformState};
+use tc_engine_api::error::EngineError;
+use tc_engine_api::RoomEngine;
+use uuid::Uuid;
+
+/// Ranking engine plugin.
+///
+/// Owns the pair-selection scheduler and Glicko-2 rating logic.
+/// Registered in the [`tc_engine_api::EngineRegistry`] at startup.
+pub struct RankingEngine;
+
+impl RankingEngine {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RankingEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl RoomEngine for RankingEngine {
+    fn engine_type(&self) -> &'static str {
+        "ranking"
+    }
+
+    fn metadata(&self) -> EngineMetadata {
+        EngineMetadata {
+            display_name: "Ranking".to_string(),
+            description: "Pairwise ranking with Glicko-2 ratings and hall of fame".to_string(),
+        }
+    }
+
+    fn routes(&self) -> axum::Router<PlatformState> {
+        // HTTP handlers will live in the service crate initially.
+        axum::Router::new()
+    }
+
+    fn config_schema(&self) -> serde_json::Value {
+        serde_json::json!({})
+    }
+
+    fn validate_config(&self, _config: &serde_json::Value) -> Result<(), EngineError> {
+        // Will be implemented in Task 9.
+        Ok(())
+    }
+
+    async fn on_room_created(
+        &self,
+        _room_id: Uuid,
+        _config: &serde_json::Value,
+        _ctx: &EngineContext,
+    ) -> Result<(), EngineError> {
+        // Will be implemented in a later task.
+        Ok(())
+    }
+
+    fn start(
+        &self,
+        _ctx: EngineContext,
+    ) -> Result<Vec<tokio::task::JoinHandle<()>>, anyhow::Error> {
+        // Background tasks will be added in a later task.
+        Ok(vec![])
+    }
+}

--- a/crates/tc-engine-ranking/src/glicko2.rs
+++ b/crates/tc-engine-ranking/src/glicko2.rs
@@ -1,0 +1,1 @@
+// Glicko-2 rating algorithm — to be implemented in Task 5.

--- a/crates/tc-engine-ranking/src/glicko2.rs
+++ b/crates/tc-engine-ranking/src/glicko2.rs
@@ -1,1 +1,260 @@
-// Glicko-2 rating algorithm — to be implemented in Task 5.
+/// Glicko-2 rating system (Mark Glickman, 2012).
+///
+/// Reference: <http://www.glicko.net/glicko/glicko2.pdf>
+use std::f64::consts::PI;
+
+/// System constant — controls how quickly volatility can change.
+const TAU: f64 = 0.5;
+
+/// Convergence tolerance for the Illinois root-finding iteration.
+const CONVERGENCE_TOLERANCE: f64 = 0.000_001;
+
+/// Scale factor for converting between Glicko-1 and Glicko-2 scales.
+/// = 400 / ln(10)
+const SCALE: f64 = 173.7178;
+
+/// A player's rating state.
+#[derive(Debug, Clone)]
+pub struct Rating {
+    /// Glicko-1 scale, default 1500.0
+    pub rating: f64,
+    /// Glicko-1 scale, default 350.0
+    pub deviation: f64,
+    /// Default 0.06
+    pub volatility: f64,
+}
+
+impl Default for Rating {
+    fn default() -> Self {
+        Self {
+            rating: 1500.0,
+            deviation: 350.0,
+            volatility: 0.06,
+        }
+    }
+}
+
+/// g(phi) reduction factor — reduces impact of uncertain opponents.
+fn g(phi: f64) -> f64 {
+    1.0 / (1.0 + 3.0 * phi * phi / (PI * PI)).sqrt()
+}
+
+/// Expected score `E(mu, mu_j, phi_j)`.
+fn expected_score(mu: f64, mu_j: f64, phi_j: f64) -> f64 {
+    1.0 / (1.0 + (-g(phi_j) * (mu - mu_j)).exp())
+}
+
+/// Compute new volatility using the Illinois variant of the Regula Falsi method.
+#[allow(clippy::suboptimal_flops, clippy::while_float)]
+fn new_volatility(phi: f64, sigma: f64, delta: f64, v: f64) -> f64 {
+    let a = sigma.powi(2).ln();
+    let tau2 = TAU * TAU;
+    let delta2 = delta * delta;
+    let phi2 = phi * phi;
+
+    // f(x) as defined in Glickman's paper
+    let f = |x: f64| -> f64 {
+        let ex = x.exp();
+        let denom = phi2 + v + ex;
+        (ex * (delta2 - phi2 - v - ex)) / (2.0 * denom * denom) - (x - a) / tau2
+    };
+
+    // Choose initial bracket [A, B] per Glickman step 5.2
+    let mut big_a = a;
+    let mut big_b = if delta2 > phi2 + v {
+        (delta2 - phi2 - v).ln()
+    } else {
+        // Find k such that f(a - k*tau) < 0
+        let mut k = 1.0_f64;
+        while f(a - k * TAU) < 0.0 {
+            k += 1.0;
+        }
+        a - k * TAU
+    };
+
+    let mut f_a = f(big_a);
+    let mut f_b = f(big_b);
+
+    // Illinois iteration
+    while (big_b - big_a).abs() > CONVERGENCE_TOLERANCE {
+        let big_c = big_a + (big_a - big_b) * f_a / (f_b - f_a);
+        let f_c = f(big_c);
+
+        if f_c * f_b <= 0.0 {
+            big_a = big_b;
+            f_a = f_b;
+        } else {
+            // Illinois step: halve f_a to ensure convergence
+            f_a /= 2.0;
+        }
+        big_b = big_c;
+        f_b = f_c;
+    }
+
+    (f64::midpoint(big_a, big_b) / 2.0).exp()
+}
+
+/// Update both ratings in-place after a single pairwise matchup.
+/// The first argument is the winner.
+#[allow(clippy::suboptimal_flops, clippy::imprecise_flops)]
+pub fn update_ratings(winner: &mut Rating, loser: &mut Rating) {
+    // Step 1: convert to Glicko-2 scale
+    let mu_w = (winner.rating - 1500.0) / SCALE;
+    let phi_w = winner.deviation / SCALE;
+
+    let mu_l = (loser.rating - 1500.0) / SCALE;
+    let phi_l = loser.deviation / SCALE;
+
+    // --- Update winner (s = 1.0 for win) ---
+    {
+        let g_l = g(phi_l);
+        let e_w = expected_score(mu_w, mu_l, phi_l);
+        let v_w = 1.0 / (g_l * g_l * e_w * (1.0 - e_w));
+        let delta_w = v_w * g_l * (1.0 - e_w);
+
+        let sigma_w_prime = new_volatility(phi_w, winner.volatility, delta_w, v_w);
+        let phi_star_w = phi_w.hypot(sigma_w_prime);
+        let phi_w_prime = 1.0 / (1.0 / (phi_star_w * phi_star_w) + 1.0 / v_w).sqrt();
+        let mu_w_prime = mu_w + phi_w_prime * phi_w_prime * g_l * (1.0 - e_w);
+
+        winner.rating = mu_w_prime * SCALE + 1500.0;
+        winner.deviation = phi_w_prime * SCALE;
+        winner.volatility = sigma_w_prime;
+    }
+
+    // --- Update loser (s = 0.0 for loss) ---
+    {
+        let g_w = g(phi_w);
+        let e_l = expected_score(mu_l, mu_w, phi_w);
+        let v_l = 1.0 / (g_w * g_w * e_l * (1.0 - e_l));
+        let delta_l = v_l * g_w * (0.0 - e_l);
+
+        let sigma_l_prime = new_volatility(phi_l, loser.volatility, delta_l, v_l);
+        let phi_star_l = phi_l.hypot(sigma_l_prime);
+        let phi_l_prime = 1.0 / (1.0 / (phi_star_l * phi_star_l) + 1.0 / v_l).sqrt();
+        let mu_l_prime = mu_l + phi_l_prime * phi_l_prime * g_w * (0.0 - e_l);
+
+        loser.rating = mu_l_prime * SCALE + 1500.0;
+        loser.deviation = phi_l_prime * SCALE;
+        loser.volatility = sigma_l_prime;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_rating() {
+        let r = Rating::default();
+        assert_eq!(r.rating, 1500.0);
+        assert_eq!(r.deviation, 350.0);
+        assert_eq!(r.volatility, 0.06);
+    }
+
+    #[test]
+    fn test_winner_rating_increases() {
+        let mut winner = Rating::default();
+        let mut loser = Rating::default();
+        update_ratings(&mut winner, &mut loser);
+        assert!(winner.rating > 1500.0);
+        assert!(loser.rating < 1500.0);
+    }
+
+    #[test]
+    fn test_symmetric_changes_for_equal_players() {
+        let mut a = Rating::default();
+        let mut b = Rating::default();
+        let a_before = a.rating;
+        let b_before = b.rating;
+        update_ratings(&mut a, &mut b);
+        let a_gain = a.rating - a_before;
+        let b_loss = b_before - b.rating;
+        assert!(
+            (a_gain - b_loss).abs() < 1.0,
+            "changes should be roughly symmetric"
+        );
+    }
+
+    #[test]
+    fn test_deviation_decreases_after_match() {
+        let mut a = Rating::default();
+        let mut b = Rating::default();
+        update_ratings(&mut a, &mut b);
+        assert!(a.deviation < 350.0);
+        assert!(b.deviation < 350.0);
+    }
+
+    #[test]
+    fn test_upset_produces_larger_swing() {
+        let mut strong = Rating {
+            rating: 1800.0,
+            deviation: 50.0,
+            volatility: 0.06,
+        };
+        let mut weak = Rating {
+            rating: 1200.0,
+            deviation: 50.0,
+            volatility: 0.06,
+        };
+        let strong_before = strong.rating;
+        update_ratings(&mut weak, &mut strong); // weak wins (upset)
+        let swing = strong_before - strong.rating;
+        assert!(
+            swing > 5.0,
+            "upset should produce significant swing, got {swing}"
+        );
+    }
+
+    #[test]
+    fn test_high_deviation_produces_larger_change() {
+        let mut a1 = Rating {
+            rating: 1500.0,
+            deviation: 350.0,
+            volatility: 0.06,
+        }; // uncertain
+        let mut b1 = Rating::default();
+        update_ratings(&mut a1, &mut b1);
+
+        let mut a2 = Rating {
+            rating: 1500.0,
+            deviation: 50.0,
+            volatility: 0.06,
+        }; // confident
+        let mut b2 = Rating::default();
+        update_ratings(&mut a2, &mut b2);
+
+        assert!(
+            (a1.rating - 1500.0).abs() > (a2.rating - 1500.0).abs(),
+            "uncertain player should have larger rating change"
+        );
+    }
+
+    #[test]
+    fn test_convergence_over_many_matches() {
+        // If a 1500-rated player beats a 1500-rated player 10 times in a row,
+        // their rating should be significantly higher and deviation should be low.
+        let mut winner = Rating::default();
+        let mut loser = Rating::default();
+        for _ in 0..10 {
+            let mut w = winner.clone();
+            let mut l = loser.clone();
+            update_ratings(&mut w, &mut l);
+            winner = w;
+            loser = l;
+        }
+        assert!(
+            winner.rating > 1700.0,
+            "winner rating after 10 wins: {}",
+            winner.rating
+        );
+        // Deviation should meaningfully decrease from the initial 350.0.
+        // With 10 rounds against an equally uncertain opponent (also starting at 350)
+        // the algorithm converges to ~200, so we verify it's well below the starting value.
+        assert!(
+            winner.deviation < 210.0,
+            "winner deviation should decrease from 350.0, got {}",
+            winner.deviation
+        );
+    }
+}

--- a/crates/tc-engine-ranking/src/lib.rs
+++ b/crates/tc-engine-ranking/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod config;
 pub mod engine;
 pub mod glicko2;
+pub mod lifecycle;
 pub mod pair_selection;
 pub mod repo;
 pub mod service;

--- a/crates/tc-engine-ranking/src/lib.rs
+++ b/crates/tc-engine-ranking/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod engine;
+pub mod glicko2;
+pub mod pair_selection;
+pub mod repo;
+pub mod service;

--- a/crates/tc-engine-ranking/src/lifecycle.rs
+++ b/crates/tc-engine-ranking/src/lifecycle.rs
@@ -1,0 +1,467 @@
+//! Background consumer for the ranking lifecycle message queue.
+//!
+//! The lifecycle queue drives the round state machine:
+//! `OpenSubmit` → `OpenRanking` → `CloseRound` → `OpenSubmit` …
+//!
+//! Each message is enqueued with a delay so the transition fires at the right
+//! wall-clock time.  On failure the message is left in the queue and will
+//! redeliver after the visibility timeout.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use tc_engine_api::engine::RoomLifecycle;
+
+use crate::config::RankingConfig;
+use crate::repo::pgmq;
+use crate::service::RankingService;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/// pgmq queue name for ranking lifecycle events.
+pub const QUEUE_NAME: &str = "rooms__ranking_lifecycle";
+
+/// Maximum delivery attempts before a message is treated as poison.
+const MAX_RETRIES: i32 = 3;
+
+/// Visibility timeout in seconds — how long a message stays hidden on read.
+const VISIBILITY_TIMEOUT_SECS: i32 = 60;
+
+// ─── Payload types ───────────────────────────────────────────────────────────
+
+/// Tagged payload for ranking lifecycle queue messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RankingLifecyclePayload {
+    /// Open the submission phase for a room. Creates a new round.
+    #[serde(rename = "open_submit")]
+    OpenSubmit { room_id: Uuid },
+    /// Transition a round from submission phase to ranking phase.
+    #[serde(rename = "open_ranking")]
+    OpenRanking { round_id: Uuid, room_id: Uuid },
+    /// Close a round and snapshot the hall of fame.
+    #[serde(rename = "close_round")]
+    CloseRound { round_id: Uuid, room_id: Uuid },
+}
+
+/// A message read from the ranking lifecycle queue.
+#[derive(Debug, Clone)]
+pub struct RankingLifecycleMessage {
+    /// pgmq message ID — needed for archive/delete.
+    pub msg_id: i64,
+    /// Number of delivery attempts.
+    pub read_ct: i32,
+    pub payload: RankingLifecyclePayload,
+    pub enqueued_at: DateTime<Utc>,
+}
+
+// ─── Queue operations ────────────────────────────────────────────────────────
+
+/// Enqueue a ranking lifecycle event with an optional delay.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on serialization failure or connection error.
+pub async fn enqueue_ranking_event(
+    pool: &PgPool,
+    payload: RankingLifecyclePayload,
+    delay_secs: i64,
+) -> Result<i64, sqlx::Error> {
+    let json_payload = serde_json::to_value(&payload)
+        .map_err(|e| sqlx::Error::Protocol(format!("failed to serialize payload: {e}")))?;
+
+    if delay_secs > 0 {
+        #[allow(clippy::cast_possible_truncation)]
+        let delay = delay_secs as i32;
+        pgmq::send_delayed(pool, QUEUE_NAME, &json_payload, delay).await
+    } else {
+        pgmq::send(pool, QUEUE_NAME, &json_payload).await
+    }
+}
+
+/// Read one ranking lifecycle message from the queue.
+///
+/// The message remains hidden from other consumers until the visibility timeout
+/// elapses or it is archived.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn read_ranking_event(
+    pool: &PgPool,
+) -> Result<Option<RankingLifecycleMessage>, sqlx::Error> {
+    let Some(msg) = pgmq::read(pool, QUEUE_NAME, VISIBILITY_TIMEOUT_SECS).await? else {
+        return Ok(None);
+    };
+
+    let payload: RankingLifecyclePayload = serde_json::from_value(msg.message)
+        .map_err(|e| sqlx::Error::Protocol(format!("invalid ranking lifecycle payload: {e}")))?;
+
+    Ok(Some(RankingLifecycleMessage {
+        msg_id: msg.msg_id,
+        read_ct: msg.read_ct,
+        payload,
+        enqueued_at: msg.enqueued_at,
+    }))
+}
+
+/// Archive a ranking lifecycle message after successful processing.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn archive_ranking_event(pool: &PgPool, msg_id: i64) -> Result<(), sqlx::Error> {
+    pgmq::archive(pool, QUEUE_NAME, msg_id).await
+}
+
+/// Check if a message has exceeded the retry limit.
+#[must_use]
+pub const fn is_poison(msg: &RankingLifecycleMessage) -> bool {
+    msg.read_ct > MAX_RETRIES
+}
+
+// ─── Consumer ────────────────────────────────────────────────────────────────
+
+/// Spawn the ranking lifecycle consumer as a background tokio task.
+///
+/// Returns the [`tokio::task::JoinHandle`] so the caller can track or abort
+/// the task on shutdown.
+pub fn spawn_ranking_lifecycle_consumer(
+    pool: PgPool,
+    ranking_service: Arc<dyn RankingService>,
+    room_lifecycle: Arc<dyn RoomLifecycle>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!(
+            poll_interval_secs = interval.as_secs(),
+            "ranking lifecycle consumer started"
+        );
+        let mut ticker = tokio::time::interval(interval);
+        loop {
+            ticker.tick().await;
+            match read_ranking_event(&pool).await {
+                Ok(Some(msg)) => {
+                    if is_poison(&msg) {
+                        tracing::warn!(
+                            msg_id = msg.msg_id,
+                            read_ct = msg.read_ct,
+                            "archiving poison ranking lifecycle message"
+                        );
+                        if let Err(e) = archive_ranking_event(&pool, msg.msg_id).await {
+                            tracing::warn!(
+                                msg_id = msg.msg_id,
+                                error = %e,
+                                "failed to archive poison message"
+                            );
+                        }
+                        continue;
+                    }
+
+                    tracing::debug!(msg_id = msg.msg_id, "processing ranking lifecycle event");
+                    let success =
+                        process_message(&pool, &*ranking_service, &*room_lifecycle, &msg).await;
+
+                    if success {
+                        if let Err(e) = archive_ranking_event(&pool, msg.msg_id).await {
+                            tracing::warn!(
+                                msg_id = msg.msg_id,
+                                error = %e,
+                                "failed to archive ranking lifecycle event"
+                            );
+                        }
+                    }
+                    // On failure: don't archive — VT expires and message redelivers.
+                }
+                Ok(None) => {} // Queue empty
+                Err(e) => {
+                    tracing::warn!("ranking lifecycle queue read failed: {e}");
+                }
+            }
+        }
+    })
+}
+
+/// Process a single lifecycle message. Returns `true` on success.
+async fn process_message(
+    pool: &PgPool,
+    ranking_service: &dyn RankingService,
+    room_lifecycle: &dyn RoomLifecycle,
+    msg: &RankingLifecycleMessage,
+) -> bool {
+    match &msg.payload {
+        RankingLifecyclePayload::OpenSubmit { room_id } => {
+            handle_open_submit(pool, ranking_service, room_lifecycle, *room_id).await
+        }
+        RankingLifecyclePayload::OpenRanking { round_id, room_id } => {
+            handle_open_ranking(pool, ranking_service, room_lifecycle, *round_id, *room_id).await
+        }
+        RankingLifecyclePayload::CloseRound { round_id, room_id } => {
+            handle_close_round(pool, ranking_service, room_lifecycle, *round_id, *room_id).await
+        }
+    }
+}
+
+async fn handle_open_submit(
+    pool: &PgPool,
+    ranking_service: &dyn RankingService,
+    room_lifecycle: &dyn RoomLifecycle,
+    room_id: Uuid,
+) -> bool {
+    let room = match room_lifecycle.get_room(room_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(room_id = %room_id, error = %e, "OpenSubmit: get_room failed");
+            return false;
+        }
+    };
+
+    let config: RankingConfig = match serde_json::from_value(room.engine_config.clone()) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                room_id = %room_id,
+                error = %e,
+                "OpenSubmit: failed to parse engine_config"
+            );
+            return false;
+        }
+    };
+
+    let now = Utc::now();
+    let submit_opens_at = now;
+    let rank_opens_at = now + chrono::Duration::seconds(config.submit_duration_secs);
+    let closes_at = rank_opens_at + chrono::Duration::seconds(config.rank_duration_secs);
+
+    let round = match ranking_service
+        .create_round(room_id, submit_opens_at, rank_opens_at, closes_at)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                room_id = %room_id,
+                error = %e,
+                "OpenSubmit: create_round failed"
+            );
+            return false;
+        }
+    };
+
+    // Enqueue transition to ranking phase after submit phase ends.
+    let delay = config.submit_duration_secs;
+    if let Err(e) = enqueue_ranking_event(
+        pool,
+        RankingLifecyclePayload::OpenRanking {
+            round_id: round.id,
+            room_id,
+        },
+        delay,
+    )
+    .await
+    {
+        tracing::warn!(
+            round_id = %round.id,
+            error = %e,
+            "OpenSubmit: failed to enqueue OpenRanking"
+        );
+        return false;
+    }
+
+    tracing::info!(
+        room_id = %room_id,
+        round_id = %round.id,
+        delay_secs = delay,
+        "round created; OpenRanking enqueued"
+    );
+    true
+}
+
+async fn handle_open_ranking(
+    pool: &PgPool,
+    ranking_service: &dyn RankingService,
+    room_lifecycle: &dyn RoomLifecycle,
+    round_id: Uuid,
+    room_id: Uuid,
+) -> bool {
+    if let Err(e) = ranking_service.open_ranking(round_id).await {
+        tracing::warn!(
+            round_id = %round_id,
+            error = %e,
+            "OpenRanking: open_ranking failed"
+        );
+        return false;
+    }
+
+    let room = match room_lifecycle.get_room(room_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                room_id = %room_id,
+                error = %e,
+                "OpenRanking: get_room failed"
+            );
+            return false;
+        }
+    };
+
+    let config: RankingConfig = match serde_json::from_value(room.engine_config.clone()) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                room_id = %room_id,
+                error = %e,
+                "OpenRanking: failed to parse engine_config"
+            );
+            return false;
+        }
+    };
+
+    let delay = config.rank_duration_secs;
+    if let Err(e) = enqueue_ranking_event(
+        pool,
+        RankingLifecyclePayload::CloseRound { round_id, room_id },
+        delay,
+    )
+    .await
+    {
+        tracing::warn!(
+            round_id = %round_id,
+            error = %e,
+            "OpenRanking: failed to enqueue CloseRound"
+        );
+        return false;
+    }
+
+    tracing::info!(
+        round_id = %round_id,
+        delay_secs = delay,
+        "ranking opened; CloseRound enqueued"
+    );
+    true
+}
+
+async fn handle_close_round(
+    pool: &PgPool,
+    ranking_service: &dyn RankingService,
+    room_lifecycle: &dyn RoomLifecycle,
+    round_id: Uuid,
+    room_id: Uuid,
+) -> bool {
+    let room = match room_lifecycle.get_room(room_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                room_id = %room_id,
+                error = %e,
+                "CloseRound: get_room failed"
+            );
+            return false;
+        }
+    };
+
+    let config: RankingConfig = match serde_json::from_value(room.engine_config.clone()) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                room_id = %room_id,
+                error = %e,
+                "CloseRound: failed to parse engine_config"
+            );
+            return false;
+        }
+    };
+
+    if let Err(e) = ranking_service
+        .close_round(round_id, config.hall_of_fame_depth)
+        .await
+    {
+        tracing::warn!(
+            round_id = %round_id,
+            error = %e,
+            "CloseRound: close_round failed"
+        );
+        return false;
+    }
+
+    // Immediately kick off the next cycle.
+    if let Err(e) =
+        enqueue_ranking_event(pool, RankingLifecyclePayload::OpenSubmit { room_id }, 0).await
+    {
+        tracing::warn!(
+            room_id = %room_id,
+            error = %e,
+            "CloseRound: failed to enqueue next OpenSubmit"
+        );
+        return false;
+    }
+
+    tracing::info!(
+        round_id = %round_id,
+        room_id = %room_id,
+        "round closed; next OpenSubmit enqueued"
+    );
+    true
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_serializes_with_type_tag() {
+        let p = RankingLifecyclePayload::OpenSubmit {
+            room_id: Uuid::nil(),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["type"], "open_submit");
+        assert!(v.get("room_id").is_some());
+    }
+
+    #[test]
+    fn payload_roundtrips_open_ranking() {
+        let p = RankingLifecyclePayload::OpenRanking {
+            round_id: Uuid::nil(),
+            room_id: Uuid::nil(),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["type"], "open_ranking");
+        let back: RankingLifecyclePayload = serde_json::from_value(v).unwrap();
+        assert!(matches!(back, RankingLifecyclePayload::OpenRanking { .. }));
+    }
+
+    #[test]
+    fn payload_roundtrips_close_round() {
+        let p = RankingLifecyclePayload::CloseRound {
+            round_id: Uuid::nil(),
+            room_id: Uuid::nil(),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["type"], "close_round");
+        let back: RankingLifecyclePayload = serde_json::from_value(v).unwrap();
+        assert!(matches!(back, RankingLifecyclePayload::CloseRound { .. }));
+    }
+
+    #[test]
+    fn is_poison_detects_excess_reads() {
+        let make_msg = |read_ct: i32| RankingLifecycleMessage {
+            msg_id: 1,
+            read_ct,
+            payload: RankingLifecyclePayload::OpenSubmit {
+                room_id: Uuid::nil(),
+            },
+            enqueued_at: Utc::now(),
+        };
+        assert!(!is_poison(&make_msg(1)));
+        assert!(!is_poison(&make_msg(3)));
+        assert!(is_poison(&make_msg(4)));
+        assert!(is_poison(&make_msg(10)));
+    }
+}

--- a/crates/tc-engine-ranking/src/pair_selection.rs
+++ b/crates/tc-engine-ranking/src/pair_selection.rs
@@ -1,0 +1,1 @@
+// Pair selection algorithm — to be implemented in Task 6.

--- a/crates/tc-engine-ranking/src/pair_selection.rs
+++ b/crates/tc-engine-ranking/src/pair_selection.rs
@@ -1,1 +1,153 @@
-// Pair selection algorithm — to be implemented in Task 6.
+/// Hybrid uncertainty + near-frontier pair selection.
+use uuid::Uuid;
+
+/// A submission with its current rating info, used for pair selection.
+#[derive(Debug, Clone)]
+pub struct RatedSubmission {
+    pub submission_id: Uuid,
+    pub author_id: Uuid,
+    pub rating: f64,
+    pub deviation: f64,
+}
+
+const UNCERTAINTY_WEIGHT: f64 = 0.7;
+const PROXIMITY_WEIGHT: f64 = 0.3;
+
+/// Select the best pair for a ranker to judge.
+///
+/// - `ratings`: all submissions with their current ratings
+/// - `judged_pairs`: pairs this ranker has already judged, as ordered (min, max) UUID tuples
+/// - `ranker_id`: the ranker's account ID (to exclude their own submission)
+///
+/// Returns the pair `(submission_a_id, submission_b_id)` with the highest score,
+/// or `None` if no unjudged pairs are available.
+#[must_use]
+pub fn select_pair(
+    ratings: &[RatedSubmission],
+    judged_pairs: &[(Uuid, Uuid)],
+    ranker_id: Uuid,
+) -> Option<(Uuid, Uuid)> {
+    // Step 1: filter out the ranker's own submissions
+    let eligible: Vec<&RatedSubmission> = ratings
+        .iter()
+        .filter(|s| s.author_id != ranker_id)
+        .collect();
+
+    if eligible.len() < 2 {
+        return None;
+    }
+
+    // Build a fast lookup set for already-judged pairs
+    let judged_set: std::collections::HashSet<(Uuid, Uuid)> =
+        judged_pairs.iter().copied().collect();
+
+    let mut best_score = f64::NEG_INFINITY;
+    let mut best_pair: Option<(Uuid, Uuid)> = None;
+
+    // Step 2 & 3: iterate all candidate pairs, skip already-judged
+    for i in 0..eligible.len() {
+        for j in (i + 1)..eligible.len() {
+            let a = eligible[i];
+            let b = eligible[j];
+
+            // Normalise to (min, max) order for lookup
+            let key = (
+                a.submission_id.min(b.submission_id),
+                a.submission_id.max(b.submission_id),
+            );
+            if judged_set.contains(&key) {
+                continue;
+            }
+
+            // Step 4: score = uncertainty component + proximity component
+            let uncertainty = (a.deviation + b.deviation) * UNCERTAINTY_WEIGHT;
+            let proximity = (1.0 / (1.0 + (a.rating - b.rating).abs())) * PROXIMITY_WEIGHT;
+            let score = uncertainty + proximity;
+
+            if score > best_score {
+                best_score = score;
+                best_pair = Some((a.submission_id, b.submission_id));
+            }
+        }
+    }
+
+    best_pair
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rated(id: Uuid, author: Uuid, rating: f64, deviation: f64) -> RatedSubmission {
+        RatedSubmission {
+            submission_id: id,
+            author_id: author,
+            rating,
+            deviation,
+        }
+    }
+
+    #[test]
+    fn test_no_submissions_returns_none() {
+        assert!(select_pair(&[], &[], Uuid::new_v4()).is_none());
+    }
+
+    #[test]
+    fn test_single_submission_returns_none() {
+        let s = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0);
+        assert!(select_pair(&[s], &[], Uuid::new_v4()).is_none());
+    }
+
+    #[test]
+    fn test_two_submissions_returns_pair() {
+        let a = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0);
+        let b = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0);
+        assert!(select_pair(&[a, b], &[], Uuid::new_v4()).is_some());
+    }
+
+    #[test]
+    fn test_excludes_already_judged() {
+        let a_id = Uuid::new_v4();
+        let b_id = Uuid::new_v4();
+        let a = make_rated(a_id, Uuid::new_v4(), 1500.0, 350.0);
+        let b = make_rated(b_id, Uuid::new_v4(), 1500.0, 350.0);
+        let judged = vec![(a_id.min(b_id), a_id.max(b_id))];
+        assert!(select_pair(&[a, b], &judged, Uuid::new_v4()).is_none());
+    }
+
+    #[test]
+    fn test_excludes_rankers_own_submission() {
+        let ranker = Uuid::new_v4();
+        let other_author = Uuid::new_v4();
+        let a = make_rated(Uuid::new_v4(), ranker, 1500.0, 350.0); // ranker's submission
+        let b = make_rated(Uuid::new_v4(), other_author, 1500.0, 350.0);
+        // Only 2 submissions, one is ranker's — can't form a valid pair without ranker's
+        assert!(select_pair(&[a, b], &[], ranker).is_none());
+    }
+
+    #[test]
+    fn test_three_submissions_ranker_excluded_still_works() {
+        let ranker = Uuid::new_v4();
+        let a = make_rated(Uuid::new_v4(), ranker, 1500.0, 350.0); // ranker's
+        let b = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0);
+        let c = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0);
+        // b and c should still be a valid pair
+        let result = select_pair(&[a, b.clone(), c.clone()], &[], ranker);
+        assert!(result.is_some());
+        let (x, y) = result.unwrap();
+        assert!(x == b.submission_id || x == c.submission_id);
+        assert!(y == b.submission_id || y == c.submission_id);
+        assert_ne!(x, y);
+    }
+
+    #[test]
+    fn test_prefers_high_uncertainty() {
+        let a = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0); // high dev
+        let b = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 350.0); // high dev
+        let c = make_rated(Uuid::new_v4(), Uuid::new_v4(), 1500.0, 50.0); // low dev
+        let result = select_pair(&[a.clone(), b.clone(), c], &[], Uuid::new_v4()).unwrap();
+        // Should prefer (a, b) since both have high deviation
+        let ids = [result.0, result.1];
+        assert!(ids.contains(&a.submission_id) && ids.contains(&b.submission_id));
+    }
+}

--- a/crates/tc-engine-ranking/src/repo/hall_of_fame.rs
+++ b/crates/tc-engine-ranking/src/repo/hall_of_fame.rs
@@ -1,1 +1,90 @@
-// Hall of fame repository — to be implemented in Task 4.
+//! Hall of fame persistence operations for the ranking engine.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HallOfFameRecord {
+    pub id: Uuid,
+    pub room_id: Uuid,
+    pub round_id: Uuid,
+    pub submission_id: Uuid,
+    pub final_rating: f64,
+    pub rank: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+// ─── Operations ─────────────────────────────────────────────────────────────
+
+/// Insert the top-ranked submissions from a closed round into the hall of fame.
+///
+/// `winners` is a slice of `(submission_id, final_rating, rank)` tuples.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn insert_winners(
+    pool: &sqlx::PgPool,
+    room_id: Uuid,
+    round_id: Uuid,
+    winners: &[(Uuid, f64, i32)],
+) -> Result<(), sqlx::Error> {
+    if winners.is_empty() {
+        return Ok(());
+    }
+
+    // Use a transaction to batch all inserts atomically.
+    let mut tx = pool.begin().await?;
+
+    for (submission_id, final_rating, rank) in winners {
+        sqlx::query(
+            r"
+            INSERT INTO rooms__hall_of_fame (room_id, round_id, submission_id, final_rating, rank)
+            VALUES ($1, $2, $3, $4, $5)
+            ",
+        )
+        .bind(room_id)
+        .bind(round_id)
+        .bind(submission_id)
+        .bind(final_rating)
+        .bind(rank)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Return hall of fame entries for a room, ordered by `created_at` DESC.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn list_hall_of_fame<'e, E>(
+    executor: E,
+    room_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<HallOfFameRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, HallOfFameRecord>(
+        r"
+        SELECT id, room_id, round_id, submission_id, final_rating, rank, created_at
+        FROM rooms__hall_of_fame
+        WHERE room_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2
+        OFFSET $3
+        ",
+    )
+    .bind(room_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(executor)
+    .await
+}

--- a/crates/tc-engine-ranking/src/repo/hall_of_fame.rs
+++ b/crates/tc-engine-ranking/src/repo/hall_of_fame.rs
@@ -1,0 +1,1 @@
+// Hall of fame repository — to be implemented in Task 4.

--- a/crates/tc-engine-ranking/src/repo/matchups.rs
+++ b/crates/tc-engine-ranking/src/repo/matchups.rs
@@ -1,1 +1,124 @@
-// Matchups repository — to be implemented in Task 4.
+//! Matchup persistence operations for the ranking engine.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MatchupRecord {
+    pub id: Uuid,
+    pub round_id: Uuid,
+    pub ranker_id: Uuid,
+    pub submission_a: Uuid,
+    pub submission_b: Uuid,
+    pub winner_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ─── Operations ─────────────────────────────────────────────────────────────
+
+/// Create a pairwise matchup.
+///
+/// Enforces `submission_a < submission_b` ordering before insert to satisfy
+/// the `chk_matchups_ordered_pair` constraint.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure or constraint violation
+/// (e.g., duplicate `(round_id, ranker_id, submission_a, submission_b)`).
+pub async fn create_matchup<'e, E>(
+    executor: E,
+    round_id: Uuid,
+    ranker_id: Uuid,
+    submission_a: Uuid,
+    submission_b: Uuid,
+    winner_id: Option<Uuid>,
+) -> Result<MatchupRecord, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let (a, b) = ordered_pair(submission_a, submission_b);
+
+    sqlx::query_as::<_, MatchupRecord>(
+        r"
+        INSERT INTO rooms__matchups (round_id, ranker_id, submission_a, submission_b, winner_id)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, round_id, ranker_id, submission_a, submission_b, winner_id, created_at
+        ",
+    )
+    .bind(round_id)
+    .bind(ranker_id)
+    .bind(a)
+    .bind(b)
+    .bind(winner_id)
+    .fetch_one(executor)
+    .await
+}
+
+/// Return all `(submission_a, submission_b)` pairs already judged by a ranker in a round.
+///
+/// Pairs are returned in their stored (ordered) form: `submission_a < submission_b`.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_judged_pairs<'e, E>(
+    executor: E,
+    round_id: Uuid,
+    ranker_id: Uuid,
+) -> Result<Vec<(Uuid, Uuid)>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let rows: Vec<(Uuid, Uuid)> = sqlx::query_as(
+        r"
+        SELECT submission_a, submission_b
+        FROM rooms__matchups
+        WHERE round_id = $1
+          AND ranker_id = $2
+        ",
+    )
+    .bind(round_id)
+    .bind(ranker_id)
+    .fetch_all(executor)
+    .await?;
+
+    Ok(rows)
+}
+
+/// Count the number of matchups a ranker has completed in a round.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn count_matchups_for_ranker<'e, E>(
+    executor: E,
+    round_id: Uuid,
+    ranker_id: Uuid,
+) -> Result<i64, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM rooms__matchups WHERE round_id = $1 AND ranker_id = $2",
+    )
+    .bind(round_id)
+    .bind(ranker_id)
+    .fetch_one(executor)
+    .await?;
+
+    Ok(count)
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/// Return `(a, b)` such that `a < b` (bytes-level UUID ordering).
+/// This ensures the `chk_matchups_ordered_pair` constraint is satisfied.
+fn ordered_pair(x: Uuid, y: Uuid) -> (Uuid, Uuid) {
+    if x < y {
+        (x, y)
+    } else {
+        (y, x)
+    }
+}

--- a/crates/tc-engine-ranking/src/repo/matchups.rs
+++ b/crates/tc-engine-ranking/src/repo/matchups.rs
@@ -1,0 +1,1 @@
+// Matchups repository — to be implemented in Task 4.

--- a/crates/tc-engine-ranking/src/repo/mod.rs
+++ b/crates/tc-engine-ranking/src/repo/mod.rs
@@ -1,0 +1,5 @@
+pub mod hall_of_fame;
+pub mod matchups;
+pub mod ratings;
+pub mod rounds;
+pub mod submissions;

--- a/crates/tc-engine-ranking/src/repo/mod.rs
+++ b/crates/tc-engine-ranking/src/repo/mod.rs
@@ -1,5 +1,6 @@
 pub mod hall_of_fame;
 pub mod matchups;
+pub(crate) mod pgmq;
 pub mod ratings;
 pub mod rounds;
 pub mod submissions;

--- a/crates/tc-engine-ranking/src/repo/pgmq.rs
+++ b/crates/tc-engine-ranking/src/repo/pgmq.rs
@@ -1,0 +1,113 @@
+//! Thin pgmq wrappers shared by ranking queue operations.
+//!
+//! Mirrors the pattern from `tc-engine-polling/src/repo/pgmq.rs`.  Each queue
+//! module in this crate builds on these generic helpers rather than calling
+//! raw SQL directly.
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::PgPool;
+
+// ─── Message type ────────────────────────────────────────────────────────────
+
+/// A message returned by `pgmq.read`.
+#[derive(Debug, Clone)]
+pub struct PgmqMessage {
+    pub msg_id: i64,
+    pub read_ct: i32,
+    pub enqueued_at: DateTime<Utc>,
+    pub message: Value,
+}
+
+#[derive(sqlx::FromRow)]
+struct PgmqRow {
+    msg_id: i64,
+    read_ct: i32,
+    enqueued_at: DateTime<Utc>,
+    message: Value,
+}
+
+impl From<PgmqRow> for PgmqMessage {
+    fn from(row: PgmqRow) -> Self {
+        Self {
+            msg_id: row.msg_id,
+            read_ct: row.read_ct,
+            enqueued_at: row.enqueued_at,
+            message: row.message,
+        }
+    }
+}
+
+// ─── Generic queue operations ────────────────────────────────────────────────
+
+/// Enqueue a JSON payload onto a named queue.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection error.
+pub async fn send(pool: &PgPool, queue_name: &str, payload: &Value) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as("SELECT * FROM pgmq.send($1, $2)")
+        .bind(queue_name)
+        .bind(payload)
+        .fetch_one(pool)
+        .await?;
+    Ok(row.0)
+}
+
+/// Enqueue a JSON payload with a visibility delay.
+///
+/// The message will not be visible until `delay_secs` seconds have elapsed.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection error.
+pub async fn send_delayed(
+    pool: &PgPool,
+    queue_name: &str,
+    payload: &Value,
+    delay_secs: i32,
+) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as("SELECT * FROM pgmq.send($1, $2, $3)")
+        .bind(queue_name)
+        .bind(payload)
+        .bind(delay_secs)
+        .fetch_one(pool)
+        .await?;
+    Ok(row.0)
+}
+
+/// Read one message from a named queue.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn read(
+    pool: &PgPool,
+    queue_name: &str,
+    visibility_timeout_secs: i32,
+) -> Result<Option<PgmqMessage>, sqlx::Error> {
+    let row = sqlx::query_as::<_, PgmqRow>(
+        "SELECT msg_id, read_ct, enqueued_at, message \
+         FROM pgmq.read($1, $2, 1)",
+    )
+    .bind(queue_name)
+    .bind(visibility_timeout_secs)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(PgmqMessage::from))
+}
+
+/// Archive a message for audit trail retention.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn archive(pool: &PgPool, queue_name: &str, msg_id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT pgmq.archive($1, $2)")
+        .bind(queue_name)
+        .bind(msg_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}

--- a/crates/tc-engine-ranking/src/repo/ratings.rs
+++ b/crates/tc-engine-ranking/src/repo/ratings.rs
@@ -1,0 +1,1 @@
+// Ratings repository — to be implemented in Task 4.

--- a/crates/tc-engine-ranking/src/repo/ratings.rs
+++ b/crates/tc-engine-ranking/src/repo/ratings.rs
@@ -1,1 +1,134 @@
-// Ratings repository — to be implemented in Task 4.
+//! Glicko-2 rating persistence operations for the ranking engine.
+
+use uuid::Uuid;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct RatingRecord {
+    pub submission_id: Uuid,
+    pub rating: f64,
+    pub deviation: f64,
+    pub volatility: f64,
+    pub matchup_count: i32,
+}
+
+// ─── Operations ─────────────────────────────────────────────────────────────
+
+/// Bulk-insert default Glicko-2 ratings for a set of submissions.
+///
+/// Uses `ON CONFLICT DO NOTHING` so it is safe to call after some ratings
+/// already exist (idempotent for existing rows).
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn initialize_ratings<'e, E>(
+    executor: E,
+    submission_ids: &[Uuid],
+) -> Result<(), sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    if submission_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Build a multi-row VALUES list via unnest for efficiency.
+    sqlx::query(
+        r"
+        INSERT INTO rooms__ratings (submission_id)
+        SELECT unnest($1::uuid[])
+        ON CONFLICT (submission_id) DO NOTHING
+        ",
+    )
+    .bind(submission_ids)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+/// Fetch the rating record for a single submission. Returns `None` if not found.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_rating<'e, E>(
+    executor: E,
+    submission_id: Uuid,
+) -> Result<Option<RatingRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, RatingRecord>(
+        r"
+        SELECT submission_id, rating, deviation, volatility, matchup_count
+        FROM rooms__ratings
+        WHERE submission_id = $1
+        ",
+    )
+    .bind(submission_id)
+    .fetch_optional(executor)
+    .await
+}
+
+/// Return all rating records for submissions in a round, ordered by rating DESC.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_ratings_for_round<'e, E>(
+    executor: E,
+    round_id: Uuid,
+) -> Result<Vec<RatingRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, RatingRecord>(
+        r"
+        SELECT r.submission_id, r.rating, r.deviation, r.volatility, r.matchup_count
+        FROM rooms__ratings r
+        JOIN rooms__submissions s ON s.id = r.submission_id
+        WHERE s.round_id = $1
+        ORDER BY r.rating DESC
+        ",
+    )
+    .bind(round_id)
+    .fetch_all(executor)
+    .await
+}
+
+/// Overwrite the Glicko-2 state for a submission.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn update_rating<'e, E>(
+    executor: E,
+    submission_id: Uuid,
+    rating: f64,
+    deviation: f64,
+    volatility: f64,
+    matchup_count: i32,
+) -> Result<(), sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query(
+        r"
+        UPDATE rooms__ratings
+        SET rating = $1, deviation = $2, volatility = $3, matchup_count = $4
+        WHERE submission_id = $5
+        ",
+    )
+    .bind(rating)
+    .bind(deviation)
+    .bind(volatility)
+    .bind(matchup_count)
+    .bind(submission_id)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}

--- a/crates/tc-engine-ranking/src/repo/rounds.rs
+++ b/crates/tc-engine-ranking/src/repo/rounds.rs
@@ -1,1 +1,183 @@
-// Rounds repository — to be implemented in Task 3.
+//! Round persistence operations for the ranking engine.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, sqlx::Type)]
+#[sqlx(type_name = "ranking_round_status", rename_all = "snake_case")]
+pub enum RoundStatus {
+    Submitting,
+    Ranking,
+    Closed,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct RoundRecord {
+    pub id: Uuid,
+    pub room_id: Uuid,
+    pub round_number: i32,
+    pub submit_opens_at: DateTime<Utc>,
+    pub rank_opens_at: DateTime<Utc>,
+    pub closes_at: DateTime<Utc>,
+    pub status: RoundStatus,
+    pub created_at: DateTime<Utc>,
+}
+
+// ─── Operations ─────────────────────────────────────────────────────────────
+
+/// Create a new round for the given room.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure or constraint violation
+/// (e.g., duplicate `(room_id, round_number)`).
+pub async fn create_round<'e, E>(
+    executor: E,
+    room_id: Uuid,
+    round_number: i32,
+    submit_opens_at: DateTime<Utc>,
+    rank_opens_at: DateTime<Utc>,
+    closes_at: DateTime<Utc>,
+) -> Result<RoundRecord, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, RoundRecord>(
+        r"
+        INSERT INTO rooms__rounds (room_id, round_number, submit_opens_at, rank_opens_at, closes_at)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, room_id, round_number, submit_opens_at, rank_opens_at, closes_at,
+                  status, created_at
+        ",
+    )
+    .bind(room_id)
+    .bind(round_number)
+    .bind(submit_opens_at)
+    .bind(rank_opens_at)
+    .bind(closes_at)
+    .fetch_one(executor)
+    .await
+}
+
+/// Fetch a single round by ID. Returns `None` if not found.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_round<'e, E>(
+    executor: E,
+    round_id: Uuid,
+) -> Result<Option<RoundRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, RoundRecord>(
+        r"
+        SELECT id, room_id, round_number, submit_opens_at, rank_opens_at, closes_at,
+               status, created_at
+        FROM rooms__rounds
+        WHERE id = $1
+        ",
+    )
+    .bind(round_id)
+    .fetch_optional(executor)
+    .await
+}
+
+/// Return all non-closed rounds for a room, ordered by `round_number` ASC.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_current_rounds<'e, E>(
+    executor: E,
+    room_id: Uuid,
+) -> Result<Vec<RoundRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, RoundRecord>(
+        r"
+        SELECT id, room_id, round_number, submit_opens_at, rank_opens_at, closes_at,
+               status, created_at
+        FROM rooms__rounds
+        WHERE room_id = $1
+          AND status != 'closed'
+        ORDER BY round_number ASC
+        ",
+    )
+    .bind(room_id)
+    .fetch_all(executor)
+    .await
+}
+
+/// Return all rounds for a room, ordered by `round_number` DESC.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn list_rounds<'e, E>(executor: E, room_id: Uuid) -> Result<Vec<RoundRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, RoundRecord>(
+        r"
+        SELECT id, room_id, round_number, submit_opens_at, rank_opens_at, closes_at,
+               status, created_at
+        FROM rooms__rounds
+        WHERE room_id = $1
+        ORDER BY round_number DESC
+        ",
+    )
+    .bind(room_id)
+    .fetch_all(executor)
+    .await
+}
+
+/// Update the status of a round.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn update_round_status<'e, E>(
+    executor: E,
+    round_id: Uuid,
+    status: RoundStatus,
+) -> Result<(), sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query(
+        r"
+        UPDATE rooms__rounds
+        SET status = $1
+        WHERE id = $2
+        ",
+    )
+    .bind(status)
+    .bind(round_id)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+/// Return the highest `round_number` for a room, or 0 if no rounds exist.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_latest_round_number<'e, E>(executor: E, room_id: Uuid) -> Result<i32, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let row: (Option<i32>,) =
+        sqlx::query_as("SELECT MAX(round_number) FROM rooms__rounds WHERE room_id = $1")
+            .bind(room_id)
+            .fetch_one(executor)
+            .await?;
+
+    Ok(row.0.unwrap_or(0))
+}

--- a/crates/tc-engine-ranking/src/repo/rounds.rs
+++ b/crates/tc-engine-ranking/src/repo/rounds.rs
@@ -1,0 +1,1 @@
+// Rounds repository — to be implemented in Task 3.

--- a/crates/tc-engine-ranking/src/repo/submissions.rs
+++ b/crates/tc-engine-ranking/src/repo/submissions.rs
@@ -1,1 +1,153 @@
-// Submissions repository — to be implemented in Task 3.
+//! Submission persistence operations for the ranking engine.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, sqlx::Type)]
+#[sqlx(type_name = "submission_content_type", rename_all = "snake_case")]
+pub enum ContentType {
+    Url,
+    Image,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SubmissionRecord {
+    pub id: Uuid,
+    pub round_id: Uuid,
+    pub author_id: Uuid,
+    pub content_type: ContentType,
+    pub url: Option<String>,
+    pub image_key: Option<String>,
+    pub caption: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ─── Operations ─────────────────────────────────────────────────────────────
+
+/// Create a new submission in the given round.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure or constraint violation
+/// (e.g., duplicate `(round_id, author_id)`, or missing `url`/`image_key` check).
+#[allow(clippy::too_many_arguments)]
+pub async fn create_submission<'e, E>(
+    executor: E,
+    round_id: Uuid,
+    author_id: Uuid,
+    content_type: ContentType,
+    url: Option<&str>,
+    image_key: Option<&str>,
+    caption: Option<&str>,
+) -> Result<SubmissionRecord, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, SubmissionRecord>(
+        r"
+        INSERT INTO rooms__submissions (round_id, author_id, content_type, url, image_key, caption)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, round_id, author_id, content_type, url, image_key, caption, created_at
+        ",
+    )
+    .bind(round_id)
+    .bind(author_id)
+    .bind(content_type)
+    .bind(url)
+    .bind(image_key)
+    .bind(caption)
+    .fetch_one(executor)
+    .await
+}
+
+/// Fetch a single submission by ID. Returns `None` if not found.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn get_submission<'e, E>(
+    executor: E,
+    submission_id: Uuid,
+) -> Result<Option<SubmissionRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, SubmissionRecord>(
+        r"
+        SELECT id, round_id, author_id, content_type, url, image_key, caption, created_at
+        FROM rooms__submissions
+        WHERE id = $1
+        ",
+    )
+    .bind(submission_id)
+    .fetch_optional(executor)
+    .await
+}
+
+/// Return all submissions for a round, ordered by `created_at` ASC.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn list_submissions<'e, E>(
+    executor: E,
+    round_id: Uuid,
+) -> Result<Vec<SubmissionRecord>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query_as::<_, SubmissionRecord>(
+        r"
+        SELECT id, round_id, author_id, content_type, url, image_key, caption, created_at
+        FROM rooms__submissions
+        WHERE round_id = $1
+        ORDER BY created_at ASC
+        ",
+    )
+    .bind(round_id)
+    .fetch_all(executor)
+    .await
+}
+
+/// Count the number of submissions for a round.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn count_submissions<'e, E>(executor: E, round_id: Uuid) -> Result<i64, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM rooms__submissions WHERE round_id = $1")
+            .bind(round_id)
+            .fetch_one(executor)
+            .await?;
+
+    Ok(count)
+}
+
+/// Check whether a given author has already submitted in this round.
+///
+/// # Errors
+///
+/// Returns `sqlx::Error` on connection failure.
+pub async fn has_submitted<'e, E>(
+    executor: E,
+    round_id: Uuid,
+    author_id: Uuid,
+) -> Result<bool, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let row: Option<(Uuid,)> =
+        sqlx::query_as("SELECT id FROM rooms__submissions WHERE round_id = $1 AND author_id = $2")
+            .bind(round_id)
+            .bind(author_id)
+            .fetch_optional(executor)
+            .await?;
+
+    Ok(row.is_some())
+}

--- a/crates/tc-engine-ranking/src/repo/submissions.rs
+++ b/crates/tc-engine-ranking/src/repo/submissions.rs
@@ -1,0 +1,1 @@
+// Submissions repository — to be implemented in Task 3.

--- a/crates/tc-engine-ranking/src/service.rs
+++ b/crates/tc-engine-ranking/src/service.rs
@@ -1,0 +1,1 @@
+// Ranking service layer — to be implemented in Task 7.

--- a/crates/tc-engine-ranking/src/service.rs
+++ b/crates/tc-engine-ranking/src/service.rs
@@ -1,1 +1,462 @@
-// Ranking service layer — to be implemented in Task 7.
+//! Service layer for ranking operations.
+//!
+//! Orchestrates round lifecycle, submission validation, Glicko-2 rating updates,
+//! pair selection, and hall-of-fame snapshotting. All repos are function-based
+//! and called with `&self.pool`.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::glicko2;
+use crate::pair_selection::{select_pair, RatedSubmission};
+use crate::repo::{
+    hall_of_fame::{self, HallOfFameRecord},
+    matchups::{self, MatchupRecord},
+    ratings::{self, RatingRecord},
+    rounds::{self, RoundRecord, RoundStatus},
+    submissions::{self, ContentType, SubmissionRecord},
+};
+
+// ─── Error type ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum RankingError {
+    #[error("round not found")]
+    RoundNotFound,
+    #[error("no active submit round")]
+    NoActiveSubmitRound,
+    #[error("no active ranking round")]
+    NoActiveRankingRound,
+    #[error("already submitted this round")]
+    AlreadySubmitted,
+    #[error("not in submit phase")]
+    NotInSubmitPhase,
+    #[error("not in ranking phase")]
+    NotInRankingPhase,
+    #[error("cannot rank own submission")]
+    CannotRankOwn,
+    #[error("no more matchups available")]
+    NoMatchupsAvailable,
+    #[error("invalid matchup: submissions not in this round")]
+    InvalidMatchup,
+    #[error("internal error")]
+    Internal(#[from] anyhow::Error),
+}
+
+// Convenience conversion from sqlx::Error
+impl From<sqlx::Error> for RankingError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Internal(anyhow::anyhow!(e))
+    }
+}
+
+// ─── Service trait ──────────────────────────────────────────────────────────
+
+#[async_trait]
+pub trait RankingService: Send + Sync {
+    async fn create_round(
+        &self,
+        room_id: Uuid,
+        submit_opens_at: DateTime<Utc>,
+        rank_opens_at: DateTime<Utc>,
+        closes_at: DateTime<Utc>,
+    ) -> Result<RoundRecord, RankingError>;
+
+    async fn submit(
+        &self,
+        room_id: Uuid,
+        author_id: Uuid,
+        content_type: ContentType,
+        url: Option<&str>,
+        image_key: Option<&str>,
+        caption: Option<&str>,
+    ) -> Result<SubmissionRecord, RankingError>;
+
+    async fn get_next_matchup(
+        &self,
+        room_id: Uuid,
+        ranker_id: Uuid,
+    ) -> Result<Option<(SubmissionRecord, SubmissionRecord)>, RankingError>;
+
+    async fn record_matchup(
+        &self,
+        room_id: Uuid,
+        ranker_id: Uuid,
+        winner_id: Uuid,
+        loser_id: Uuid,
+    ) -> Result<MatchupRecord, RankingError>;
+
+    async fn skip_matchup(
+        &self,
+        room_id: Uuid,
+        ranker_id: Uuid,
+        submission_a: Uuid,
+        submission_b: Uuid,
+    ) -> Result<MatchupRecord, RankingError>;
+
+    async fn get_leaderboard(&self, round_id: Uuid) -> Result<Vec<RatingRecord>, RankingError>;
+
+    async fn get_hall_of_fame(
+        &self,
+        room_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<HallOfFameRecord>, RankingError>;
+
+    async fn open_ranking(&self, round_id: Uuid) -> Result<(), RankingError>;
+
+    async fn close_round(
+        &self,
+        round_id: Uuid,
+        hall_of_fame_depth: i32,
+    ) -> Result<(), RankingError>;
+
+    async fn get_current_rounds(&self, room_id: Uuid) -> Result<Vec<RoundRecord>, RankingError>;
+
+    async fn list_rounds(&self, room_id: Uuid) -> Result<Vec<RoundRecord>, RankingError>;
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────────
+
+pub struct DefaultRankingService {
+    pool: PgPool,
+}
+
+impl DefaultRankingService {
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+/// Find the active submitting round for a room, if one exists.
+async fn find_submitting_round(
+    pool: &PgPool,
+    room_id: Uuid,
+) -> Result<Option<RoundRecord>, RankingError> {
+    let rounds = rounds::get_current_rounds(pool, room_id).await?;
+    Ok(rounds
+        .into_iter()
+        .find(|r| matches!(r.status, RoundStatus::Submitting)))
+}
+
+/// Find the active ranking round for a room, if one exists.
+async fn find_ranking_round(
+    pool: &PgPool,
+    room_id: Uuid,
+) -> Result<Option<RoundRecord>, RankingError> {
+    let rounds = rounds::get_current_rounds(pool, room_id).await?;
+    Ok(rounds
+        .into_iter()
+        .find(|r| matches!(r.status, RoundStatus::Ranking)))
+}
+
+#[async_trait]
+impl RankingService for DefaultRankingService {
+    async fn create_round(
+        &self,
+        room_id: Uuid,
+        submit_opens_at: DateTime<Utc>,
+        rank_opens_at: DateTime<Utc>,
+        closes_at: DateTime<Utc>,
+    ) -> Result<RoundRecord, RankingError> {
+        let latest = rounds::get_latest_round_number(&self.pool, room_id).await?;
+        let round_number = latest + 1;
+        let record = rounds::create_round(
+            &self.pool,
+            room_id,
+            round_number,
+            submit_opens_at,
+            rank_opens_at,
+            closes_at,
+        )
+        .await?;
+        Ok(record)
+    }
+
+    async fn submit(
+        &self,
+        room_id: Uuid,
+        author_id: Uuid,
+        content_type: ContentType,
+        url: Option<&str>,
+        image_key: Option<&str>,
+        caption: Option<&str>,
+    ) -> Result<SubmissionRecord, RankingError> {
+        let round = find_submitting_round(&self.pool, room_id)
+            .await?
+            .ok_or(RankingError::NotInSubmitPhase)?;
+
+        if submissions::has_submitted(&self.pool, round.id, author_id).await? {
+            return Err(RankingError::AlreadySubmitted);
+        }
+
+        let record = submissions::create_submission(
+            &self.pool,
+            round.id,
+            author_id,
+            content_type,
+            url,
+            image_key,
+            caption,
+        )
+        .await?;
+        Ok(record)
+    }
+
+    async fn get_next_matchup(
+        &self,
+        room_id: Uuid,
+        ranker_id: Uuid,
+    ) -> Result<Option<(SubmissionRecord, SubmissionRecord)>, RankingError> {
+        let Some(round) = find_ranking_round(&self.pool, room_id).await? else {
+            return Ok(None);
+        };
+
+        let subs = submissions::list_submissions(&self.pool, round.id).await?;
+        let rating_records = ratings::get_ratings_for_round(&self.pool, round.id).await?;
+
+        // Build a lookup map from submission_id → rating record
+        let rating_map: std::collections::HashMap<Uuid, &RatingRecord> = rating_records
+            .iter()
+            .map(|r| (r.submission_id, r))
+            .collect();
+
+        // Build RatedSubmission vec — skip any submission without a rating row
+        let rated: Vec<RatedSubmission> = subs
+            .iter()
+            .filter_map(|s| {
+                rating_map.get(&s.id).map(|r| RatedSubmission {
+                    submission_id: s.id,
+                    author_id: s.author_id,
+                    rating: r.rating,
+                    deviation: r.deviation,
+                })
+            })
+            .collect();
+
+        let judged = matchups::get_judged_pairs(&self.pool, round.id, ranker_id).await?;
+
+        let pair = select_pair(&rated, &judged, ranker_id);
+        let Some((a_id, b_id)) = pair else {
+            return Ok(None);
+        };
+
+        // Look up the full submission records
+        let sub_map: std::collections::HashMap<Uuid, SubmissionRecord> =
+            subs.into_iter().map(|s| (s.id, s)).collect();
+
+        let sub_a = sub_map
+            .get(&a_id)
+            .cloned()
+            .ok_or_else(|| RankingError::Internal(anyhow::anyhow!("submission a missing")))?;
+        let sub_b = sub_map
+            .get(&b_id)
+            .cloned()
+            .ok_or_else(|| RankingError::Internal(anyhow::anyhow!("submission b missing")))?;
+
+        Ok(Some((sub_a, sub_b)))
+    }
+
+    async fn record_matchup(
+        &self,
+        room_id: Uuid,
+        ranker_id: Uuid,
+        winner_id: Uuid,
+        loser_id: Uuid,
+    ) -> Result<MatchupRecord, RankingError> {
+        let round = find_ranking_round(&self.pool, room_id)
+            .await?
+            .ok_or(RankingError::NotInRankingPhase)?;
+
+        // Validate both submissions belong to this round
+        let winner_sub = submissions::get_submission(&self.pool, winner_id)
+            .await?
+            .ok_or(RankingError::InvalidMatchup)?;
+        let loser_sub = submissions::get_submission(&self.pool, loser_id)
+            .await?
+            .ok_or(RankingError::InvalidMatchup)?;
+
+        if winner_sub.round_id != round.id || loser_sub.round_id != round.id {
+            return Err(RankingError::InvalidMatchup);
+        }
+
+        // Validate ranker is not the author of either submission
+        if winner_sub.author_id == ranker_id || loser_sub.author_id == ranker_id {
+            return Err(RankingError::CannotRankOwn);
+        }
+
+        // Load current ratings (use defaults if missing)
+        let winner_rating_rec = ratings::get_rating(&self.pool, winner_id).await?;
+        let loser_rating_rec = ratings::get_rating(&self.pool, loser_id).await?;
+
+        let mut winner_glicko = winner_rating_rec
+            .as_ref()
+            .map(|r| glicko2::Rating {
+                rating: r.rating,
+                deviation: r.deviation,
+                volatility: r.volatility,
+            })
+            .unwrap_or_default();
+
+        let mut loser_glicko = loser_rating_rec
+            .as_ref()
+            .map(|r| glicko2::Rating {
+                rating: r.rating,
+                deviation: r.deviation,
+                volatility: r.volatility,
+            })
+            .unwrap_or_default();
+
+        glicko2::update_ratings(&mut winner_glicko, &mut loser_glicko);
+
+        let winner_matchup_count = winner_rating_rec.as_ref().map_or(0, |r| r.matchup_count) + 1;
+        let loser_matchup_count = loser_rating_rec.as_ref().map_or(0, |r| r.matchup_count) + 1;
+
+        // Persist atomically: create matchup + update both ratings
+        let mut tx = self.pool.begin().await?;
+
+        let matchup = matchups::create_matchup(
+            &mut *tx,
+            round.id,
+            ranker_id,
+            winner_id,
+            loser_id,
+            Some(winner_id),
+        )
+        .await?;
+
+        ratings::update_rating(
+            &mut *tx,
+            winner_id,
+            winner_glicko.rating,
+            winner_glicko.deviation,
+            winner_glicko.volatility,
+            winner_matchup_count,
+        )
+        .await?;
+
+        ratings::update_rating(
+            &mut *tx,
+            loser_id,
+            loser_glicko.rating,
+            loser_glicko.deviation,
+            loser_glicko.volatility,
+            loser_matchup_count,
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(matchup)
+    }
+
+    async fn skip_matchup(
+        &self,
+        room_id: Uuid,
+        ranker_id: Uuid,
+        submission_a: Uuid,
+        submission_b: Uuid,
+    ) -> Result<MatchupRecord, RankingError> {
+        let round = find_ranking_round(&self.pool, room_id)
+            .await?
+            .ok_or(RankingError::NotInRankingPhase)?;
+
+        let matchup = matchups::create_matchup(
+            &self.pool,
+            round.id,
+            ranker_id,
+            submission_a,
+            submission_b,
+            None,
+        )
+        .await?;
+
+        Ok(matchup)
+    }
+
+    async fn get_leaderboard(&self, round_id: Uuid) -> Result<Vec<RatingRecord>, RankingError> {
+        let records = ratings::get_ratings_for_round(&self.pool, round_id).await?;
+        Ok(records)
+    }
+
+    async fn get_hall_of_fame(
+        &self,
+        room_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<HallOfFameRecord>, RankingError> {
+        let records = hall_of_fame::list_hall_of_fame(&self.pool, room_id, limit, offset).await?;
+        Ok(records)
+    }
+
+    async fn open_ranking(&self, round_id: Uuid) -> Result<(), RankingError> {
+        let round = rounds::get_round(&self.pool, round_id)
+            .await?
+            .ok_or(RankingError::RoundNotFound)?;
+
+        if !matches!(round.status, RoundStatus::Submitting) {
+            return Err(RankingError::NotInSubmitPhase);
+        }
+
+        // Initialize ratings for all submissions in this round
+        let subs = submissions::list_submissions(&self.pool, round_id).await?;
+        let sub_ids: Vec<Uuid> = subs.iter().map(|s| s.id).collect();
+        ratings::initialize_ratings(&self.pool, &sub_ids).await?;
+
+        rounds::update_round_status(&self.pool, round_id, RoundStatus::Ranking).await?;
+
+        Ok(())
+    }
+
+    async fn close_round(
+        &self,
+        round_id: Uuid,
+        hall_of_fame_depth: i32,
+    ) -> Result<(), RankingError> {
+        let round = rounds::get_round(&self.pool, round_id)
+            .await?
+            .ok_or(RankingError::RoundNotFound)?;
+
+        if !matches!(round.status, RoundStatus::Ranking) {
+            return Err(RankingError::NotInRankingPhase);
+        }
+
+        // Get ratings ordered by rating DESC
+        let rating_records = ratings::get_ratings_for_round(&self.pool, round_id).await?;
+
+        // Take top N and build winners list: (submission_id, final_rating, rank).
+        // hall_of_fame_depth is validated as non-negative by callers; a depth of 0 or
+        // negative simply produces an empty list.
+        let depth = usize::try_from(hall_of_fame_depth).unwrap_or(0);
+        let winners: Vec<(Uuid, f64, i32)> = rating_records
+            .iter()
+            .take(depth)
+            .enumerate()
+            .map(|(i, r)| {
+                // i is bounded by `depth` which fits in i32 for any realistic hall_of_fame_depth
+                #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                let rank = (i + 1) as i32;
+                (r.submission_id, r.rating, rank)
+            })
+            .collect();
+
+        hall_of_fame::insert_winners(&self.pool, round.room_id, round_id, &winners).await?;
+
+        rounds::update_round_status(&self.pool, round_id, RoundStatus::Closed).await?;
+
+        Ok(())
+    }
+
+    async fn get_current_rounds(&self, room_id: Uuid) -> Result<Vec<RoundRecord>, RankingError> {
+        let records = rounds::get_current_rounds(&self.pool, room_id).await?;
+        Ok(records)
+    }
+
+    async fn list_rounds(&self, room_id: Uuid) -> Result<Vec<RoundRecord>, RankingError> {
+        let records = rounds::list_rounds(&self.pool, room_id).await?;
+        Ok(records)
+    }
+}

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -72,6 +72,7 @@ urlencoding = "2"
 # Engine plugin API
 tc-engine-api = { path = "../crates/tc-engine-api", version = "0.1.0" }
 tc-engine-polling = { path = "../crates/tc-engine-polling", version = "0.1.0" }
+tc-engine-ranking = { path = "../crates/tc-engine-ranking", version = "0.1.0" }
 tc-llm = { path = "../crates/tc-llm", version = "0.1.0" }
 
 # Cryptography
@@ -117,7 +118,7 @@ path = "src/bin/tc_ops.rs"
 
 # cargo-machete false positives (used via derive macros or wired in follow-up tasks)
 [package.metadata.cargo-machete]
-ignored = ["serde", "thiserror", "async-trait", "utoipa", "tc-engine-polling"]
+ignored = ["serde", "thiserror", "async-trait", "utoipa", "tc-engine-polling", "tc-engine-ranking"]
 
 [lints]
 workspace = true

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -10,7 +10,7 @@ test-utils = []
 
 [dependencies]
 # Web server
-axum = "0.8"
+axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "time"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }

--- a/service/migrations/29_ranking_tables.sql
+++ b/service/migrations/29_ranking_tables.sql
@@ -1,0 +1,95 @@
+-- Migration 29: Ranking tables for the meme ranking engine.
+--
+-- Adds tables for daily tournament rounds, submissions, pairwise matchups,
+-- Glicko-2 ratings, and a hall of fame for daily winners.
+
+-- Enums
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ranking_round_status') THEN
+        CREATE TYPE ranking_round_status AS ENUM ('submitting', 'ranking', 'closed');
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'submission_content_type') THEN
+        CREATE TYPE submission_content_type AS ENUM ('url', 'image');
+    END IF;
+END $$;
+
+-- One row per daily tournament cycle.
+CREATE TABLE IF NOT EXISTS rooms__rounds (
+    id              UUID                 PRIMARY KEY DEFAULT gen_random_uuid(),
+    room_id         UUID                 NOT NULL REFERENCES rooms__rooms(id) ON DELETE CASCADE,
+    round_number    INT                  NOT NULL,
+    submit_opens_at TIMESTAMPTZ          NOT NULL,
+    rank_opens_at   TIMESTAMPTZ          NOT NULL,
+    closes_at       TIMESTAMPTZ          NOT NULL,
+    status          ranking_round_status NOT NULL DEFAULT 'submitting',
+    created_at      TIMESTAMPTZ          NOT NULL DEFAULT now(),
+    CONSTRAINT uq_rounds_room_number UNIQUE (room_id, round_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rounds_room_status ON rooms__rounds (room_id, status);
+
+-- One meme submission per user per round.
+CREATE TABLE IF NOT EXISTS rooms__submissions (
+    id           UUID                   PRIMARY KEY DEFAULT gen_random_uuid(),
+    round_id     UUID                   NOT NULL REFERENCES rooms__rounds(id) ON DELETE CASCADE,
+    author_id    UUID                   NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    content_type submission_content_type NOT NULL,
+    url          TEXT,
+    image_key    TEXT,
+    caption      TEXT,
+    created_at   TIMESTAMPTZ            NOT NULL DEFAULT now(),
+    CONSTRAINT uq_submissions_round_author UNIQUE (round_id, author_id),
+    CONSTRAINT chk_submissions_url_requires_url
+        CHECK (content_type <> 'url' OR url IS NOT NULL),
+    CONSTRAINT chk_submissions_image_requires_key
+        CHECK (content_type <> 'image' OR image_key IS NOT NULL)
+);
+
+-- Every pairwise comparison a ranker makes within a round.
+CREATE TABLE IF NOT EXISTS rooms__matchups (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    round_id     UUID        NOT NULL REFERENCES rooms__rounds(id) ON DELETE CASCADE,
+    ranker_id    UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    submission_a UUID        NOT NULL REFERENCES rooms__submissions(id) ON DELETE CASCADE,
+    submission_b UUID        NOT NULL REFERENCES rooms__submissions(id) ON DELETE CASCADE,
+    winner_id    UUID        REFERENCES rooms__submissions(id) ON DELETE SET NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_matchups_ordered_pair CHECK (submission_a < submission_b),
+    CONSTRAINT uq_matchups_round_ranker_pair UNIQUE (round_id, ranker_id, submission_a, submission_b)
+);
+
+CREATE INDEX IF NOT EXISTS idx_matchups_round         ON rooms__matchups (round_id);
+CREATE INDEX IF NOT EXISTS idx_matchups_round_ranker  ON rooms__matchups (round_id, ranker_id);
+
+-- Glicko-2 rating state per submission, updated after each round closes.
+CREATE TABLE IF NOT EXISTS rooms__ratings (
+    submission_id UUID            PRIMARY KEY REFERENCES rooms__submissions(id) ON DELETE CASCADE,
+    rating        DOUBLE PRECISION NOT NULL DEFAULT 1500.0,
+    deviation     DOUBLE PRECISION NOT NULL DEFAULT 350.0,
+    volatility    DOUBLE PRECISION NOT NULL DEFAULT 0.06,
+    matchup_count INT              NOT NULL DEFAULT 0
+);
+
+-- Daily winners archive.
+CREATE TABLE IF NOT EXISTS rooms__hall_of_fame (
+    id            UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    room_id       UUID            NOT NULL REFERENCES rooms__rooms(id) ON DELETE CASCADE,
+    round_id      UUID            NOT NULL REFERENCES rooms__rounds(id) ON DELETE CASCADE,
+    submission_id UUID            NOT NULL REFERENCES rooms__submissions(id) ON DELETE CASCADE,
+    final_rating  DOUBLE PRECISION NOT NULL,
+    rank          INT              NOT NULL,
+    created_at    TIMESTAMPTZ      NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hall_of_fame_room_created
+    ON rooms__hall_of_fame (room_id, created_at DESC);
+
+-- pgmq queue for ranking lifecycle events (round transitions, rating jobs).
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pgmq.meta WHERE queue_name = 'rooms__ranking_lifecycle') THEN
+        PERFORM pgmq.create('rooms__ranking_lifecycle');
+    END IF;
+END $$;

--- a/service/src/identity/http/auth.rs
+++ b/service/src/identity/http/auth.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum::{
     body::Bytes,
-    extract::{FromRequest, Request},
+    extract::{FromRequest, FromRequestParts, Request},
+    http::request::Parts,
     response::Response,
 };
 use sha2::{Digest, Sha256};
@@ -265,6 +266,149 @@ impl<S: Send + Sync> FromRequest<S> for AuthenticatedDevice {
             account_id: device.account_id,
             device_kid: kid,
             body_bytes,
+        })
+    }
+}
+
+// ─── Parts-only auth extractor (for multipart/form-data handlers) ────────────
+
+/// Authenticated device extracted from request headers only (no body read).
+///
+/// Unlike [`AuthenticatedDevice`], this extractor implements [`FromRequestParts`]
+/// and does **not** consume the request body.  The signature is verified over an
+/// empty body hash, so the frontend must sign the canonical message with an empty
+/// body string when using multipart upload endpoints.
+///
+/// Use this in handlers that also extract [`axum::extract::Multipart`] because
+/// Axum only allows one [`FromRequest`] (body-consuming) extractor per handler.
+pub struct AuthenticatedDeviceParts {
+    pub account_id: Uuid,
+    pub device_kid: tc_crypto::Kid,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for AuthenticatedDeviceParts {
+    type Rejection = Response;
+
+    #[allow(clippy::too_many_lines)]
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let repo = parts
+            .extensions
+            .get::<Arc<dyn IdentityRepo>>()
+            .ok_or_else(|| auth_error("Server misconfiguration"))?
+            .clone();
+
+        let kid_str = parts
+            .headers
+            .get("X-Device-Kid")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| auth_error("Missing X-Device-Kid header"))?
+            .to_string();
+
+        let signature_str = parts
+            .headers
+            .get("X-Signature")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| auth_error("Missing X-Signature header"))?
+            .to_string();
+
+        let timestamp_str = parts
+            .headers
+            .get("X-Timestamp")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| auth_error("Missing X-Timestamp header"))?
+            .to_string();
+
+        let nonce = parts
+            .headers
+            .get("X-Nonce")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| auth_error("Missing X-Nonce header"))?
+            .to_string();
+
+        if let Err(msg) = validate_nonce(&nonce) {
+            return Err(auth_error(msg));
+        }
+
+        let kid: tc_crypto::Kid = kid_str
+            .parse()
+            .map_err(|_| auth_error("Invalid KID format"))?;
+
+        let timestamp: i64 = timestamp_str
+            .parse()
+            .map_err(|_| auth_error("Invalid timestamp"))?;
+
+        let now = chrono::Utc::now().timestamp();
+        if super::timestamp_is_stale(now, timestamp) {
+            return Err(auth_error("Timestamp out of range"));
+        }
+
+        let sig_bytes = tc_crypto::decode_base64url(&signature_str)
+            .map_err(|_| auth_error("Invalid signature encoding"))?;
+        let sig_arr: [u8; 64] = sig_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| auth_error("Signature must be 64 bytes"))?;
+
+        let method = parts.method.to_string();
+        let path = parts.uri.path_and_query().map_or_else(
+            || parts.uri.path().to_string(),
+            |pq| pq.as_str().to_string(),
+        );
+
+        // Verify signature over empty body (canonical message with empty body hash).
+        let empty_hash = Sha256::digest(b"");
+        let empty_hash_hex = format!("{empty_hash:x}");
+        let canonical = format!("{method}\n{path}\n{timestamp}\n{nonce}\n{empty_hash_hex}");
+
+        let device = repo
+            .get_device_key_by_kid(&kid)
+            .await
+            .map_err(|e| match e {
+                DeviceKeyRepoError::NotFound => auth_error("Device not found"),
+                DeviceKeyRepoError::Database(db_err) => {
+                    tracing::error!("Auth device lookup failed: {db_err}");
+                    auth_error("Authentication failed")
+                }
+                DeviceKeyRepoError::DuplicateKid
+                | DeviceKeyRepoError::AlreadyRevoked
+                | DeviceKeyRepoError::MaxDevicesReached => {
+                    tracing::error!("Unexpected repo error during auth lookup: {e}");
+                    auth_error("Authentication failed")
+                }
+            })?;
+
+        let device_pubkey = DevicePubkey::from_base64url(&device.device_pubkey)
+            .map_err(|_| auth_error("Corrupted device key"))?;
+
+        tc_crypto::verify_ed25519(device_pubkey.as_bytes(), canonical.as_bytes(), &sig_arr)
+            .map_err(|_| auth_error("Invalid signature"))?;
+
+        let nonce_hash = Sha256::digest(nonce.as_bytes());
+        repo.check_and_record_nonce(&nonce_hash)
+            .await
+            .map_err(|e| match e {
+                NonceRepoError::Replay => auth_error("Duplicate nonce (possible replay)"),
+                NonceRepoError::Database(db_err) => {
+                    tracing::error!("Nonce check failed: {db_err}");
+                    auth_error("Authentication failed")
+                }
+            })?;
+
+        if device.revoked_at.is_some() {
+            return Err(super::forbidden("Device has been revoked"));
+        }
+
+        let touch_kid = kid.clone();
+        let touch_repo = repo;
+        tokio::spawn(async move {
+            if let Err(e) = touch_repo.touch_device_key(&touch_kid).await {
+                tracing::warn!("Failed to touch device {touch_kid}: {e}");
+            }
+        });
+
+        Ok(Self {
+            account_id: device.account_id,
+            device_kid: kid,
         })
     }
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -18,4 +18,5 @@ pub mod reputation;
 pub mod rest;
 pub mod rooms;
 pub mod sim;
+pub mod storage;
 pub mod trust;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -25,6 +25,8 @@ use tc_engine_api::constraints::ConstraintRegistry;
 use tc_engine_api::engine::{EngineContext, EngineRegistry};
 use tc_engine_polling::engine::PollingEngine;
 use tc_engine_polling::service::{DefaultPollingService, PollingService};
+use tc_engine_ranking::engine::RankingEngine;
+use tc_engine_ranking::service::{DefaultRankingService, RankingService};
 use tinycongress_api::{
     build_info::BuildInfo,
     config::Config,
@@ -224,6 +226,7 @@ async fn build_app(
     // Register room engine plugins
     let mut engine_registry = EngineRegistry::new();
     engine_registry.register(PollingEngine::new());
+    engine_registry.register(RankingEngine::new());
 
     // Start background tasks for all registered engines
     // TODO: Store engine handles in app state and join them during graceful shutdown.
@@ -263,6 +266,10 @@ async fn build_app(
     let polling_service = Arc::new(DefaultPollingService::new(pool.clone(), trust_graph_reader))
         as Arc<dyn PollingService>;
 
+    // Ranking wiring
+    let ranking_service =
+        Arc::new(DefaultRankingService::new(pool.clone())) as Arc<dyn RankingService>;
+
     let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
 
     let app = Router::new()
@@ -294,6 +301,7 @@ async fn build_app(
         .layer(Extension(reputation_repo_ext))
         .layer(Extension(rooms_service))
         .layer(Extension(polling_service))
+        .layer(Extension(ranking_service))
         .layer(Extension(trust_service))
         .layer(Extension(trust_repo_for_http))
         .layer(Extension(trust_engine.clone()))

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -48,9 +48,11 @@ use tinycongress_api::{
     rooms::{
         self,
         content_filter::{ContentFilter, NoopFilter},
+        http::serve_upload,
         repo::{PgRoomsRepo, RoomsRepo},
         service::{DefaultRoomsService, RoomsService},
     },
+    storage::{LocalFileStore, ObjectStore},
     trust::{
         self,
         engine::TrustEngine,
@@ -163,7 +165,16 @@ async fn build_app(
     schema: Schema<QueryRoot, MutationRoot, EmptySubscription>,
     allow_origin: AllowOrigin,
 ) -> Result<(Router, PgPool), anyhow::Error> {
-    let rest_v1 = Router::new().route("/build-info", get(rest::get_build_info));
+    // Object store for uploaded files
+    let upload_dir = std::env::var("TC_UPLOAD_DIR").unwrap_or_else(|_| "./uploads".to_string());
+    let object_store: Arc<dyn ObjectStore> = Arc::new(
+        LocalFileStore::new(upload_dir.into(), "/api/v1/uploads")
+            .map_err(|e| anyhow::anyhow!("failed to create upload directory: {e}"))?,
+    );
+
+    let rest_v1 = Router::new()
+        .route("/build-info", get(rest::get_build_info))
+        .route("/uploads/{*key}", get(serve_upload));
 
     // Identity wiring
     let repo = Arc::new(PgIdentityRepo::new(pool.clone()));
@@ -310,7 +321,8 @@ async fn build_app(
         .layer(Extension(pool.clone()))
         .layer(Extension(engine_registry))
         .layer(Extension(engine_ctx))
-        .layer(Extension(Arc::new(NoopFilter) as Arc<dyn ContentFilter>));
+        .layer(Extension(Arc::new(NoopFilter) as Arc<dyn ContentFilter>))
+        .layer(Extension(object_store));
 
     // Add ID.me config extension if configured
     let app = if let Some(ref idme_config) = config.idme {

--- a/service/src/rest.rs
+++ b/service/src/rest.rs
@@ -135,6 +135,14 @@ impl IntoResponse for ProblemDetails {
         crate::rooms::http::polling::get_distribution,
         crate::rooms::http::polling::my_votes,
         crate::rooms::http::polling::get_poll_traces,
+        // Rooms (ranking)
+        crate::rooms::http::ranking::submit_meme,
+        crate::rooms::http::ranking::get_matchup,
+        crate::rooms::http::ranking::record_matchup,
+        crate::rooms::http::ranking::get_leaderboard,
+        crate::rooms::http::ranking::get_hall_of_fame,
+        crate::rooms::http::ranking::list_rounds,
+        crate::rooms::http::ranking::get_current_rounds,
     ),
     components(schemas(
         BuildInfo,
@@ -201,6 +209,18 @@ impl IntoResponse for ProblemDetails {
         crate::rooms::http::polling::PollStatusTransition,
         crate::rooms::http::polling::CreateEvidenceBody,
         crate::rooms::http::polling::EvidenceItem,
+        // Ranking schemas
+        crate::rooms::http::ranking::SubmitMemeRequest,
+        crate::rooms::http::ranking::SubmissionResponse,
+        crate::rooms::http::ranking::SubmissionWithAuthorResponse,
+        crate::rooms::http::ranking::MatchupResponse,
+        crate::rooms::http::ranking::RecordMatchupRequest,
+        crate::rooms::http::ranking::MatchupResultResponse,
+        crate::rooms::http::ranking::LeaderboardEntry,
+        crate::rooms::http::ranking::LeaderboardResponse,
+        crate::rooms::http::ranking::RoundResponse,
+        crate::rooms::http::ranking::HallOfFameEntryResponse,
+        crate::rooms::http::ranking::PaginationParams,
     ))
 )]
 pub struct ApiDoc;

--- a/service/src/rooms/http/mod.rs
+++ b/service/src/rooms/http/mod.rs
@@ -6,6 +6,7 @@
 
 pub(crate) mod platform;
 pub(crate) mod polling;
+pub(crate) mod ranking;
 
 use axum::{
     routing::{delete, get, patch, post},
@@ -201,5 +202,34 @@ pub fn router() -> Router {
         .route(
             "/rooms/{room_id}/polls/{poll_id}/traces",
             get(polling::get_poll_traces),
+        )
+        // Ranking engine routes
+        .route(
+            "/rooms/{room_id}/submissions",
+            post(ranking::submit_meme),
+        )
+        .route(
+            "/rooms/{room_id}/matchup",
+            get(ranking::get_matchup),
+        )
+        .route(
+            "/rooms/{room_id}/matchups",
+            post(ranking::record_matchup),
+        )
+        .route(
+            "/rooms/{room_id}/rounds/current",
+            get(ranking::get_current_rounds),
+        )
+        .route(
+            "/rooms/{room_id}/rounds",
+            get(ranking::list_rounds),
+        )
+        .route(
+            "/rooms/{room_id}/rounds/{round_id}/leaderboard",
+            get(ranking::get_leaderboard),
+        )
+        .route(
+            "/rooms/{room_id}/hall-of-fame",
+            get(ranking::get_hall_of_fame),
         )
 }

--- a/service/src/rooms/http/mod.rs
+++ b/service/src/rooms/http/mod.rs
@@ -9,19 +9,21 @@ pub(crate) mod polling;
 pub(crate) mod ranking;
 
 use axum::{
+    extract::DefaultBodyLimit,
     routing::{delete, get, patch, post},
     Router,
 };
 use serde::Deserialize;
 use utoipa::ToSchema;
 
-// Re-export response/request types that external code depends on
+// Re-export handlers/types that external code depends on
 pub use polling::{
     BucketResponse, CreateDimensionRequest, CreateEvidenceBody, CreatePollRequest,
     DimensionDetailResponse, DimensionDistributionResponse, DimensionResponse,
     DimensionStatsResponse, EvidenceItem, EvidenceResponse, PollDistributionResponse, PollResponse,
     PollResultsResponse, PollStatusRequest, VoteResponse,
 };
+pub use ranking::serve_upload;
 
 // ─── Request types (platform-level) ───────────────────────────────────────
 
@@ -207,6 +209,10 @@ pub fn router() -> Router {
         .route(
             "/rooms/{room_id}/submissions",
             post(ranking::submit_meme),
+        )
+        .route(
+            "/rooms/{room_id}/submissions/upload",
+            post(ranking::submit_meme_upload).layer(DefaultBodyLimit::max(6 * 1024 * 1024)),
         )
         .route(
             "/rooms/{room_id}/matchup",

--- a/service/src/rooms/http/ranking.rs
+++ b/service/src/rooms/http/ranking.rs
@@ -1,0 +1,621 @@
+// lint-patterns:allow-raw-pool — leaderboard and hall-of-fame need direct SQL joins
+//! HTTP handlers for ranking-engine-specific operations.
+//!
+//! Covers submissions, matchups, leaderboard, hall of fame, and rounds.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{extract::Extension, extract::Query, http::StatusCode, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use tc_engine_ranking::repo::rounds::{RoundRecord, RoundStatus};
+use tc_engine_ranking::repo::submissions::{ContentType, SubmissionRecord};
+use tc_engine_ranking::service::{RankingError, RankingService};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::http::{bad_request, conflict, forbidden, internal_error, not_found, Path};
+use crate::identity::http::auth::AuthenticatedDevice;
+
+// ─── Response types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SubmissionResponse {
+    pub id: String,
+    pub round_id: String,
+    pub content_type: String,
+    pub url: Option<String>,
+    pub image_key: Option<String>,
+    pub caption: Option<String>,
+    pub created_at: String,
+    // author_id intentionally omitted — anonymous during ranking
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SubmissionWithAuthorResponse {
+    pub id: String,
+    pub round_id: String,
+    pub author_id: String,
+    pub content_type: String,
+    pub url: Option<String>,
+    pub image_key: Option<String>,
+    pub caption: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MatchupResponse {
+    pub submission_a: SubmissionResponse,
+    pub submission_b: SubmissionResponse,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MatchupResultResponse {
+    pub id: String,
+    pub winner_id: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LeaderboardEntry {
+    pub submission: SubmissionResponse,
+    pub rating: f64,
+    pub deviation: f64,
+    pub matchup_count: i32,
+    pub rank: i32,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LeaderboardResponse {
+    pub round_id: String,
+    pub round_status: String,
+    pub entries: Vec<LeaderboardEntry>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RoundResponse {
+    pub id: String,
+    pub room_id: String,
+    pub round_number: i32,
+    pub submit_opens_at: String,
+    pub rank_opens_at: String,
+    pub closes_at: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct HallOfFameEntryResponse {
+    pub submission: SubmissionWithAuthorResponse,
+    pub round_number: i32,
+    pub final_rating: f64,
+    pub rank: i32,
+}
+
+// ─── Request types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SubmitMemeRequest {
+    pub content_type: String,
+    pub url: Option<String>,
+    pub image_key: Option<String>,
+    pub caption: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RecordMatchupRequest {
+    pub winner_id: Option<String>,
+    pub loser_id: Option<String>,
+    pub submission_a: Option<String>,
+    pub submission_b: Option<String>,
+    pub skipped: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PaginationParams {
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    #[serde(default)]
+    pub offset: i64,
+}
+
+const fn default_limit() -> i64 {
+    20
+}
+
+// ─── Converters ───────────────────────────────────────────────────────────────
+
+const fn content_type_to_str(ct: &ContentType) -> &'static str {
+    match ct {
+        ContentType::Url => "url",
+        ContentType::Image => "image",
+    }
+}
+
+fn submission_to_response(s: &SubmissionRecord) -> SubmissionResponse {
+    SubmissionResponse {
+        id: s.id.to_string(),
+        round_id: s.round_id.to_string(),
+        content_type: content_type_to_str(&s.content_type).to_string(),
+        url: s.url.clone(),
+        image_key: s.image_key.clone(),
+        caption: s.caption.clone(),
+        created_at: s.created_at.to_rfc3339(),
+    }
+}
+
+fn submission_to_response_with_author(s: &SubmissionRecord) -> SubmissionWithAuthorResponse {
+    SubmissionWithAuthorResponse {
+        id: s.id.to_string(),
+        round_id: s.round_id.to_string(),
+        author_id: s.author_id.to_string(),
+        content_type: content_type_to_str(&s.content_type).to_string(),
+        url: s.url.clone(),
+        image_key: s.image_key.clone(),
+        caption: s.caption.clone(),
+        created_at: s.created_at.to_rfc3339(),
+    }
+}
+
+const fn round_status_to_str(status: &RoundStatus) -> &'static str {
+    match status {
+        RoundStatus::Submitting => "submitting",
+        RoundStatus::Ranking => "ranking",
+        RoundStatus::Closed => "closed",
+    }
+}
+
+fn round_to_response(r: &RoundRecord) -> RoundResponse {
+    RoundResponse {
+        id: r.id.to_string(),
+        room_id: r.room_id.to_string(),
+        round_number: r.round_number,
+        submit_opens_at: r.submit_opens_at.to_rfc3339(),
+        rank_opens_at: r.rank_opens_at.to_rfc3339(),
+        closes_at: r.closes_at.to_rfc3339(),
+        status: round_status_to_str(&r.status).to_string(),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn parse_content_type(s: &str) -> Result<ContentType, axum::response::Response> {
+    match s {
+        "url" => Ok(ContentType::Url),
+        "image" => Ok(ContentType::Image),
+        other => Err(bad_request(&format!("unknown content_type: {other}"))),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn parse_uuid(s: &str, field: &str) -> Result<Uuid, axum::response::Response> {
+    s.parse::<Uuid>()
+        .map_err(|_| bad_request(&format!("invalid UUID for {field}")))
+}
+
+fn ranking_error_response(e: RankingError) -> axum::response::Response {
+    match e {
+        RankingError::AlreadySubmitted => conflict("already submitted this round"),
+        RankingError::NotInSubmitPhase | RankingError::NoActiveSubmitRound => {
+            bad_request("not in submit phase")
+        }
+        RankingError::NotInRankingPhase | RankingError::NoActiveRankingRound => {
+            bad_request("not in ranking phase")
+        }
+        RankingError::CannotRankOwn => forbidden("cannot rank your own submission"),
+        RankingError::NoMatchupsAvailable => not_found("no matchups available"),
+        RankingError::InvalidMatchup => {
+            bad_request("invalid matchup: submissions not in this round")
+        }
+        RankingError::RoundNotFound => not_found("round not found"),
+        RankingError::Internal(inner) => {
+            tracing::error!("Ranking service internal error: {inner}");
+            internal_error()
+        }
+    }
+}
+
+// ─── Submission handlers ──────────────────────────────────────────────────────
+
+/// Submit a meme to the current round
+#[utoipa::path(
+    post,
+    path = "/rooms/{room_id}/submissions",
+    tag = "Ranking",
+    params(("room_id" = String, Path, description = "Room ID")),
+    request_body = SubmitMemeRequest,
+    responses(
+        (status = 201, description = "Submission created", body = SubmissionResponse),
+        (status = 400, description = "Invalid request or not in submit phase"),
+        (status = 409, description = "Already submitted this round"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn submit_meme(
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+    Path(room_id): Path<Uuid>,
+    auth: AuthenticatedDevice,
+) -> impl IntoResponse {
+    let req: SubmitMemeRequest = match auth.json() {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let content_type = match parse_content_type(&req.content_type) {
+        Ok(ct) => ct,
+        Err(resp) => return resp,
+    };
+
+    match ranking_service
+        .submit(
+            room_id,
+            auth.account_id,
+            content_type,
+            req.url.as_deref(),
+            req.image_key.as_deref(),
+            req.caption.as_deref(),
+        )
+        .await
+    {
+        Ok(sub) => (StatusCode::CREATED, Json(submission_to_response(&sub))).into_response(),
+        Err(e) => ranking_error_response(e),
+    }
+}
+
+// ─── Matchup handlers ─────────────────────────────────────────────────────────
+
+/// Get the next matchup pair to judge
+#[utoipa::path(
+    get,
+    path = "/rooms/{room_id}/matchup",
+    tag = "Ranking",
+    params(("room_id" = String, Path, description = "Room ID")),
+    responses(
+        (status = 200, description = "Next matchup pair", body = MatchupResponse),
+        (status = 404, description = "No matchups available"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn get_matchup(
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+    Path(room_id): Path<Uuid>,
+    auth: AuthenticatedDevice,
+) -> impl IntoResponse {
+    match ranking_service
+        .get_next_matchup(room_id, auth.account_id)
+        .await
+    {
+        Ok(Some((sub_a, sub_b))) => {
+            let response = MatchupResponse {
+                submission_a: submission_to_response(&sub_a),
+                submission_b: submission_to_response(&sub_b),
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Ok(None) => not_found("no matchups available"),
+        Err(e) => ranking_error_response(e),
+    }
+}
+
+/// Record a matchup judgment (win/loss or skip)
+#[utoipa::path(
+    post,
+    path = "/rooms/{room_id}/matchups",
+    tag = "Ranking",
+    params(("room_id" = String, Path, description = "Room ID")),
+    request_body = RecordMatchupRequest,
+    responses(
+        (status = 201, description = "Matchup recorded", body = MatchupResultResponse),
+        (status = 400, description = "Invalid request or not in ranking phase"),
+        (status = 403, description = "Cannot rank own submission"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn record_matchup(
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+    Path(room_id): Path<Uuid>,
+    auth: AuthenticatedDevice,
+) -> impl IntoResponse {
+    let req: RecordMatchupRequest = match auth.json() {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let result = if req.skipped == Some(true) {
+        let Some(a_str) = req.submission_a.as_deref() else {
+            return bad_request("submission_a required for skip");
+        };
+        let Some(b_str) = req.submission_b.as_deref() else {
+            return bad_request("submission_b required for skip");
+        };
+        let sub_a = match parse_uuid(a_str, "submission_a") {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
+        let sub_b = match parse_uuid(b_str, "submission_b") {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
+        ranking_service
+            .skip_matchup(room_id, auth.account_id, sub_a, sub_b)
+            .await
+    } else {
+        let Some(winner_str) = req.winner_id.as_deref() else {
+            return bad_request("winner_id required");
+        };
+        let Some(loser_str) = req.loser_id.as_deref() else {
+            return bad_request("loser_id required");
+        };
+        let winner_id = match parse_uuid(winner_str, "winner_id") {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
+        let loser_id = match parse_uuid(loser_str, "loser_id") {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
+        ranking_service
+            .record_matchup(room_id, auth.account_id, winner_id, loser_id)
+            .await
+    };
+
+    match result {
+        Ok(matchup) => {
+            let response = MatchupResultResponse {
+                id: matchup.id.to_string(),
+                winner_id: matchup.winner_id.map(|id| id.to_string()),
+                created_at: matchup.created_at.to_rfc3339(),
+            };
+            (StatusCode::CREATED, Json(response)).into_response()
+        }
+        Err(e) => ranking_error_response(e),
+    }
+}
+
+// ─── Leaderboard handler ──────────────────────────────────────────────────────
+
+/// Get the leaderboard for a specific round
+#[utoipa::path(
+    get,
+    path = "/rooms/{room_id}/rounds/{round_id}/leaderboard",
+    tag = "Ranking",
+    params(
+        ("room_id" = String, Path, description = "Room ID"),
+        ("round_id" = String, Path, description = "Round ID"),
+    ),
+    responses(
+        (status = 200, description = "Leaderboard for the round", body = LeaderboardResponse),
+        (status = 404, description = "Round not found"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn get_leaderboard(
+    Path((_room_id, round_id)): Path<(Uuid, Uuid)>,
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+    Extension(pool): Extension<PgPool>,
+) -> impl IntoResponse {
+    // Fetch the round to get status and room_id
+    let round: Option<RoundRecord> = match sqlx::query_as::<_, RoundRecord>(
+        r"
+        SELECT id, room_id, round_number, submit_opens_at, rank_opens_at, closes_at,
+               status, created_at
+        FROM rooms__rounds
+        WHERE id = $1
+        ",
+    )
+    .bind(round_id)
+    .fetch_optional(&pool)
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to fetch round {round_id}: {e}");
+            return internal_error();
+        }
+    };
+
+    let Some(round) = round else {
+        return not_found("round not found");
+    };
+
+    // Fetch rating records ordered by rating DESC
+    let ratings = match ranking_service.get_leaderboard(round_id).await {
+        Ok(r) => r,
+        Err(e) => return ranking_error_response(e),
+    };
+
+    // Fetch all submissions for this round to join with ratings
+    let submissions: Vec<SubmissionRecord> = match sqlx::query_as::<_, SubmissionRecord>(
+        r"
+        SELECT id, round_id, author_id, content_type, url, image_key, caption, created_at
+        FROM rooms__submissions
+        WHERE round_id = $1
+        ORDER BY created_at ASC
+        ",
+    )
+    .bind(round_id)
+    .fetch_all(&pool)
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Failed to fetch submissions for round {round_id}: {e}");
+            return internal_error();
+        }
+    };
+
+    let sub_map: HashMap<Uuid, &SubmissionRecord> = submissions.iter().map(|s| (s.id, s)).collect();
+
+    let entries: Vec<LeaderboardEntry> = ratings
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| {
+            let sub = sub_map.get(&r.submission_id)?;
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            let rank = (i + 1) as i32;
+            Some(LeaderboardEntry {
+                submission: submission_to_response(sub),
+                rating: r.rating,
+                deviation: r.deviation,
+                matchup_count: r.matchup_count,
+                rank,
+            })
+        })
+        .collect();
+
+    let response = LeaderboardResponse {
+        round_id: round_id.to_string(),
+        round_status: round_status_to_str(&round.status).to_string(),
+        entries,
+    };
+
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+// ─── Hall of fame handler ─────────────────────────────────────────────────────
+
+/// Get hall of fame entries for a room
+#[utoipa::path(
+    get,
+    path = "/rooms/{room_id}/hall-of-fame",
+    tag = "Ranking",
+    params(
+        ("room_id" = String, Path, description = "Room ID"),
+        ("limit" = Option<i64>, Query, description = "Max entries to return (default 20)"),
+        ("offset" = Option<i64>, Query, description = "Offset for pagination (default 0)"),
+    ),
+    responses(
+        (status = 200, description = "Hall of fame entries", body = Vec<HallOfFameEntryResponse>),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn get_hall_of_fame(
+    Path(room_id): Path<Uuid>,
+    Query(params): Query<PaginationParams>,
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+    Extension(pool): Extension<PgPool>,
+) -> impl IntoResponse {
+    let hof_records = match ranking_service
+        .get_hall_of_fame(room_id, params.limit, params.offset)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return ranking_error_response(e),
+    };
+
+    if hof_records.is_empty() {
+        return (StatusCode::OK, Json(Vec::<HallOfFameEntryResponse>::new())).into_response();
+    }
+
+    // Collect submission IDs and round IDs needed for enrichment
+    let sub_ids: Vec<Uuid> = hof_records.iter().map(|h| h.submission_id).collect();
+    let round_ids: Vec<Uuid> = hof_records.iter().map(|h| h.round_id).collect();
+
+    // Fetch all relevant submissions in one query
+    let submissions: Vec<SubmissionRecord> = match sqlx::query_as::<_, SubmissionRecord>(
+        r"
+        SELECT id, round_id, author_id, content_type, url, image_key, caption, created_at
+        FROM rooms__submissions
+        WHERE id = ANY($1)
+        ",
+    )
+    .bind(&sub_ids)
+    .fetch_all(&pool)
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Failed to fetch submissions for hall of fame: {e}");
+            return internal_error();
+        }
+    };
+
+    let sub_map: HashMap<Uuid, &SubmissionRecord> = submissions.iter().map(|s| (s.id, s)).collect();
+
+    // Fetch round numbers for display
+    let rounds: Vec<RoundRecord> = match sqlx::query_as::<_, RoundRecord>(
+        r"
+        SELECT id, room_id, round_number, submit_opens_at, rank_opens_at, closes_at,
+               status, created_at
+        FROM rooms__rounds
+        WHERE id = ANY($1)
+        ",
+    )
+    .bind(&round_ids)
+    .fetch_all(&pool)
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to fetch rounds for hall of fame: {e}");
+            return internal_error();
+        }
+    };
+
+    let round_map: HashMap<Uuid, &RoundRecord> = rounds.iter().map(|r| (r.id, r)).collect();
+
+    let entries: Vec<HallOfFameEntryResponse> = hof_records
+        .iter()
+        .filter_map(|h| {
+            let sub = sub_map.get(&h.submission_id)?;
+            let round = round_map.get(&h.round_id)?;
+            Some(HallOfFameEntryResponse {
+                submission: submission_to_response_with_author(sub),
+                round_number: round.round_number,
+                final_rating: h.final_rating,
+                rank: h.rank,
+            })
+        })
+        .collect();
+
+    (StatusCode::OK, Json(entries)).into_response()
+}
+
+// ─── Round handlers ────────────────────────────────────────────────────────────
+
+/// List all rounds for a room
+#[utoipa::path(
+    get,
+    path = "/rooms/{room_id}/rounds",
+    tag = "Ranking",
+    params(("room_id" = String, Path, description = "Room ID")),
+    responses(
+        (status = 200, description = "All rounds for the room", body = Vec<RoundResponse>),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn list_rounds(
+    Path(room_id): Path<Uuid>,
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+) -> impl IntoResponse {
+    match ranking_service.list_rounds(room_id).await {
+        Ok(rounds) => {
+            let resp: Vec<_> = rounds.iter().map(round_to_response).collect();
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+        Err(e) => ranking_error_response(e),
+    }
+}
+
+/// Get current (non-closed) rounds for a room
+#[utoipa::path(
+    get,
+    path = "/rooms/{room_id}/rounds/current",
+    tag = "Ranking",
+    params(("room_id" = String, Path, description = "Room ID")),
+    responses(
+        (status = 200, description = "Active rounds for the room", body = Vec<RoundResponse>),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn get_current_rounds(
+    Path(room_id): Path<Uuid>,
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+) -> impl IntoResponse {
+    match ranking_service.get_current_rounds(room_id).await {
+        Ok(rounds) => {
+            let resp: Vec<_> = rounds.iter().map(round_to_response).collect();
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+        Err(e) => ranking_error_response(e),
+    }
+}

--- a/service/src/rooms/http/ranking.rs
+++ b/service/src/rooms/http/ranking.rs
@@ -6,7 +6,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::{extract::Extension, extract::Query, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::Extension,
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use tc_engine_ranking::repo::rounds::{RoundRecord, RoundStatus};
@@ -16,7 +22,14 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::http::{bad_request, conflict, forbidden, internal_error, not_found, Path};
-use crate::identity::http::auth::AuthenticatedDevice;
+use crate::identity::http::auth::{AuthenticatedDevice, AuthenticatedDeviceParts};
+use crate::storage::ObjectStore;
+
+/// Maximum allowed upload size in bytes (5 MiB).
+const MAX_UPLOAD_BYTES: usize = 5 * 1024 * 1024;
+
+/// MIME types accepted for image uploads.
+const ALLOWED_IMAGE_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
 
 // ─── Response types ──────────────────────────────────────────────────────────
 
@@ -616,6 +629,149 @@ pub async fn get_current_rounds(
             let resp: Vec<_> = rounds.iter().map(round_to_response).collect();
             (StatusCode::OK, Json(resp)).into_response()
         }
+        Err(e) => ranking_error_response(e),
+    }
+}
+
+// ─── Upload handlers ──────────────────────────────────────────────────────────
+
+/// Serve an uploaded file by its storage key.
+// lint-patterns:allow-no-utoipa — static file serving endpoint; no JSON schema needed
+pub async fn serve_upload(
+    Path(key): Path<String>,
+    Extension(store): Extension<Arc<dyn ObjectStore>>,
+) -> Response {
+    match store.get(&key).await {
+        Ok(Some((data, content_type))) => Response::builder()
+            .header("Content-Type", content_type)
+            .header("Cache-Control", "public, max-age=31536000, immutable")
+            .body(axum::body::Body::from(data))
+            .unwrap_or_else(|_| internal_error()),
+        Ok(None) => not_found("file not found"),
+        Err(e) => {
+            tracing::error!("Object store get error: {e}");
+            internal_error()
+        }
+    }
+}
+
+/// Return the file extension string for a known image MIME type.
+fn ext_for_mime(mime: &str) -> Option<&'static str> {
+    match mime {
+        "image/jpeg" => Some("jpg"),
+        "image/png" => Some("png"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        _ => None,
+    }
+}
+
+/// Submit a meme with an image upload via multipart/form-data.
+///
+/// Form fields:
+/// - `image` (required): the image file
+/// - `caption` (optional): text caption
+///
+/// Authentication: uses [`AuthenticatedDeviceParts`] (signature over empty body)
+/// because [`axum::extract::Multipart`] also consumes the request body and only
+/// one body-consuming extractor is allowed per handler.
+// lint-patterns:allow-no-utoipa — multipart endpoint; utoipa doesn't support multipart form bodies
+pub async fn submit_meme_upload(
+    auth: AuthenticatedDeviceParts,
+    Path(room_id): Path<Uuid>,
+    Extension(ranking_service): Extension<Arc<dyn RankingService>>,
+    Extension(store): Extension<Arc<dyn ObjectStore>>,
+    mut multipart: axum::extract::Multipart,
+) -> Response {
+    let mut image_data: Option<Vec<u8>> = None;
+    let mut image_content_type: Option<String> = None;
+    let mut caption: Option<String> = None;
+
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => return bad_request(&format!("invalid multipart data: {e}")),
+        };
+
+        let field_name = field.name().unwrap_or("").to_string();
+
+        match field_name.as_str() {
+            "image" => {
+                let ct = field
+                    .content_type()
+                    .unwrap_or("application/octet-stream")
+                    .to_string();
+
+                if !ALLOWED_IMAGE_TYPES.contains(&ct.as_str()) {
+                    return bad_request(&format!(
+                        "unsupported image type: {ct}. Allowed: jpeg, png, gif, webp"
+                    ));
+                }
+
+                let bytes = match field.bytes().await {
+                    Ok(b) => b,
+                    Err(e) => return bad_request(&format!("failed to read image data: {e}")),
+                };
+
+                if bytes.len() > MAX_UPLOAD_BYTES {
+                    return bad_request("image exceeds 5 MB limit");
+                }
+
+                if bytes.is_empty() {
+                    return bad_request("image field is empty");
+                }
+
+                image_content_type = Some(ct);
+                image_data = Some(bytes.to_vec());
+            }
+            "caption" => {
+                let text = match field.text().await {
+                    Ok(t) => t,
+                    Err(e) => return bad_request(&format!("failed to read caption: {e}")),
+                };
+                if !text.is_empty() {
+                    caption = Some(text);
+                }
+            }
+            _ => {
+                // Ignore unknown fields
+            }
+        }
+    }
+
+    let Some(data) = image_data else {
+        return bad_request("image field is required");
+    };
+    let Some(content_type) = image_content_type else {
+        return bad_request("image content-type is missing");
+    };
+
+    let Some(ext) = ext_for_mime(&content_type) else {
+        return bad_request(&format!("unsupported image type: {content_type}"));
+    };
+
+    // Key format: {room_id}/{uuid}.{ext}
+    let file_id = Uuid::new_v4();
+    let key = format!("{room_id}/{file_id}.{ext}");
+
+    if let Err(e) = store.put(&key, &data, &content_type).await {
+        tracing::error!("Failed to store upload {key}: {e}");
+        return internal_error();
+    }
+
+    match ranking_service
+        .submit(
+            room_id,
+            auth.account_id,
+            ContentType::Image,
+            None,
+            Some(&key),
+            caption.as_deref(),
+        )
+        .await
+    {
+        Ok(sub) => (StatusCode::CREATED, Json(submission_to_response(&sub))).into_response(),
         Err(e) => ranking_error_response(e),
     }
 }

--- a/service/src/storage.rs
+++ b/service/src/storage.rs
@@ -1,0 +1,79 @@
+//! Object store abstraction for uploaded files.
+//!
+//! Provides a `LocalFileStore` implementation backed by the local filesystem
+//! for development and MVP use. A production S3-compatible implementation
+//! can be swapped in behind the same trait.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+/// Trait for storing and retrieving uploaded files.
+#[async_trait]
+pub trait ObjectStore: Send + Sync {
+    /// Store bytes under `key`. `content_type` is persisted alongside the data.
+    async fn put(&self, key: &str, data: &[u8], content_type: &str) -> Result<(), anyhow::Error>;
+
+    /// Retrieve bytes and content-type for `key`, or `None` if it doesn't exist.
+    async fn get(&self, key: &str) -> Result<Option<(Vec<u8>, String)>, anyhow::Error>;
+
+    /// Return the URL path that serves this file (e.g. `/api/v1/uploads/{key}`).
+    fn url_path(&self, key: &str) -> String;
+}
+
+/// Local filesystem object store for development / MVP deployments.
+///
+/// Files are written under `base_dir/{key}`.  The MIME type is persisted in a
+/// sidecar file at `{path}.ct` so the serve handler can echo the correct
+/// `Content-Type` header without inspecting the bytes.
+pub struct LocalFileStore {
+    base_dir: PathBuf,
+    serve_prefix: String,
+}
+
+impl LocalFileStore {
+    /// Create a new store rooted at `base_dir`, serving paths under
+    /// `serve_prefix` (e.g. `"/api/v1/uploads"`).
+    ///
+    /// Creates `base_dir` if it does not already exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the directory cannot be created.
+    pub fn new(base_dir: PathBuf, serve_prefix: &str) -> Result<Self, std::io::Error> {
+        std::fs::create_dir_all(&base_dir)?;
+        Ok(Self {
+            base_dir,
+            serve_prefix: serve_prefix.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl ObjectStore for LocalFileStore {
+    async fn put(&self, key: &str, data: &[u8], content_type: &str) -> Result<(), anyhow::Error> {
+        let path = self.base_dir.join(key);
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&path, data).await?;
+        tokio::fs::write(format!("{}.ct", path.display()), content_type).await?;
+        Ok(())
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<(Vec<u8>, String)>, anyhow::Error> {
+        let path = self.base_dir.join(key);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let data = tokio::fs::read(&path).await?;
+        let ct = tokio::fs::read_to_string(format!("{}.ct", path.display()))
+            .await
+            .unwrap_or_else(|_| "application/octet-stream".to_string());
+        Ok(Some((data, ct)))
+    }
+
+    fn url_path(&self, key: &str) -> String {
+        format!("{}/{}", self.serve_prefix, key)
+    }
+}

--- a/service/tests/ranking_repo_tests.rs
+++ b/service/tests/ranking_repo_tests.rs
@@ -1,0 +1,759 @@
+//! Integration tests for the ranking engine repo layer.
+//!
+//! Tests run against a real PostgreSQL database via testcontainers.
+//! Each test uses a transaction that rolls back on completion, so tests
+//! are independent.
+
+mod common;
+
+use chrono::Utc;
+use common::factories::AccountFactory;
+use common::test_db::test_transaction;
+use tc_engine_ranking::repo::{hall_of_fame, matchups, ratings, rounds, submissions};
+use tc_test_macros::shared_runtime_test;
+use uuid::Uuid;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+/// Insert a minimal room and return its ID.
+async fn create_test_room(tx: &mut sqlx::PgConnection) -> Uuid {
+    sqlx::query_scalar(
+        "INSERT INTO rooms__rooms (name, status, engine_type, engine_config) \
+         VALUES ($1, 'open', 'ranking', '{}') RETURNING id",
+    )
+    .bind(format!("test-room-{}", Uuid::new_v4()))
+    .fetch_one(tx)
+    .await
+    .expect("create test room")
+}
+
+/// Build a timestamp offset by `secs` seconds from now.
+fn ts(secs: i64) -> chrono::DateTime<Utc> {
+    Utc::now() + chrono::Duration::seconds(secs)
+}
+
+// ─── Round tests ────────────────────────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn test_create_round_returns_all_fields() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let submit_opens = ts(0);
+    let rank_opens = ts(3600);
+    let closes = ts(7200);
+
+    let record = rounds::create_round(&mut *tx, room_id, 1, submit_opens, rank_opens, closes)
+        .await
+        .expect("create round");
+
+    assert_eq!(record.room_id, room_id);
+    assert_eq!(record.round_number, 1);
+    assert!(matches!(record.status, rounds::RoundStatus::Submitting));
+}
+
+#[shared_runtime_test]
+async fn test_round_status_transitions() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = rounds::create_round(&mut *tx, room_id, 1, ts(0), ts(1), ts(2))
+        .await
+        .expect("create round");
+
+    rounds::update_round_status(&mut *tx, round.id, rounds::RoundStatus::Ranking)
+        .await
+        .expect("to ranking");
+
+    let r = rounds::get_round(&mut *tx, round.id)
+        .await
+        .expect("get round")
+        .expect("round exists");
+    assert!(matches!(r.status, rounds::RoundStatus::Ranking));
+
+    rounds::update_round_status(&mut *tx, round.id, rounds::RoundStatus::Closed)
+        .await
+        .expect("to closed");
+
+    let r = rounds::get_round(&mut *tx, round.id)
+        .await
+        .expect("get round")
+        .expect("round exists");
+    assert!(matches!(r.status, rounds::RoundStatus::Closed));
+}
+
+#[shared_runtime_test]
+async fn test_get_latest_round_number_empty_then_correct() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+
+    let n = rounds::get_latest_round_number(&mut *tx, room_id)
+        .await
+        .expect("latest round number (empty)");
+    assert_eq!(n, 0, "no rounds → should return 0");
+
+    rounds::create_round(&mut *tx, room_id, 1, ts(0), ts(1), ts(2))
+        .await
+        .expect("create round 1");
+    rounds::create_round(&mut *tx, room_id, 5, ts(0), ts(1), ts(2))
+        .await
+        .expect("create round 5");
+
+    let n = rounds::get_latest_round_number(&mut *tx, room_id)
+        .await
+        .expect("latest round number");
+    assert_eq!(n, 5);
+}
+
+#[shared_runtime_test]
+async fn test_get_current_rounds_excludes_closed() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+
+    let r1 = rounds::create_round(&mut *tx, room_id, 1, ts(0), ts(1), ts(2))
+        .await
+        .expect("round 1");
+    rounds::create_round(&mut *tx, room_id, 2, ts(0), ts(1), ts(2))
+        .await
+        .expect("round 2");
+
+    // Close round 1.
+    rounds::update_round_status(&mut *tx, r1.id, rounds::RoundStatus::Closed)
+        .await
+        .expect("close round 1");
+
+    let current = rounds::get_current_rounds(&mut *tx, room_id)
+        .await
+        .expect("get current rounds");
+
+    assert_eq!(current.len(), 1);
+    assert_eq!(current[0].round_number, 2);
+}
+
+#[shared_runtime_test]
+async fn test_list_rounds_ordered_desc() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+
+    rounds::create_round(&mut *tx, room_id, 1, ts(0), ts(1), ts(2))
+        .await
+        .expect("round 1");
+    rounds::create_round(&mut *tx, room_id, 2, ts(0), ts(1), ts(2))
+        .await
+        .expect("round 2");
+    rounds::create_round(&mut *tx, room_id, 3, ts(0), ts(1), ts(2))
+        .await
+        .expect("round 3");
+
+    let all = rounds::list_rounds(&mut *tx, room_id)
+        .await
+        .expect("list rounds");
+
+    assert_eq!(all.len(), 3);
+    assert_eq!(all[0].round_number, 3, "DESC order: first should be 3");
+    assert_eq!(all[2].round_number, 1, "DESC order: last should be 1");
+}
+
+// ─── Submission tests ────────────────────────────────────────────────────────
+
+async fn create_test_round(
+    tx: &mut sqlx::PgConnection,
+    room_id: Uuid,
+    round_number: i32,
+) -> rounds::RoundRecord {
+    rounds::create_round(tx, room_id, round_number, ts(0), ts(1), ts(2))
+        .await
+        .expect("create test round")
+}
+
+#[shared_runtime_test]
+async fn test_create_submission_url_type() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let author = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("account");
+
+    let record = submissions::create_submission(
+        &mut *tx,
+        round.id,
+        author.id,
+        submissions::ContentType::Url,
+        Some("https://example.com/meme.png"),
+        None,
+        Some("A great meme"),
+    )
+    .await
+    .expect("create url submission");
+
+    assert_eq!(record.round_id, round.id);
+    assert_eq!(record.author_id, author.id);
+    assert!(matches!(record.content_type, submissions::ContentType::Url));
+    assert_eq!(record.url.as_deref(), Some("https://example.com/meme.png"));
+    assert!(record.image_key.is_none());
+    assert_eq!(record.caption.as_deref(), Some("A great meme"));
+}
+
+#[shared_runtime_test]
+async fn test_create_submission_image_type() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let author = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("account");
+
+    let record = submissions::create_submission(
+        &mut *tx,
+        round.id,
+        author.id,
+        submissions::ContentType::Image,
+        None,
+        Some("uploads/abc123.png"),
+        None,
+    )
+    .await
+    .expect("create image submission");
+
+    assert!(matches!(
+        record.content_type,
+        submissions::ContentType::Image
+    ));
+    assert!(record.url.is_none());
+    assert_eq!(record.image_key.as_deref(), Some("uploads/abc123.png"));
+}
+
+#[shared_runtime_test]
+async fn test_duplicate_submission_fails() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let author = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("account");
+
+    submissions::create_submission(
+        &mut *tx,
+        round.id,
+        author.id,
+        submissions::ContentType::Url,
+        Some("https://example.com/a.png"),
+        None,
+        None,
+    )
+    .await
+    .expect("first submission");
+
+    let result = submissions::create_submission(
+        &mut *tx,
+        round.id,
+        author.id,
+        submissions::ContentType::Url,
+        Some("https://example.com/b.png"),
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.is_err(), "duplicate (round, author) should fail");
+}
+
+#[shared_runtime_test]
+async fn test_has_submitted_returns_correct_bool() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let author = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("account");
+    let other = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("other account");
+
+    let before = submissions::has_submitted(&mut *tx, round.id, author.id)
+        .await
+        .expect("has_submitted before");
+    assert!(!before);
+
+    submissions::create_submission(
+        &mut *tx,
+        round.id,
+        author.id,
+        submissions::ContentType::Url,
+        Some("https://example.com/a.png"),
+        None,
+        None,
+    )
+    .await
+    .expect("create submission");
+
+    let after = submissions::has_submitted(&mut *tx, round.id, author.id)
+        .await
+        .expect("has_submitted after");
+    assert!(after);
+
+    let other_check = submissions::has_submitted(&mut *tx, round.id, other.id)
+        .await
+        .expect("has_submitted other");
+    assert!(!other_check);
+}
+
+#[shared_runtime_test]
+async fn test_count_submissions() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+
+    let a1 = AccountFactory::new().create(&mut *tx).await.expect("a1");
+    let a2 = AccountFactory::new().create(&mut *tx).await.expect("a2");
+    let a3 = AccountFactory::new().create(&mut *tx).await.expect("a3");
+
+    let count0 = submissions::count_submissions(&mut *tx, round.id)
+        .await
+        .expect("count 0");
+    assert_eq!(count0, 0);
+
+    for (account, url) in [
+        (&a1, "https://example.com/1.png"),
+        (&a2, "https://example.com/2.png"),
+        (&a3, "https://example.com/3.png"),
+    ] {
+        submissions::create_submission(
+            &mut *tx,
+            round.id,
+            account.id,
+            submissions::ContentType::Url,
+            Some(url),
+            None,
+            None,
+        )
+        .await
+        .expect("create submission");
+    }
+
+    let count3 = submissions::count_submissions(&mut *tx, round.id)
+        .await
+        .expect("count 3");
+    assert_eq!(count3, 3);
+}
+
+// ─── Matchup tests ──────────────────────────────────────────────────────────
+
+async fn create_url_submission(
+    tx: &mut sqlx::PgConnection,
+    round_id: Uuid,
+    author_id: Uuid,
+    url: &str,
+) -> submissions::SubmissionRecord {
+    submissions::create_submission(
+        tx,
+        round_id,
+        author_id,
+        submissions::ContentType::Url,
+        Some(url),
+        None,
+        None,
+    )
+    .await
+    .expect("create url submission")
+}
+
+#[shared_runtime_test]
+async fn test_create_matchup_orders_pair() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let ranker = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("ranker");
+    let author_a = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("author a");
+    let author_b = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("author b");
+
+    let sub_a = create_url_submission(&mut *tx, round.id, author_a.id, "https://a.com").await;
+    let sub_b = create_url_submission(&mut *tx, round.id, author_b.id, "https://b.com").await;
+
+    // Deliberately pass b, a (reversed) to verify the repo re-orders them.
+    let (bigger, smaller) = if sub_a.id > sub_b.id {
+        (sub_a.id, sub_b.id)
+    } else {
+        (sub_b.id, sub_a.id)
+    };
+
+    let record = matchups::create_matchup(
+        &mut *tx, round.id, ranker.id, bigger, // intentionally the larger UUID first
+        smaller, None,
+    )
+    .await
+    .expect("create matchup");
+
+    assert!(
+        record.submission_a < record.submission_b,
+        "submission_a must be < submission_b after ordering"
+    );
+}
+
+#[shared_runtime_test]
+async fn test_duplicate_matchup_fails() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let ranker = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("ranker");
+    let auth_a = AccountFactory::new().create(&mut *tx).await.expect("a");
+    let auth_b = AccountFactory::new().create(&mut *tx).await.expect("b");
+
+    let sub_a = create_url_submission(&mut *tx, round.id, auth_a.id, "https://a.com").await;
+    let sub_b = create_url_submission(&mut *tx, round.id, auth_b.id, "https://b.com").await;
+
+    matchups::create_matchup(&mut *tx, round.id, ranker.id, sub_a.id, sub_b.id, None)
+        .await
+        .expect("first matchup");
+
+    let result =
+        matchups::create_matchup(&mut *tx, round.id, ranker.id, sub_a.id, sub_b.id, None).await;
+
+    assert!(result.is_err(), "duplicate matchup should fail");
+}
+
+#[shared_runtime_test]
+async fn test_get_judged_pairs_returns_correct_set() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let ranker = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("ranker");
+    let auth_a = AccountFactory::new().create(&mut *tx).await.expect("a");
+    let auth_b = AccountFactory::new().create(&mut *tx).await.expect("b");
+    let auth_c = AccountFactory::new().create(&mut *tx).await.expect("c");
+
+    let sub_a = create_url_submission(&mut *tx, round.id, auth_a.id, "https://a.com").await;
+    let sub_b = create_url_submission(&mut *tx, round.id, auth_b.id, "https://b.com").await;
+    let sub_c = create_url_submission(&mut *tx, round.id, auth_c.id, "https://c.com").await;
+
+    matchups::create_matchup(
+        &mut *tx,
+        round.id,
+        ranker.id,
+        sub_a.id,
+        sub_b.id,
+        Some(sub_a.id),
+    )
+    .await
+    .expect("matchup a-b");
+    matchups::create_matchup(
+        &mut *tx,
+        round.id,
+        ranker.id,
+        sub_b.id,
+        sub_c.id,
+        Some(sub_b.id),
+    )
+    .await
+    .expect("matchup b-c");
+
+    let pairs = matchups::get_judged_pairs(&mut *tx, round.id, ranker.id)
+        .await
+        .expect("get judged pairs");
+
+    assert_eq!(pairs.len(), 2);
+    // All returned pairs must be ordered a < b.
+    for (a, b) in &pairs {
+        assert!(a < b, "judged pair must be ordered a < b");
+    }
+}
+
+#[shared_runtime_test]
+async fn test_count_matchups_for_ranker() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let ranker = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("ranker");
+    let auth_a = AccountFactory::new().create(&mut *tx).await.expect("a");
+    let auth_b = AccountFactory::new().create(&mut *tx).await.expect("b");
+    let auth_c = AccountFactory::new().create(&mut *tx).await.expect("c");
+
+    let sub_a = create_url_submission(&mut *tx, round.id, auth_a.id, "https://a.com").await;
+    let sub_b = create_url_submission(&mut *tx, round.id, auth_b.id, "https://b.com").await;
+    let sub_c = create_url_submission(&mut *tx, round.id, auth_c.id, "https://c.com").await;
+
+    let c0 = matchups::count_matchups_for_ranker(&mut *tx, round.id, ranker.id)
+        .await
+        .expect("count 0");
+    assert_eq!(c0, 0);
+
+    matchups::create_matchup(&mut *tx, round.id, ranker.id, sub_a.id, sub_b.id, None)
+        .await
+        .expect("matchup 1");
+    matchups::create_matchup(&mut *tx, round.id, ranker.id, sub_a.id, sub_c.id, None)
+        .await
+        .expect("matchup 2");
+
+    let c2 = matchups::count_matchups_for_ranker(&mut *tx, round.id, ranker.id)
+        .await
+        .expect("count 2");
+    assert_eq!(c2, 2);
+}
+
+// ─── Rating tests ────────────────────────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn test_initialize_ratings_defaults() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let auth_a = AccountFactory::new().create(&mut *tx).await.expect("a");
+    let auth_b = AccountFactory::new().create(&mut *tx).await.expect("b");
+
+    let sub_a = create_url_submission(&mut *tx, round.id, auth_a.id, "https://a.com").await;
+    let sub_b = create_url_submission(&mut *tx, round.id, auth_b.id, "https://b.com").await;
+
+    // Use initialize_ratings with the transaction executor.
+    ratings::initialize_ratings(&mut *tx, &[sub_a.id, sub_b.id])
+        .await
+        .expect("initialize ratings");
+
+    let ra = ratings::get_rating(&mut *tx, sub_a.id)
+        .await
+        .expect("get rating a")
+        .expect("rating a exists");
+
+    assert!(
+        (ra.rating - 1500.0).abs() < f64::EPSILON,
+        "default rating is 1500"
+    );
+    assert!(
+        (ra.deviation - 350.0).abs() < f64::EPSILON,
+        "default deviation is 350"
+    );
+    assert!(
+        (ra.volatility - 0.06).abs() < 1e-9,
+        "default volatility is 0.06"
+    );
+    assert_eq!(ra.matchup_count, 0, "default matchup_count is 0");
+}
+
+#[shared_runtime_test]
+async fn test_update_rating() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let author = AccountFactory::new()
+        .create(&mut *tx)
+        .await
+        .expect("author");
+
+    let sub = create_url_submission(&mut *tx, round.id, author.id, "https://a.com").await;
+
+    sqlx::query("INSERT INTO rooms__ratings (submission_id) VALUES ($1)")
+        .bind(sub.id)
+        .execute(&mut *tx)
+        .await
+        .expect("insert rating");
+
+    ratings::update_rating(&mut *tx, sub.id, 1600.0, 200.0, 0.07, 5)
+        .await
+        .expect("update rating");
+
+    let r = ratings::get_rating(&mut *tx, sub.id)
+        .await
+        .expect("get rating")
+        .expect("exists");
+
+    assert!((r.rating - 1600.0).abs() < f64::EPSILON);
+    assert!((r.deviation - 200.0).abs() < f64::EPSILON);
+    assert!((r.volatility - 0.07).abs() < 1e-9);
+    assert_eq!(r.matchup_count, 5);
+}
+
+#[shared_runtime_test]
+async fn test_get_ratings_for_round_ordered_desc() {
+    let mut tx = test_transaction().await;
+
+    let room_id = create_test_room(&mut *tx).await;
+    let round = create_test_round(&mut *tx, room_id, 1).await;
+    let auth_a = AccountFactory::new().create(&mut *tx).await.expect("a");
+    let auth_b = AccountFactory::new().create(&mut *tx).await.expect("b");
+    let auth_c = AccountFactory::new().create(&mut *tx).await.expect("c");
+
+    let sub_a = create_url_submission(&mut *tx, round.id, auth_a.id, "https://a.com").await;
+    let sub_b = create_url_submission(&mut *tx, round.id, auth_b.id, "https://b.com").await;
+    let sub_c = create_url_submission(&mut *tx, round.id, auth_c.id, "https://c.com").await;
+
+    // Insert ratings with known values.
+    sqlx::query(
+        "INSERT INTO rooms__ratings (submission_id, rating) VALUES ($1, 1700), ($2, 1500), ($3, 1600)",
+    )
+    .bind(sub_a.id)
+    .bind(sub_b.id)
+    .bind(sub_c.id)
+    .execute(&mut *tx)
+    .await
+    .expect("insert ratings");
+
+    let list = ratings::get_ratings_for_round(&mut *tx, round.id)
+        .await
+        .expect("get ratings for round");
+
+    assert_eq!(list.len(), 3);
+    // Should be ordered by rating DESC.
+    assert!(list[0].rating >= list[1].rating);
+    assert!(list[1].rating >= list[2].rating);
+    assert_eq!(
+        list[0].submission_id, sub_a.id,
+        "sub_a has highest rating (1700)"
+    );
+}
+
+// ─── Hall of fame tests ──────────────────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn test_insert_and_list_hall_of_fame() {
+    // Use isolated_db so all writes are cleaned up automatically on drop.
+    let db = common::test_db::isolated_db().await;
+    let pool = db.pool();
+
+    let room_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO rooms__rooms (name, status, engine_type, engine_config) \
+         VALUES ($1, 'open', 'ranking', '{}') RETURNING id",
+    )
+    .bind(format!("hof-room-{}", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("create hof room");
+
+    let round_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO rooms__rounds \
+         (room_id, round_number, submit_opens_at, rank_opens_at, closes_at) \
+         VALUES ($1, 1, now(), now(), now()) RETURNING id",
+    )
+    .bind(room_id)
+    .fetch_one(pool)
+    .await
+    .expect("create hof round");
+
+    let author_id: Uuid = AccountFactory::new()
+        .create(pool)
+        .await
+        .expect("hof author")
+        .id;
+    let sub_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO rooms__submissions (round_id, author_id, content_type, url) \
+         VALUES ($1, $2, 'url', 'https://hof.com') RETURNING id",
+    )
+    .bind(round_id)
+    .bind(author_id)
+    .fetch_one(pool)
+    .await
+    .expect("create hof submission");
+
+    let winners = vec![(sub_id, 1750.0f64, 1i32)];
+    hall_of_fame::insert_winners(pool, room_id, round_id, &winners)
+        .await
+        .expect("insert winners");
+
+    let list = hall_of_fame::list_hall_of_fame(pool, room_id, 10, 0)
+        .await
+        .expect("list hall of fame");
+
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].submission_id, sub_id);
+    assert_eq!(list[0].room_id, room_id);
+    assert_eq!(list[0].round_id, round_id);
+    assert!((list[0].final_rating - 1750.0).abs() < f64::EPSILON);
+    assert_eq!(list[0].rank, 1);
+}
+
+#[shared_runtime_test]
+async fn test_hall_of_fame_pagination() {
+    // Use isolated_db so all writes are cleaned up automatically on drop.
+    let db = common::test_db::isolated_db().await;
+    let pool = db.pool();
+
+    let room_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO rooms__rooms (name, status, engine_type, engine_config) \
+         VALUES ($1, 'open', 'ranking', '{}') RETURNING id",
+    )
+    .bind(format!("hof-page-room-{}", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("create room");
+
+    // Create 3 rounds with 1 submission each.
+    for rn in 1..=3i32 {
+        let round_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO rooms__rounds \
+             (room_id, round_number, submit_opens_at, rank_opens_at, closes_at) \
+             VALUES ($1, $2, now(), now(), now()) RETURNING id",
+        )
+        .bind(room_id)
+        .bind(rn)
+        .fetch_one(pool)
+        .await
+        .expect("create round");
+
+        let author = AccountFactory::new().create(pool).await.expect("author");
+        let sub_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO rooms__submissions (round_id, author_id, content_type, url) \
+             VALUES ($1, $2, 'url', $3) RETURNING id",
+        )
+        .bind(round_id)
+        .bind(author.id)
+        .bind(format!("https://example.com/{rn}.png"))
+        .fetch_one(pool)
+        .await
+        .expect("create submission");
+
+        hall_of_fame::insert_winners(
+            pool,
+            room_id,
+            round_id,
+            &[(sub_id, 1500.0 + f64::from(rn) * 10.0, 1)],
+        )
+        .await
+        .expect("insert winner");
+    }
+
+    let page1 = hall_of_fame::list_hall_of_fame(pool, room_id, 2, 0)
+        .await
+        .expect("page 1");
+    assert_eq!(page1.len(), 2, "page 1 should have 2 entries");
+
+    let page2 = hall_of_fame::list_hall_of_fame(pool, room_id, 2, 2)
+        .await
+        .expect("page 2");
+    assert_eq!(page2.len(), 1, "page 2 should have 1 entry");
+}

--- a/service/tests/ranking_service_tests.rs
+++ b/service/tests/ranking_service_tests.rs
@@ -1,0 +1,652 @@
+//! Integration tests for the ranking service layer.
+//!
+//! Tests run against a real `PostgreSQL` database via testcontainers.
+//! Service tests use `isolated_db()` because the service operates on a full
+//! `PgPool` (required by `DefaultRankingService`) rather than a raw transaction.
+
+mod common;
+
+use chrono::Utc;
+use common::factories::AccountFactory;
+use common::test_db::isolated_db;
+use tc_engine_ranking::repo::{rounds, submissions};
+use tc_engine_ranking::service::{DefaultRankingService, RankingError, RankingService};
+use tc_test_macros::shared_runtime_test;
+use uuid::Uuid;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+/// Insert a minimal ranking room and return its ID.
+async fn create_test_room(pool: &sqlx::PgPool) -> Uuid {
+    sqlx::query_scalar(
+        "INSERT INTO rooms__rooms (name, status, engine_type, engine_config) \
+         VALUES ($1, 'open', 'ranking', '{}') RETURNING id",
+    )
+    .bind(format!("svc-test-room-{}", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("create test room")
+}
+
+/// Build a timestamp offset by `secs` seconds from now.
+fn ts(secs: i64) -> chrono::DateTime<Utc> {
+    Utc::now() + chrono::Duration::seconds(secs)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[shared_runtime_test]
+async fn test_submit_succeeds_during_submit_phase() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let author = AccountFactory::new()
+        .create(&pool)
+        .await
+        .expect("create author");
+
+    let service = DefaultRankingService::new(pool);
+
+    // Create a round in submitting status
+    service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    let result = service
+        .submit(
+            room_id,
+            author.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/meme.png"),
+            None,
+            Some("A great meme"),
+        )
+        .await
+        .expect("submit");
+
+    assert_eq!(result.author_id, author.id);
+    assert_eq!(result.url.as_deref(), Some("https://example.com/meme.png"));
+}
+
+#[shared_runtime_test]
+async fn test_submit_rejects_duplicate() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let author = AccountFactory::new()
+        .create(&pool)
+        .await
+        .expect("create author");
+
+    let service = DefaultRankingService::new(pool);
+
+    service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    service
+        .submit(
+            room_id,
+            author.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/first.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("first submit");
+
+    let second = service
+        .submit(
+            room_id,
+            author.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/second.png"),
+            None,
+            None,
+        )
+        .await;
+
+    assert!(
+        matches!(second, Err(RankingError::AlreadySubmitted)),
+        "expected AlreadySubmitted, got: {second:?}"
+    );
+}
+
+#[shared_runtime_test]
+async fn test_submit_rejects_when_not_submitting() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let author = AccountFactory::new()
+        .create(&pool)
+        .await
+        .expect("create author");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    // Create a round and advance it to ranking status
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    // Manually move to ranking status (open_ranking requires submissions; skip that here)
+    rounds::update_round_status(&pool, round.id, rounds::RoundStatus::Ranking)
+        .await
+        .expect("update to ranking");
+
+    let result = service
+        .submit(
+            room_id,
+            author.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/meme.png"),
+            None,
+            None,
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(RankingError::NotInSubmitPhase)),
+        "expected NotInSubmitPhase, got: {result:?}"
+    );
+}
+
+#[shared_runtime_test]
+async fn test_open_ranking_initializes_ratings() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    // Submit two entries
+    service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    // Verify ratings exist for all submissions
+    let ratings = tc_engine_ranking::repo::ratings::get_ratings_for_round(&pool, round.id)
+        .await
+        .expect("get ratings");
+
+    assert_eq!(ratings.len(), 2, "both submissions should have ratings");
+    for r in &ratings {
+        assert!(
+            (r.rating - 1500.0).abs() < f64::EPSILON,
+            "default rating should be 1500"
+        );
+    }
+}
+
+#[shared_runtime_test]
+async fn test_get_next_matchup_returns_pair() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+    let ranker = AccountFactory::new().create(&pool).await.expect("ranker");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    let matchup = service
+        .get_next_matchup(room_id, ranker.id)
+        .await
+        .expect("get next matchup");
+
+    assert!(matchup.is_some(), "should return a pair");
+    let (sub_a, sub_b) = matchup.unwrap();
+    assert_ne!(
+        sub_a.id, sub_b.id,
+        "pair should be two different submissions"
+    );
+}
+
+#[shared_runtime_test]
+async fn test_get_next_matchup_returns_none_when_exhausted() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+    let ranker = AccountFactory::new().create(&pool).await.expect("ranker");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    // Get the pair and record a matchup to exhaust all pairs
+    let (sub_a, sub_b) = service
+        .get_next_matchup(room_id, ranker.id)
+        .await
+        .expect("get first matchup")
+        .expect("first pair exists");
+
+    service
+        .record_matchup(room_id, ranker.id, sub_a.id, sub_b.id)
+        .await
+        .expect("record matchup");
+
+    // Now the only pair has been judged — should return None
+    let second = service
+        .get_next_matchup(room_id, ranker.id)
+        .await
+        .expect("get next matchup after exhaustion");
+
+    assert!(
+        second.is_none(),
+        "expected None after all pairs exhausted, got: {second:?}"
+    );
+}
+
+#[shared_runtime_test]
+async fn test_record_matchup_updates_ratings() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+    let ranker = AccountFactory::new().create(&pool).await.expect("ranker");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    let sub1 = service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    let sub2 = service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    // sub1 wins
+    service
+        .record_matchup(room_id, ranker.id, sub1.id, sub2.id)
+        .await
+        .expect("record matchup");
+
+    let ratings = tc_engine_ranking::repo::ratings::get_ratings_for_round(&pool, round.id)
+        .await
+        .expect("get ratings");
+
+    let winner_rating = ratings
+        .iter()
+        .find(|r| r.submission_id == sub1.id)
+        .expect("winner rating");
+    let loser_rating = ratings
+        .iter()
+        .find(|r| r.submission_id == sub2.id)
+        .expect("loser rating");
+
+    assert!(
+        winner_rating.rating > 1500.0,
+        "winner rating should increase above 1500, got {}",
+        winner_rating.rating
+    );
+    assert!(
+        loser_rating.rating < 1500.0,
+        "loser rating should decrease below 1500, got {}",
+        loser_rating.rating
+    );
+    assert_eq!(winner_rating.matchup_count, 1);
+    assert_eq!(loser_rating.matchup_count, 1);
+}
+
+#[shared_runtime_test]
+async fn test_skip_matchup_no_rating_change() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+    let ranker = AccountFactory::new().create(&pool).await.expect("ranker");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    let sub1 = service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    let sub2 = service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    service
+        .skip_matchup(room_id, ranker.id, sub1.id, sub2.id)
+        .await
+        .expect("skip matchup");
+
+    let ratings = tc_engine_ranking::repo::ratings::get_ratings_for_round(&pool, round.id)
+        .await
+        .expect("get ratings");
+
+    // Ratings should be unchanged (still default 1500)
+    for r in &ratings {
+        assert!(
+            (r.rating - 1500.0).abs() < f64::EPSILON,
+            "rating should remain 1500 after skip, got {}",
+            r.rating
+        );
+    }
+}
+
+#[shared_runtime_test]
+async fn test_close_round_snapshots_hall_of_fame() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+    let a3 = AccountFactory::new().create(&pool).await.expect("a3");
+    let ranker = AccountFactory::new().create(&pool).await.expect("ranker");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    let sub1 = service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    let sub2 = service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    service
+        .submit(
+            room_id,
+            a3.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/3.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 3");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    // sub1 wins a matchup to have a higher rating
+    service
+        .record_matchup(room_id, ranker.id, sub1.id, sub2.id)
+        .await
+        .expect("record matchup");
+
+    // Close round with top 2
+    service.close_round(round.id, 2).await.expect("close round");
+
+    let hof = service
+        .get_hall_of_fame(room_id, 10, 0)
+        .await
+        .expect("get hall of fame");
+
+    assert_eq!(hof.len(), 2, "should have exactly 2 hall of fame entries");
+
+    // The round should now be closed
+    let updated_round = rounds::get_round(&pool, round.id)
+        .await
+        .expect("get round")
+        .expect("round exists");
+    assert!(
+        matches!(updated_round.status, rounds::RoundStatus::Closed),
+        "round should be closed"
+    );
+}
+
+#[shared_runtime_test]
+async fn test_leaderboard_ordered_by_rating() {
+    let db = isolated_db().await;
+    let pool = db.pool().clone();
+
+    let room_id = create_test_room(&pool).await;
+    let a1 = AccountFactory::new().create(&pool).await.expect("a1");
+    let a2 = AccountFactory::new().create(&pool).await.expect("a2");
+    let a3 = AccountFactory::new().create(&pool).await.expect("a3");
+    let ranker = AccountFactory::new().create(&pool).await.expect("ranker");
+
+    let service = DefaultRankingService::new(pool.clone());
+
+    let round = service
+        .create_round(room_id, ts(0), ts(3600), ts(7200))
+        .await
+        .expect("create round");
+
+    let sub1 = service
+        .submit(
+            room_id,
+            a1.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/1.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 1");
+
+    let sub2 = service
+        .submit(
+            room_id,
+            a2.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/2.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 2");
+
+    let sub3 = service
+        .submit(
+            room_id,
+            a3.id,
+            submissions::ContentType::Url,
+            Some("https://example.com/3.png"),
+            None,
+            None,
+        )
+        .await
+        .expect("submit 3");
+
+    service.open_ranking(round.id).await.expect("open ranking");
+
+    // sub1 beats sub2 and sub3
+    service
+        .record_matchup(room_id, ranker.id, sub1.id, sub2.id)
+        .await
+        .expect("matchup 1 vs 2");
+
+    service
+        .record_matchup(room_id, ranker.id, sub1.id, sub3.id)
+        .await
+        .expect("matchup 1 vs 3");
+
+    let leaderboard = service
+        .get_leaderboard(round.id)
+        .await
+        .expect("get leaderboard");
+
+    assert_eq!(leaderboard.len(), 3);
+
+    // Verify descending order
+    for i in 0..(leaderboard.len() - 1) {
+        assert!(
+            leaderboard[i].rating >= leaderboard[i + 1].rating,
+            "leaderboard should be ordered DESC by rating, but [{i}]={} and [{}]={}",
+            leaderboard[i].rating,
+            i + 1,
+            leaderboard[i + 1].rating
+        );
+    }
+
+    // sub1 won twice and should be at the top
+    assert_eq!(
+        leaderboard[0].submission_id, sub1.id,
+        "sub1 (2 wins) should be first"
+    );
+}

--- a/service/tests/snapshots/openapi_snapshot_tests__openapi_schema.snap
+++ b/service/tests/snapshots/openapi_snapshot_tests__openapi_schema.snap
@@ -720,6 +720,153 @@ expression: schema
         }
       }
     },
+    "/rooms/{room_id}/hall-of-fame": {
+      "get": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "Get hall of fame entries for a room",
+        "operationId": "get_hall_of_fame",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max entries to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Offset for pagination (default 0)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hall of fame entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HallOfFameEntryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/rooms/{room_id}/matchup": {
+      "get": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "Get the next matchup pair to judge",
+        "operationId": "get_matchup",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Next matchup pair",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchupResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No matchups available"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/rooms/{room_id}/matchups": {
+      "post": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "Record a matchup judgment (win/loss or skip)",
+        "operationId": "record_matchup",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordMatchupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Matchup recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchupResultResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or not in ranking phase"
+          },
+          "403": {
+            "description": "Cannot rank own submission"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/rooms/{room_id}/my-capabilities": {
       "get": {
         "tags": [
@@ -1439,6 +1586,180 @@ expression: schema
           },
           "404": {
             "description": "Room not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/rooms/{room_id}/rounds": {
+      "get": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "List all rounds for a room",
+        "operationId": "list_rounds",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All rounds for the room",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoundResponse"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/rooms/{room_id}/rounds/current": {
+      "get": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "Get current (non-closed) rounds for a room",
+        "operationId": "get_current_rounds",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Active rounds for the room",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoundResponse"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/rooms/{room_id}/rounds/{round_id}/leaderboard": {
+      "get": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "Get the leaderboard for a specific round",
+        "operationId": "get_leaderboard",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "round_id",
+            "in": "path",
+            "description": "Round ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard for the round",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeaderboardResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Round not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/rooms/{room_id}/submissions": {
+      "post": {
+        "tags": [
+          "Ranking"
+        ],
+        "summary": "Submit a meme to the current round",
+        "operationId": "submit_meme",
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "description": "Room ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitMemeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Submission created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmissionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or not in submit phase"
+          },
+          "409": {
+            "description": "Already submitted this round"
           },
           "500": {
             "description": "Internal server error"
@@ -2776,6 +3097,32 @@ expression: schema
           }
         }
       },
+      "HallOfFameEntryResponse": {
+        "type": "object",
+        "required": [
+          "submission",
+          "round_number",
+          "final_rating",
+          "rank"
+        ],
+        "properties": {
+          "final_rating": {
+            "type": "number",
+            "format": "double"
+          },
+          "rank": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "round_number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "submission": {
+            "$ref": "#/components/schemas/SubmissionWithAuthorResponse"
+          }
+        }
+      },
       "HasEndorsementResponse": {
         "type": "object",
         "required": [
@@ -2831,6 +3178,59 @@ expression: schema
             "items": {
               "$ref": "#/components/schemas/InviteResponse"
             }
+          }
+        }
+      },
+      "LeaderboardEntry": {
+        "type": "object",
+        "required": [
+          "submission",
+          "rating",
+          "deviation",
+          "matchup_count",
+          "rank"
+        ],
+        "properties": {
+          "deviation": {
+            "type": "number",
+            "format": "double"
+          },
+          "matchup_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rank": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rating": {
+            "type": "number",
+            "format": "double"
+          },
+          "submission": {
+            "$ref": "#/components/schemas/SubmissionResponse"
+          }
+        }
+      },
+      "LeaderboardResponse": {
+        "type": "object",
+        "required": [
+          "round_id",
+          "round_status",
+          "entries"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LeaderboardEntry"
+            }
+          },
+          "round_id": {
+            "type": "string"
+          },
+          "round_status": {
+            "type": "string"
           }
         }
       },
@@ -2900,6 +3300,42 @@ expression: schema
           }
         }
       },
+      "MatchupResponse": {
+        "type": "object",
+        "required": [
+          "submission_a",
+          "submission_b"
+        ],
+        "properties": {
+          "submission_a": {
+            "$ref": "#/components/schemas/SubmissionResponse"
+          },
+          "submission_b": {
+            "$ref": "#/components/schemas/SubmissionResponse"
+          }
+        }
+      },
+      "MatchupResultResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "winner_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
       "MessageResponse": {
         "type": "object",
         "required": [
@@ -2939,6 +3375,19 @@ expression: schema
           },
           "role": {
             "type": "string"
+          }
+        }
+      },
+      "PaginationParams": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -3130,6 +3579,41 @@ expression: schema
           }
         }
       },
+      "RecordMatchupRequest": {
+        "type": "object",
+        "properties": {
+          "loser_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "skipped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "submission_a": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "submission_b": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "winner_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
       "RenameDeviceRequest": {
         "type": "object",
         "required": [
@@ -3207,6 +3691,42 @@ expression: schema
             "format": "int32"
           },
           "status": {
+            "type": "string"
+          }
+        }
+      },
+      "RoundResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "room_id",
+          "round_number",
+          "submit_opens_at",
+          "rank_opens_at",
+          "closes_at",
+          "status"
+        ],
+        "properties": {
+          "closes_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "rank_opens_at": {
+            "type": "string"
+          },
+          "room_id": {
+            "type": "string"
+          },
+          "round_number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string"
+          },
+          "submit_opens_at": {
             "type": "string"
           }
         }
@@ -3343,6 +3863,121 @@ expression: schema
           },
           "root_kid": {
             "type": "string"
+          }
+        }
+      },
+      "SubmissionResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "round_id",
+          "content_type",
+          "created_at"
+        ],
+        "properties": {
+          "caption": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "round_id": {
+            "type": "string"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "SubmissionWithAuthorResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "round_id",
+          "author_id",
+          "content_type",
+          "created_at"
+        ],
+        "properties": {
+          "author_id": {
+            "type": "string"
+          },
+          "caption": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "round_id": {
+            "type": "string"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "SubmitMemeRequest": {
+        "type": "object",
+        "required": [
+          "content_type"
+        ],
+        "properties": {
+          "caption": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "image_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/service/tests/snapshots/schema_snapshot__schema_matches_snapshot.snap
+++ b/service/tests/snapshots/schema_snapshot__schema_matches_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: service/tests/schema_snapshot.rs
-assertion_line: 188
 expression: current_schema
 ---
 -- Schema Snapshot
@@ -70,6 +69,24 @@ CREATE TABLE rooms__bot_traces (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     completed_at TIMESTAMPTZ);
 
+CREATE TABLE rooms__hall_of_fame (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    room_id UUID NOT NULL,
+    round_id UUID NOT NULL,
+    submission_id UUID NOT NULL,
+    final_rating FLOAT8 NOT NULL,
+    rank INT4 NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now());
+
+CREATE TABLE rooms__matchups (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    round_id UUID NOT NULL,
+    ranker_id UUID NOT NULL,
+    submission_a UUID NOT NULL,
+    submission_b UUID NOT NULL,
+    winner_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now());
+
 CREATE TABLE rooms__poll_dimensions (
     id UUID NOT NULL DEFAULT gen_random_uuid(),
     poll_id UUID NOT NULL,
@@ -100,6 +117,13 @@ CREATE TABLE rooms__polls (
     closed_at TIMESTAMPTZ,
     closes_at TIMESTAMPTZ,
     agenda_position INT4);
+
+CREATE TABLE rooms__ratings (
+    submission_id UUID NOT NULL,
+    rating FLOAT8 NOT NULL DEFAULT 1500.0,
+    deviation FLOAT8 NOT NULL DEFAULT 350.0,
+    volatility FLOAT8 NOT NULL DEFAULT 0.06,
+    matchup_count INT4 NOT NULL DEFAULT 0);
 
 CREATE TABLE rooms__research_suggestions (
     id UUID NOT NULL DEFAULT gen_random_uuid(),
@@ -135,6 +159,26 @@ CREATE TABLE rooms__rooms (
     engine_type TEXT NOT NULL DEFAULT 'polling'::text,
     engine_config JSONB NOT NULL DEFAULT '{}'::jsonb,
     owner_id UUID);
+
+CREATE TABLE rooms__rounds (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    room_id UUID NOT NULL,
+    round_number INT4 NOT NULL,
+    submit_opens_at TIMESTAMPTZ NOT NULL,
+    rank_opens_at TIMESTAMPTZ NOT NULL,
+    closes_at TIMESTAMPTZ NOT NULL,
+    status RANKING_ROUND_STATUS NOT NULL DEFAULT 'submitting'::ranking_round_status,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now());
+
+CREATE TABLE rooms__submissions (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    round_id UUID NOT NULL,
+    author_id UUID NOT NULL,
+    content_type SUBMISSION_CONTENT_TYPE NOT NULL,
+    url TEXT,
+    image_key TEXT,
+    caption TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now());
 
 CREATE TABLE rooms__votes (
     id UUID NOT NULL DEFAULT gen_random_uuid(),
@@ -270,6 +314,24 @@ CREATE INDEX idx_bot_traces_status ON public.rooms__bot_traces USING btree (stat
 -- rooms__bot_traces.rooms__bot_traces_pkey
 CREATE UNIQUE INDEX rooms__bot_traces_pkey ON public.rooms__bot_traces USING btree (id)
 
+-- rooms__hall_of_fame.idx_hall_of_fame_room_created
+CREATE INDEX idx_hall_of_fame_room_created ON public.rooms__hall_of_fame USING btree (room_id, created_at DESC)
+
+-- rooms__hall_of_fame.rooms__hall_of_fame_pkey
+CREATE UNIQUE INDEX rooms__hall_of_fame_pkey ON public.rooms__hall_of_fame USING btree (id)
+
+-- rooms__matchups.idx_matchups_round
+CREATE INDEX idx_matchups_round ON public.rooms__matchups USING btree (round_id)
+
+-- rooms__matchups.idx_matchups_round_ranker
+CREATE INDEX idx_matchups_round_ranker ON public.rooms__matchups USING btree (round_id, ranker_id)
+
+-- rooms__matchups.rooms__matchups_pkey
+CREATE UNIQUE INDEX rooms__matchups_pkey ON public.rooms__matchups USING btree (id)
+
+-- rooms__matchups.uq_matchups_round_ranker_pair
+CREATE UNIQUE INDEX uq_matchups_round_ranker_pair ON public.rooms__matchups USING btree (round_id, ranker_id, submission_a, submission_b)
+
 -- rooms__poll_dimensions.idx_poll_dimensions_poll
 CREATE INDEX idx_poll_dimensions_poll ON public.rooms__poll_dimensions USING btree (poll_id)
 
@@ -290,6 +352,9 @@ CREATE INDEX idx_polls_room ON public.rooms__polls USING btree (room_id)
 
 -- rooms__polls.rooms__polls_pkey
 CREATE UNIQUE INDEX rooms__polls_pkey ON public.rooms__polls USING btree (id)
+
+-- rooms__ratings.rooms__ratings_pkey
+CREATE UNIQUE INDEX rooms__ratings_pkey ON public.rooms__ratings USING btree (submission_id)
 
 -- rooms__research_suggestions.idx_suggestions_account_daily
 CREATE INDEX idx_suggestions_account_daily ON public.rooms__research_suggestions USING btree (room_id, account_id, created_at)
@@ -314,6 +379,21 @@ CREATE UNIQUE INDEX rooms__rooms_pkey ON public.rooms__rooms USING btree (id)
 
 -- rooms__rooms.uq_rooms_name
 CREATE UNIQUE INDEX uq_rooms_name ON public.rooms__rooms USING btree (name)
+
+-- rooms__rounds.idx_rounds_room_status
+CREATE INDEX idx_rounds_room_status ON public.rooms__rounds USING btree (room_id, status)
+
+-- rooms__rounds.rooms__rounds_pkey
+CREATE UNIQUE INDEX rooms__rounds_pkey ON public.rooms__rounds USING btree (id)
+
+-- rooms__rounds.uq_rounds_room_number
+CREATE UNIQUE INDEX uq_rounds_room_number ON public.rooms__rounds USING btree (room_id, round_number)
+
+-- rooms__submissions.rooms__submissions_pkey
+CREATE UNIQUE INDEX rooms__submissions_pkey ON public.rooms__submissions USING btree (id)
+
+-- rooms__submissions.uq_submissions_round_author
+CREATE UNIQUE INDEX uq_submissions_round_author ON public.rooms__submissions USING btree (round_id, author_id)
 
 -- rooms__votes.idx_votes_poll
 CREATE INDEX idx_votes_poll ON public.rooms__votes USING btree (poll_id)
@@ -371,9 +451,18 @@ CREATE UNIQUE INDEX trust__user_influence_pkey ON public.trust__user_influence U
 -- reputation__external_identities.account_id -> accounts.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__bot_traces.poll_id -> rooms__polls.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
 -- rooms__bot_traces.room_id -> rooms__rooms.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
+-- rooms__hall_of_fame.room_id -> rooms__rooms.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__hall_of_fame.round_id -> rooms__rounds.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__hall_of_fame.submission_id -> rooms__submissions.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__matchups.ranker_id -> accounts.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__matchups.round_id -> rooms__rounds.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__matchups.submission_a -> rooms__submissions.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__matchups.submission_b -> rooms__submissions.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__matchups.winner_id -> rooms__submissions.id (ON UPDATE NO ACTION, ON DELETE SET NULL)
 -- rooms__poll_dimensions.poll_id -> rooms__polls.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__poll_evidence.dimension_id -> rooms__poll_dimensions.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__polls.room_id -> rooms__rooms.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__ratings.submission_id -> rooms__submissions.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__research_suggestions.account_id -> accounts.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
 -- rooms__research_suggestions.poll_id -> rooms__polls.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
 -- rooms__research_suggestions.room_id -> rooms__rooms.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
@@ -381,6 +470,9 @@ CREATE UNIQUE INDEX trust__user_influence_pkey ON public.trust__user_influence U
 -- rooms__role_assignments.assigned_by -> accounts.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
 -- rooms__role_assignments.room_id -> rooms__rooms.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
 -- rooms__rooms.owner_id -> accounts.id (ON UPDATE NO ACTION, ON DELETE NO ACTION)
+-- rooms__rounds.room_id -> rooms__rooms.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__submissions.author_id -> accounts.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
+-- rooms__submissions.round_id -> rooms__rounds.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__votes.dimension_id -> rooms__poll_dimensions.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__votes.poll_id -> rooms__polls.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
 -- rooms__votes.user_id -> accounts.id (ON UPDATE NO ACTION, ON DELETE CASCADE)
@@ -448,6 +540,23 @@ CREATE UNIQUE INDEX trust__user_influence_pkey ON public.trust__user_influence U
 -- rooms__bot_traces: rooms__bot_traces_steps_not_null (CHECK)
 -- rooms__bot_traces: rooms__bot_traces_task_not_null (CHECK)
 -- rooms__bot_traces: rooms__bot_traces_total_cost_usd_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_created_at_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_final_rating_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_id_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_pkey (PRIMARY KEY)
+-- rooms__hall_of_fame: rooms__hall_of_fame_rank_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_room_id_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_round_id_not_null (CHECK)
+-- rooms__hall_of_fame: rooms__hall_of_fame_submission_id_not_null (CHECK)
+-- rooms__matchups: chk_matchups_ordered_pair (CHECK)
+-- rooms__matchups: rooms__matchups_created_at_not_null (CHECK)
+-- rooms__matchups: rooms__matchups_id_not_null (CHECK)
+-- rooms__matchups: rooms__matchups_pkey (PRIMARY KEY)
+-- rooms__matchups: rooms__matchups_ranker_id_not_null (CHECK)
+-- rooms__matchups: rooms__matchups_round_id_not_null (CHECK)
+-- rooms__matchups: rooms__matchups_submission_a_not_null (CHECK)
+-- rooms__matchups: rooms__matchups_submission_b_not_null (CHECK)
+-- rooms__matchups: uq_matchups_round_ranker_pair (UNIQUE)
 -- rooms__poll_dimensions: rooms__poll_dimensions_id_not_null (CHECK)
 -- rooms__poll_dimensions: rooms__poll_dimensions_max_value_not_null (CHECK)
 -- rooms__poll_dimensions: rooms__poll_dimensions_min_value_not_null (CHECK)
@@ -470,6 +579,12 @@ CREATE UNIQUE INDEX trust__user_influence_pkey ON public.trust__user_influence U
 -- rooms__polls: rooms__polls_room_id_not_null (CHECK)
 -- rooms__polls: rooms__polls_status_check (CHECK)
 -- rooms__polls: rooms__polls_status_not_null (CHECK)
+-- rooms__ratings: rooms__ratings_deviation_not_null (CHECK)
+-- rooms__ratings: rooms__ratings_matchup_count_not_null (CHECK)
+-- rooms__ratings: rooms__ratings_pkey (PRIMARY KEY)
+-- rooms__ratings: rooms__ratings_rating_not_null (CHECK)
+-- rooms__ratings: rooms__ratings_submission_id_not_null (CHECK)
+-- rooms__ratings: rooms__ratings_volatility_not_null (CHECK)
 -- rooms__research_suggestions: rooms__research_suggestions_account_id_not_null (CHECK)
 -- rooms__research_suggestions: rooms__research_suggestions_created_at_not_null (CHECK)
 -- rooms__research_suggestions: rooms__research_suggestions_evidence_ids_not_null (CHECK)
@@ -499,6 +614,25 @@ CREATE UNIQUE INDEX trust__user_influence_pkey ON public.trust__user_influence U
 -- rooms__rooms: rooms__rooms_status_check (CHECK)
 -- rooms__rooms: rooms__rooms_status_not_null (CHECK)
 -- rooms__rooms: uq_rooms_name (UNIQUE)
+-- rooms__rounds: rooms__rounds_closes_at_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_created_at_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_id_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_pkey (PRIMARY KEY)
+-- rooms__rounds: rooms__rounds_rank_opens_at_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_room_id_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_round_number_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_status_not_null (CHECK)
+-- rooms__rounds: rooms__rounds_submit_opens_at_not_null (CHECK)
+-- rooms__rounds: uq_rounds_room_number (UNIQUE)
+-- rooms__submissions: chk_submissions_image_requires_key (CHECK)
+-- rooms__submissions: chk_submissions_url_requires_url (CHECK)
+-- rooms__submissions: rooms__submissions_author_id_not_null (CHECK)
+-- rooms__submissions: rooms__submissions_content_type_not_null (CHECK)
+-- rooms__submissions: rooms__submissions_created_at_not_null (CHECK)
+-- rooms__submissions: rooms__submissions_id_not_null (CHECK)
+-- rooms__submissions: rooms__submissions_pkey (PRIMARY KEY)
+-- rooms__submissions: rooms__submissions_round_id_not_null (CHECK)
+-- rooms__submissions: uq_submissions_round_author (UNIQUE)
 -- rooms__votes: rooms__votes_created_at_not_null (CHECK)
 -- rooms__votes: rooms__votes_dimension_id_not_null (CHECK)
 -- rooms__votes: rooms__votes_id_not_null (CHECK)

--- a/web/src/api/signing.ts
+++ b/web/src/api/signing.ts
@@ -75,3 +75,66 @@ export async function signedFetchJson<T>(
 
   return fetchJson<T>(path, options);
 }
+
+/**
+ * Send a multipart/form-data request with Ed25519 auth headers.
+ *
+ * The signature is computed over an **empty** body string. The backend's
+ * `AuthenticatedDeviceParts` extractor verifies the same empty-body canonical
+ * message because multipart bodies cannot be read twice in the same handler.
+ *
+ * Do NOT set Content-Type — the browser must set it (with the form boundary).
+ */
+export async function signedFetchFormData<T>(
+  path: string,
+  method: string,
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule,
+  formData: FormData
+): Promise<T> {
+  // Sign over empty body — backend verifies the same empty-body canonical msg
+  const emptyBytes = new TextEncoder().encode('');
+  const authHeaders = await buildAuthHeaders(
+    method,
+    path,
+    emptyBytes,
+    deviceKid,
+    privateKey,
+    wasmCrypto
+  );
+
+  const url = `${(await import('@/config')).getApiBaseUrl()}${path}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: authHeaders, // No Content-Type — browser sets it with boundary
+      body: formData,
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('The request was cancelled.');
+    }
+    throw new Error('Unable to connect. Check your internet connection and try again.');
+  }
+
+  if (!response.ok) {
+    let errorMessage = `HTTP ${String(response.status)}: ${response.statusText}`;
+    try {
+      const errorBody = (await response.json()) as { error?: string };
+      if (errorBody.error) {
+        errorMessage = errorBody.error;
+      }
+    } catch {
+      // JSON parsing failed, use default
+    }
+    throw new Error(errorMessage);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/web/src/engines/ranking/RankingEngineView.tsx
+++ b/web/src/engines/ranking/RankingEngineView.tsx
@@ -1,0 +1,103 @@
+/**
+ * RankingEngineView — room detail page for the ranking (meme tournament) engine.
+ *
+ * Shows tabs for submitting memes, ranking pairs, viewing the leaderboard,
+ * and browsing the Hall of Fame.
+ */
+
+import { Center, Loader, Stack, Tabs, Text } from '@mantine/core';
+import type { EngineViewProps } from '../api';
+import { useCurrentRounds, useListRounds } from './api';
+import { HallOfFame } from './components/HallOfFame';
+import { Leaderboard } from './components/Leaderboard';
+import { RankView } from './components/RankView';
+import { SubmitView } from './components/SubmitView';
+
+function resolveDefaultTab(submittingRound: boolean, rankingRound: boolean): string {
+  if (rankingRound) {
+    return 'rank';
+  }
+  if (submittingRound) {
+    return 'submit';
+  }
+  return 'leaderboard';
+}
+
+export function RankingEngineView({ roomId }: EngineViewProps) {
+  const { data: currentRounds, isLoading: currentLoading } = useCurrentRounds(roomId);
+  const { data: allRounds } = useListRounds(roomId);
+
+  const submittingRound = currentRounds?.find((r) => r.status === 'submitting');
+  const rankingRound = currentRounds?.find((r) => r.status === 'ranking');
+
+  // Most recent closed round for leaderboard default
+  const mostRecentRound =
+    rankingRound ??
+    submittingRound ??
+    allRounds?.slice().sort((a, b) => b.round_number - a.round_number)[0];
+
+  const defaultTab = resolveDefaultTab(Boolean(submittingRound), Boolean(rankingRound));
+
+  if (currentLoading) {
+    return (
+      <Center mt="xl">
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  return (
+    <Stack gap="lg" maw={900} mx="auto" mt="xl" px="md">
+      <Tabs defaultValue={defaultTab}>
+        <Tabs.List>
+          <Tabs.Tab value="submit" disabled={!submittingRound}>
+            Submit
+          </Tabs.Tab>
+          <Tabs.Tab value="rank" disabled={!rankingRound}>
+            Rank
+          </Tabs.Tab>
+          <Tabs.Tab value="leaderboard">Leaderboard</Tabs.Tab>
+          <Tabs.Tab value="hall-of-fame">Hall of Fame</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="submit">
+          {submittingRound ? (
+            <SubmitView roomId={roomId} round={submittingRound} />
+          ) : (
+            <Text size="sm" c="dimmed" mt="md">
+              No submission window is open right now.
+            </Text>
+          )}
+        </Tabs.Panel>
+
+        <Tabs.Panel value="rank">
+          {rankingRound ? (
+            <RankView roomId={roomId} round={rankingRound} />
+          ) : (
+            <Text size="sm" c="dimmed" mt="md">
+              No ranking window is open right now.
+            </Text>
+          )}
+        </Tabs.Panel>
+
+        <Tabs.Panel value="leaderboard">
+          {mostRecentRound ? (
+            <Leaderboard
+              roomId={roomId}
+              roundId={mostRecentRound.id}
+              roundStatus={mostRecentRound.status}
+            />
+          ) : (
+            <Text size="sm" c="dimmed" mt="md">
+              No rounds have started yet.
+            </Text>
+          )}
+        </Tabs.Panel>
+
+        <Tabs.Panel value="hall-of-fame">
+          <HallOfFame roomId={roomId} />
+        </Tabs.Panel>
+      </Tabs>
+    </Stack>
+  );
+}

--- a/web/src/engines/ranking/api/client.ts
+++ b/web/src/engines/ranking/api/client.ts
@@ -1,0 +1,156 @@
+/**
+ * Ranking engine API client
+ * Type-safe REST client for ranking rounds, submissions, matchups, and leaderboard endpoints
+ */
+
+import { fetchJson } from '@/api/fetchClient';
+import { signedFetchJson } from '@/api/signing';
+import type { CryptoModule } from '@/providers/CryptoProvider';
+
+// === Types ===
+
+export interface Round {
+  id: string;
+  room_id: string;
+  round_number: number;
+  submit_opens_at: string;
+  rank_opens_at: string;
+  closes_at: string;
+  status: 'submitting' | 'ranking' | 'closed';
+}
+
+export interface Submission {
+  id: string;
+  round_id: string;
+  author_id?: string;
+  content_type: 'url' | 'image';
+  url?: string;
+  image_key?: string;
+  caption?: string;
+  created_at: string;
+}
+
+export interface MatchupPair {
+  submission_a: Submission;
+  submission_b: Submission;
+}
+
+export interface MatchupResult {
+  id: string;
+  winner_id?: string;
+  created_at: string;
+}
+
+export interface LeaderboardEntry {
+  submission: Submission;
+  rating: number;
+  deviation: number;
+  matchup_count: number;
+  rank: number;
+}
+
+export interface LeaderboardResponse {
+  round_id: string;
+  round_status: string;
+  entries: LeaderboardEntry[];
+}
+
+export interface HallOfFameEntry {
+  submission: Submission & { author_id: string };
+  round_number: number;
+  final_rating: number;
+  rank: number;
+}
+
+export interface SubmitBody {
+  content_type: string;
+  url?: string;
+  image_key?: string;
+  caption?: string;
+}
+
+export interface RecordMatchupBody {
+  winner_id?: string;
+  loser_id?: string;
+  submission_a?: string;
+  submission_b?: string;
+  skipped?: boolean;
+}
+
+// === Public endpoints (no auth) ===
+
+export async function getCurrentRounds(roomId: string): Promise<Round[]> {
+  return fetchJson(`/api/v1/rooms/${roomId}/rounds/current`);
+}
+
+export async function listRounds(roomId: string): Promise<Round[]> {
+  return fetchJson(`/api/v1/rooms/${roomId}/rounds`);
+}
+
+export async function getLeaderboard(
+  roomId: string,
+  roundId: string
+): Promise<LeaderboardResponse> {
+  return fetchJson(`/api/v1/rooms/${roomId}/rounds/${roundId}/leaderboard`);
+}
+
+export async function getHallOfFame(
+  roomId: string,
+  limit = 20,
+  offset = 0
+): Promise<HallOfFameEntry[]> {
+  return fetchJson(
+    `/api/v1/rooms/${roomId}/hall-of-fame?limit=${String(limit)}&offset=${String(offset)}`
+  );
+}
+
+// === Authenticated endpoints ===
+
+export async function submitMeme(
+  roomId: string,
+  body: SubmitBody,
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<Submission> {
+  return signedFetchJson(
+    `/api/v1/rooms/${roomId}/submissions`,
+    'POST',
+    deviceKid,
+    privateKey,
+    wasmCrypto,
+    body
+  );
+}
+
+export async function getMatchup(
+  roomId: string,
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<MatchupPair> {
+  return signedFetchJson(
+    `/api/v1/rooms/${roomId}/matchup`,
+    'GET',
+    deviceKid,
+    privateKey,
+    wasmCrypto
+  );
+}
+
+export async function recordMatchup(
+  roomId: string,
+  body: RecordMatchupBody,
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<MatchupResult> {
+  return signedFetchJson(
+    `/api/v1/rooms/${roomId}/matchups`,
+    'POST',
+    deviceKid,
+    privateKey,
+    wasmCrypto,
+    body
+  );
+}

--- a/web/src/engines/ranking/api/client.ts
+++ b/web/src/engines/ranking/api/client.ts
@@ -4,7 +4,7 @@
  */
 
 import { fetchJson } from '@/api/fetchClient';
-import { signedFetchJson } from '@/api/signing';
+import { signedFetchFormData, signedFetchJson } from '@/api/signing';
 import type { CryptoModule } from '@/providers/CryptoProvider';
 
 // === Types ===
@@ -120,6 +120,29 @@ export async function submitMeme(
     privateKey,
     wasmCrypto,
     body
+  );
+}
+
+export async function submitMemeWithImage(
+  roomId: string,
+  image: File,
+  caption: string | undefined,
+  deviceKid: string,
+  privateKey: CryptoKey,
+  wasmCrypto: CryptoModule
+): Promise<Submission> {
+  const formData = new FormData();
+  formData.append('image', image);
+  if (caption) {
+    formData.append('caption', caption);
+  }
+  return signedFetchFormData(
+    `/api/v1/rooms/${roomId}/submissions/upload`,
+    'POST',
+    deviceKid,
+    privateKey,
+    wasmCrypto,
+    formData
   );
 }
 

--- a/web/src/engines/ranking/api/index.ts
+++ b/web/src/engines/ranking/api/index.ts
@@ -1,0 +1,2 @@
+export * from './client';
+export * from './queries';

--- a/web/src/engines/ranking/api/queries.ts
+++ b/web/src/engines/ranking/api/queries.ts
@@ -12,6 +12,7 @@ import {
   listRounds,
   recordMatchup,
   submitMeme,
+  submitMemeWithImage,
   type HallOfFameEntry,
   type LeaderboardResponse,
   type MatchupPair,
@@ -91,6 +92,28 @@ export function useSubmitMeme(roomId: string) {
   >({
     mutationFn: ({ body, deviceKid, privateKey, wasmCrypto }) =>
       submitMeme(roomId, body, deviceKid, privateKey, wasmCrypto),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ranking', 'rounds', 'current', roomId] });
+    },
+  });
+}
+
+export function useSubmitMemeWithImage(roomId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Submission,
+    Error,
+    {
+      image: File;
+      caption?: string;
+      deviceKid: string;
+      privateKey: CryptoKey;
+      wasmCrypto: CryptoModule;
+    }
+  >({
+    mutationFn: ({ image, caption, deviceKid, privateKey, wasmCrypto }) =>
+      submitMemeWithImage(roomId, image, caption, deviceKid, privateKey, wasmCrypto),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['ranking', 'rounds', 'current', roomId] });
     },

--- a/web/src/engines/ranking/api/queries.ts
+++ b/web/src/engines/ranking/api/queries.ts
@@ -1,0 +1,115 @@
+/**
+ * TanStack Query hooks for the ranking engine
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CryptoModule } from '@/providers/CryptoProvider';
+import {
+  getCurrentRounds,
+  getHallOfFame,
+  getLeaderboard,
+  getMatchup,
+  listRounds,
+  recordMatchup,
+  submitMeme,
+  type HallOfFameEntry,
+  type LeaderboardResponse,
+  type MatchupPair,
+  type MatchupResult,
+  type RecordMatchupBody,
+  type Round,
+  type Submission,
+  type SubmitBody,
+} from './client';
+
+export function useCurrentRounds(roomId: string) {
+  return useQuery<Round[]>({
+    queryKey: ['ranking', 'rounds', 'current', roomId],
+    queryFn: () => getCurrentRounds(roomId),
+    enabled: Boolean(roomId),
+    refetchInterval: 15_000,
+  });
+}
+
+export function useListRounds(roomId: string) {
+  return useQuery<Round[]>({
+    queryKey: ['ranking', 'rounds', roomId],
+    queryFn: () => listRounds(roomId),
+    enabled: Boolean(roomId),
+    refetchInterval: 15_000,
+  });
+}
+
+export function useLeaderboard(roomId: string, roundId: string | undefined) {
+  return useQuery<LeaderboardResponse>({
+    queryKey: ['ranking', 'leaderboard', roomId, roundId],
+    queryFn: () => {
+      if (!roundId) {
+        throw new Error('roundId is required');
+      }
+      return getLeaderboard(roomId, roundId);
+    },
+    enabled: Boolean(roomId && roundId),
+    refetchInterval: 15_000,
+  });
+}
+
+export function useHallOfFame(roomId: string) {
+  return useQuery<HallOfFameEntry[]>({
+    queryKey: ['ranking', 'hallOfFame', roomId],
+    queryFn: () => getHallOfFame(roomId),
+    enabled: Boolean(roomId),
+  });
+}
+
+export function useMatchup(
+  roomId: string,
+  deviceKid: string | null,
+  privateKey: CryptoKey | null,
+  wasmCrypto: CryptoModule | null
+) {
+  return useQuery<MatchupPair>({
+    queryKey: ['ranking', 'matchup', roomId],
+    queryFn: () => {
+      if (!deviceKid || !privateKey || !wasmCrypto) {
+        throw new Error('Not authenticated');
+      }
+      return getMatchup(roomId, deviceKid, privateKey, wasmCrypto);
+    },
+    enabled: Boolean(roomId && deviceKid && privateKey && wasmCrypto),
+    retry: false,
+  });
+}
+
+export function useSubmitMeme(roomId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Submission,
+    Error,
+    { body: SubmitBody; deviceKid: string; privateKey: CryptoKey; wasmCrypto: CryptoModule }
+  >({
+    mutationFn: ({ body, deviceKid, privateKey, wasmCrypto }) =>
+      submitMeme(roomId, body, deviceKid, privateKey, wasmCrypto),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ranking', 'rounds', 'current', roomId] });
+    },
+  });
+}
+
+export function useRecordMatchup(roomId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    MatchupResult,
+    Error,
+    { body: RecordMatchupBody; deviceKid: string; privateKey: CryptoKey; wasmCrypto: CryptoModule }
+  >({
+    mutationFn: ({ body, deviceKid, privateKey, wasmCrypto }) =>
+      recordMatchup(roomId, body, deviceKid, privateKey, wasmCrypto),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ranking', 'matchup', roomId] });
+      void queryClient.invalidateQueries({ queryKey: ['ranking', 'leaderboard', roomId] });
+    },
+  });
+}

--- a/web/src/engines/ranking/components/HallOfFame.tsx
+++ b/web/src/engines/ranking/components/HallOfFame.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { Badge, Button, Card, Center, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { getHallOfFame, type HallOfFameEntry } from '../api';
+
+const PAGE_SIZE = 20;
+
+interface Props {
+  roomId: string;
+}
+
+function HallOfFameCard({ entry }: { entry: HallOfFameEntry }) {
+  return (
+    <Card withBorder padding="sm" radius="sm">
+      <Group justify="space-between" wrap="nowrap" align="flex-start">
+        <Stack gap={4}>
+          <Group gap="xs" wrap="nowrap">
+            <Badge color="yellow" variant="filled" size="sm">
+              Round {String(entry.round_number)}
+            </Badge>
+            <Badge color="blue" variant="light" size="sm">
+              #{String(entry.rank)}
+            </Badge>
+          </Group>
+          {entry.submission.content_type === 'url' && entry.submission.url ? (
+            <Text size="sm" truncate maw={300} c="blue" td="underline">
+              {entry.submission.url}
+            </Text>
+          ) : null}
+          {entry.submission.content_type === 'image' ? (
+            <Text size="sm" c="dimmed" fs="italic">
+              [image]
+            </Text>
+          ) : null}
+          {entry.submission.caption ? <Text size="sm">{entry.submission.caption}</Text> : null}
+          <Text size="xs" c="dimmed">
+            by {entry.submission.author_id}
+          </Text>
+        </Stack>
+        <Stack gap={2} align="flex-end">
+          <Text size="xs" c="dimmed">
+            Rating
+          </Text>
+          <Text size="sm" fw={600}>
+            {entry.final_rating.toFixed(0)}
+          </Text>
+        </Stack>
+      </Group>
+    </Card>
+  );
+}
+
+type LoadState = 'idle' | 'loading' | 'error';
+
+export function HallOfFame({ roomId }: Props) {
+  const [entries, setEntries] = useState<HallOfFameEntry[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [initialState, setInitialState] = useState<LoadState>('loading');
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Initial load — useEffect would be cleaner but this component manages its own
+  // pagination state outside the query cache, so we use a ref-guarded one-shot.
+  const [initialized, setInitialized] = useState(false);
+  if (!initialized) {
+    setInitialized(true);
+    getHallOfFame(roomId, PAGE_SIZE, 0)
+      .then((data) => {
+        setEntries(data);
+        setHasMore(data.length === PAGE_SIZE);
+        setOffset(data.length);
+        setInitialState('idle');
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load Hall of Fame');
+        setInitialState('error');
+      });
+  }
+
+  const handleLoadMore = () => {
+    setIsLoadingMore(true);
+    getHallOfFame(roomId, PAGE_SIZE, offset)
+      .then((data) => {
+        setEntries((prev) => [...prev, ...data]);
+        setHasMore(data.length === PAGE_SIZE);
+        setOffset((prev) => prev + data.length);
+        setIsLoadingMore(false);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load more');
+        setIsLoadingMore(false);
+      });
+  };
+
+  if (initialState === 'loading') {
+    return (
+      <Center mt="xl">
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  if (initialState === 'error') {
+    return (
+      <Text size="sm" c="red" mt="md">
+        {error}
+      </Text>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Text size="sm" c="dimmed" mt="md">
+        No winners yet — complete a round to see the Hall of Fame.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="md" mt="md">
+      <Title order={4}>Hall of Fame</Title>
+      {entries.map((entry, i) => (
+        <HallOfFameCard
+          key={`${String(entry.round_number)}-${String(entry.rank)}-${String(i)}`}
+          entry={entry}
+        />
+      ))}
+      {hasMore ? (
+        <Button
+          variant="subtle"
+          onClick={handleLoadMore}
+          loading={isLoadingMore}
+          size="sm"
+          mx="auto"
+        >
+          Load more
+        </Button>
+      ) : null}
+    </Stack>
+  );
+}

--- a/web/src/engines/ranking/components/HallOfFame.tsx
+++ b/web/src/engines/ranking/components/HallOfFame.tsx
@@ -1,5 +1,17 @@
 import { useState } from 'react';
-import { Badge, Button, Card, Center, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import {
+  Badge,
+  Button,
+  Card,
+  Center,
+  Group,
+  Image,
+  Loader,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { getApiBaseUrl } from '@/config';
 import { getHallOfFame, type HallOfFameEntry } from '../api';
 
 const PAGE_SIZE = 20;
@@ -26,10 +38,14 @@ function HallOfFameCard({ entry }: { entry: HallOfFameEntry }) {
               {entry.submission.url}
             </Text>
           ) : null}
-          {entry.submission.content_type === 'image' ? (
-            <Text size="sm" c="dimmed" fs="italic">
-              [image]
-            </Text>
+          {entry.submission.content_type === 'image' && entry.submission.image_key ? (
+            <Image
+              src={`${getApiBaseUrl()}/api/v1/uploads/${entry.submission.image_key}`}
+              alt={entry.submission.caption ?? 'Submission'}
+              maw={200}
+              radius="sm"
+              fallbackSrc="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+            />
           ) : null}
           {entry.submission.caption ? <Text size="sm">{entry.submission.caption}</Text> : null}
           <Text size="xs" c="dimmed">

--- a/web/src/engines/ranking/components/Leaderboard.tsx
+++ b/web/src/engines/ranking/components/Leaderboard.tsx
@@ -1,4 +1,5 @@
-import { Badge, Center, Loader, Stack, Table, Text, Title } from '@mantine/core';
+import { Badge, Center, Image, Loader, Stack, Table, Text, Title } from '@mantine/core';
+import { getApiBaseUrl } from '@/config';
 import { useLeaderboard, type Submission } from '../api';
 
 interface Props {
@@ -41,9 +42,13 @@ function SubmissionPreviewCell({
         </Text>
       ) : null}
       {submission.content_type === 'image' && submission.image_key ? (
-        <Text size="sm" c="dimmed" fs="italic">
-          [image]
-        </Text>
+        <Image
+          src={`${getApiBaseUrl()}/api/v1/uploads/${submission.image_key}`}
+          alt={submission.caption ?? 'Submission'}
+          maw={120}
+          radius="sm"
+          fallbackSrc="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        />
       ) : null}
       {submission.caption ? (
         <Text size="xs" c="dimmed" truncate maw={250}>

--- a/web/src/engines/ranking/components/Leaderboard.tsx
+++ b/web/src/engines/ranking/components/Leaderboard.tsx
@@ -1,0 +1,135 @@
+import { Badge, Center, Loader, Stack, Table, Text, Title } from '@mantine/core';
+import { useLeaderboard, type Submission } from '../api';
+
+interface Props {
+  roomId: string;
+  roundId: string;
+  roundStatus: string;
+}
+
+const RANK_COLORS: Record<number, string> = {
+  1: 'yellow',
+  2: 'gray',
+  3: 'orange',
+};
+
+function rankLabel(rank: number): string {
+  if (rank === 1) {
+    return '1st';
+  }
+  if (rank === 2) {
+    return '2nd';
+  }
+  if (rank === 3) {
+    return '3rd';
+  }
+  return `${String(rank)}th`;
+}
+
+function SubmissionPreviewCell({
+  submission,
+  showAuthor,
+}: {
+  submission: Submission;
+  showAuthor: boolean;
+}) {
+  return (
+    <Stack gap={2}>
+      {submission.content_type === 'url' && submission.url ? (
+        <Text size="sm" truncate maw={250} c="blue" td="underline">
+          {submission.url}
+        </Text>
+      ) : null}
+      {submission.content_type === 'image' && submission.image_key ? (
+        <Text size="sm" c="dimmed" fs="italic">
+          [image]
+        </Text>
+      ) : null}
+      {submission.caption ? (
+        <Text size="xs" c="dimmed" truncate maw={250}>
+          {submission.caption}
+        </Text>
+      ) : null}
+      {showAuthor && submission.author_id ? (
+        <Text size="xs" c="dimmed">
+          by {submission.author_id}
+        </Text>
+      ) : null}
+    </Stack>
+  );
+}
+
+export function Leaderboard({ roomId, roundId, roundStatus }: Props) {
+  const { data, isLoading, isError, error } = useLeaderboard(roomId, roundId);
+
+  const showAuthor = roundStatus === 'closed';
+
+  if (isLoading) {
+    return (
+      <Center mt="xl">
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Text size="sm" c="red" mt="md">
+        {error.message}
+      </Text>
+    );
+  }
+
+  if (!data || data.entries.length === 0) {
+    return (
+      <Text size="sm" c="dimmed" mt="md">
+        No submissions yet.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="md" mt="md">
+      <Title order={4}>Leaderboard</Title>
+      {roundStatus === 'ranking' ? (
+        <Text size="xs" c="dimmed">
+          Authors are hidden during the ranking phase.
+        </Text>
+      ) : null}
+      <Table striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Rank</Table.Th>
+            <Table.Th>Submission</Table.Th>
+            <Table.Th>Rating</Table.Th>
+            <Table.Th>Matchups</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {data.entries.map((entry) => (
+            <Table.Tr key={entry.submission.id}>
+              <Table.Td>
+                <Badge
+                  color={RANK_COLORS[entry.rank] ?? 'blue'}
+                  variant={entry.rank <= 3 ? 'filled' : 'light'}
+                  size="sm"
+                >
+                  {rankLabel(entry.rank)}
+                </Badge>
+              </Table.Td>
+              <Table.Td>
+                <SubmissionPreviewCell submission={entry.submission} showAuthor={showAuthor} />
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm">{entry.rating.toFixed(0)}</Text>
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm">{String(entry.matchup_count)}</Text>
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Stack>
+  );
+}

--- a/web/src/engines/ranking/components/RankView.tsx
+++ b/web/src/engines/ranking/components/RankView.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   Title,
 } from '@mantine/core';
+import { getApiBaseUrl } from '@/config';
 import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
 import { useMatchup, useRecordMatchup, type Round, type Submission } from '../api';
@@ -47,7 +48,7 @@ function SubmissionCard({
       <Stack gap="xs">
         {submission.content_type === 'image' && submission.image_key ? (
           <Image
-            src={submission.image_key}
+            src={`${getApiBaseUrl()}/api/v1/uploads/${submission.image_key}`}
             alt="Submission"
             radius="sm"
             fit="contain"

--- a/web/src/engines/ranking/components/RankView.tsx
+++ b/web/src/engines/ranking/components/RankView.tsx
@@ -1,0 +1,245 @@
+import { useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  Center,
+  Group,
+  Image,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { useCrypto } from '@/providers/CryptoProvider';
+import { useDevice } from '@/providers/DeviceProvider';
+import { useMatchup, useRecordMatchup, type Round, type Submission } from '../api';
+
+interface Props {
+  roomId: string;
+  round: Round;
+}
+
+function SubmissionCard({
+  submission,
+  onPick,
+  isPicking,
+  isSelected,
+}: {
+  submission: Submission;
+  onPick: () => void;
+  isPicking: boolean;
+  isSelected: boolean;
+}) {
+  return (
+    <Card
+      withBorder
+      padding="md"
+      radius="md"
+      onClick={onPick}
+      style={{
+        cursor: isPicking ? 'not-allowed' : 'pointer',
+        outline: isSelected ? '2px solid var(--mantine-color-blue-5)' : undefined,
+        transition: 'outline 0.1s ease',
+      }}
+    >
+      <Stack gap="xs">
+        {submission.content_type === 'image' && submission.image_key ? (
+          <Image
+            src={submission.image_key}
+            alt="Submission"
+            radius="sm"
+            fit="contain"
+            mah={300}
+            fallbackSrc="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          />
+        ) : null}
+        {submission.content_type === 'url' && submission.url ? (
+          <Card withBorder padding="xs" radius="sm" bg="gray.0">
+            <Text size="sm" truncate c="blue" td="underline">
+              {submission.url}
+            </Text>
+          </Card>
+        ) : null}
+        {submission.caption ? (
+          <Text size="sm" c="dimmed">
+            {submission.caption}
+          </Text>
+        ) : null}
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            onPick();
+          }}
+          disabled={isPicking}
+          variant={isSelected ? 'filled' : 'light'}
+          size="sm"
+          fullWidth
+        >
+          {isSelected ? 'Picking...' : 'Pick this one'}
+        </Button>
+      </Stack>
+    </Card>
+  );
+}
+
+export function RankView({ roomId, round }: Props) {
+  const { deviceKid, privateKey } = useDevice();
+  const { crypto } = useCrypto();
+  const [matchupCount, setMatchupCount] = useState(0);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const matchupQuery = useMatchup(roomId, deviceKid, privateKey, crypto);
+  const recordMutation = useRecordMatchup(roomId);
+
+  const isAuthenticated = Boolean(deviceKid && privateKey && crypto);
+
+  const handlePick = (winnerId: string, loserId: string) => {
+    if (!deviceKid || !privateKey || !crypto) {
+      return;
+    }
+    setSelectedId(winnerId);
+
+    const pair = matchupQuery.data;
+    if (!pair) {
+      return;
+    }
+
+    recordMutation.mutate(
+      {
+        body: {
+          winner_id: winnerId,
+          loser_id: loserId,
+          submission_a: pair.submission_a.id,
+          submission_b: pair.submission_b.id,
+        },
+        deviceKid,
+        privateKey,
+        wasmCrypto: crypto,
+      },
+      {
+        onSuccess: () => {
+          setMatchupCount((c) => c + 1);
+          setSelectedId(null);
+        },
+        onError: () => {
+          setSelectedId(null);
+        },
+      }
+    );
+  };
+
+  const handleSkip = () => {
+    if (!deviceKid || !privateKey || !crypto) {
+      return;
+    }
+
+    const pair = matchupQuery.data;
+    if (!pair) {
+      return;
+    }
+
+    recordMutation.mutate(
+      {
+        body: {
+          submission_a: pair.submission_a.id,
+          submission_b: pair.submission_b.id,
+          skipped: true,
+        },
+        deviceKid,
+        privateKey,
+        wasmCrypto: crypto,
+      },
+      {
+        onSuccess: () => {
+          setMatchupCount((c) => c + 1);
+        },
+      }
+    );
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <Stack gap="md" mt="md">
+        <Text size="sm" c="dimmed">
+          Sign in to rank memes.
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (matchupQuery.isLoading || recordMutation.isPending) {
+    return (
+      <Center mt="xl">
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  // 404 or no matchups available
+  if (matchupQuery.isError || !matchupQuery.data) {
+    return (
+      <Stack gap="md" mt="md" ta="center">
+        <Title order={4}>You've ranked everything!</Title>
+        <Text size="sm" c="dimmed">
+          No more pairs to rank right now. Check back soon or see the leaderboard.
+        </Text>
+        {matchupCount > 0 ? (
+          <Badge color="green" variant="light" size="lg" mx="auto">
+            {matchupCount} {matchupCount === 1 ? 'matchup' : 'matchups'} ranked
+          </Badge>
+        ) : null}
+      </Stack>
+    );
+  }
+
+  const { submission_a, submission_b } = matchupQuery.data;
+  const isPicking = recordMutation.isPending;
+
+  return (
+    <Stack gap="md" mt="md">
+      <Group justify="space-between" wrap="nowrap">
+        <Title order={4}>Which is better?</Title>
+        {matchupCount > 0 ? (
+          <Badge color="blue" variant="light" size="sm">
+            {matchupCount} ranked
+          </Badge>
+        ) : null}
+      </Group>
+
+      <Text size="sm" c="dimmed">
+        Round {String(round.round_number)} — tap your pick
+      </Text>
+
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+        <SubmissionCard
+          submission={submission_a}
+          onPick={() => {
+            handlePick(submission_a.id, submission_b.id);
+          }}
+          isPicking={isPicking}
+          isSelected={selectedId === submission_a.id}
+        />
+        <SubmissionCard
+          submission={submission_b}
+          onPick={() => {
+            handlePick(submission_b.id, submission_a.id);
+          }}
+          isPicking={isPicking}
+          isSelected={selectedId === submission_b.id}
+        />
+      </SimpleGrid>
+
+      {recordMutation.error ? (
+        <Text size="sm" c="red">
+          {recordMutation.error.message}
+        </Text>
+      ) : null}
+
+      <Button variant="subtle" color="gray" onClick={handleSkip} disabled={isPicking} size="sm">
+        Can't decide — skip
+      </Button>
+    </Stack>
+  );
+}

--- a/web/src/engines/ranking/components/RoundCountdown.tsx
+++ b/web/src/engines/ranking/components/RoundCountdown.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { Text } from '@mantine/core';
+
+interface Props {
+  deadline: string;
+  label: string;
+}
+
+function formatTimeRemaining(seconds: number): string {
+  if (seconds <= 0) {
+    return 'Closed';
+  }
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) {
+    return `${String(h)}h ${String(m)}m ${String(s)}s`;
+  }
+  if (m > 0) {
+    return `${String(m)}m ${String(s)}s`;
+  }
+  return `${String(s)}s`;
+}
+
+export function RoundCountdown({ deadline, label }: Props) {
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+
+  useEffect(() => {
+    const update = () => {
+      const ms = new Date(deadline).getTime() - Date.now();
+      setSecondsLeft(Math.max(0, Math.floor(ms / 1000)));
+    };
+
+    update();
+    const id = setInterval(update, 1000);
+    return () => {
+      clearInterval(id);
+    };
+  }, [deadline]);
+
+  if (secondsLeft === null) {
+    return null;
+  }
+
+  const isClosed = secondsLeft <= 0;
+  const isUrgent = secondsLeft > 0 && secondsLeft <= 60;
+
+  return (
+    <Text
+      size="sm"
+      c={isClosed ? 'dimmed' : isUrgent ? 'red' : 'dimmed'}
+      fw={isUrgent ? 600 : undefined}
+    >
+      {label}: {isClosed ? 'Closed' : formatTimeRemaining(secondsLeft)}
+    </Text>
+  );
+}

--- a/web/src/engines/ranking/components/SubmitView.tsx
+++ b/web/src/engines/ranking/components/SubmitView.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  FileInput,
+  Group,
+  Image,
+  SegmentedControl,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useCrypto } from '@/providers/CryptoProvider';
+import { useDevice } from '@/providers/DeviceProvider';
+import { useSubmitMeme, type Round, type Submission } from '../api';
+import { RoundCountdown } from './RoundCountdown';
+
+interface Props {
+  roomId: string;
+  round: Round;
+}
+
+type ContentMode = 'url' | 'image';
+
+function SubmissionPreview({ submission }: { submission: Submission }) {
+  return (
+    <Card withBorder padding="sm" radius="sm">
+      <Stack gap="xs">
+        <Group gap="xs">
+          <Badge color="green" variant="filled" size="sm">
+            Submitted
+          </Badge>
+          <Text size="xs" c="dimmed">
+            {submission.content_type === 'url' ? 'URL' : 'Image'}
+          </Text>
+        </Group>
+        {submission.content_type === 'url' && submission.url ? (
+          <Text size="sm" truncate>
+            {submission.url}
+          </Text>
+        ) : null}
+        {submission.content_type === 'image' && submission.image_key ? (
+          <Image
+            src={submission.image_key}
+            alt="Submitted meme"
+            maw={300}
+            radius="sm"
+            fallbackSrc="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          />
+        ) : null}
+        {submission.caption ? (
+          <Text size="sm" c="dimmed">
+            {submission.caption}
+          </Text>
+        ) : null}
+      </Stack>
+    </Card>
+  );
+}
+
+export function SubmitView({ roomId, round }: Props) {
+  const { deviceKid, privateKey } = useDevice();
+  const { crypto } = useCrypto();
+  const submitMutation = useSubmitMeme(roomId);
+
+  const [mode, setMode] = useState<ContentMode>('url');
+  const [url, setUrl] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [caption, setCaption] = useState('');
+  const [submitted, setSubmitted] = useState<Submission | null>(null);
+
+  const isAuthenticated = Boolean(deviceKid && privateKey && crypto);
+  const hasContent = mode === 'url' ? url.trim().length > 0 : imageFile !== null;
+
+  const handleSubmit = () => {
+    if (!deviceKid || !privateKey || !crypto) {
+      return;
+    }
+    if (!hasContent) {
+      return;
+    }
+
+    const body =
+      mode === 'url'
+        ? {
+            content_type: 'url' as const,
+            url: url.trim(),
+            caption: caption.trim() || undefined,
+          }
+        : {
+            content_type: 'image' as const,
+            // image_key would be set after upload; placeholder for now
+            image_key: imageFile?.name,
+            caption: caption.trim() || undefined,
+          };
+
+    submitMutation.mutate(
+      { body, deviceKid, privateKey, wasmCrypto: crypto },
+      {
+        onSuccess: (result) => {
+          setSubmitted(result);
+        },
+      }
+    );
+  };
+
+  if (submitted) {
+    return (
+      <Stack gap="md" mt="md">
+        <Title order={4}>Your submission</Title>
+        <SubmissionPreview submission={submitted} />
+        <Text size="sm" c="dimmed">
+          Ranking opens when the submission window closes.
+        </Text>
+        <RoundCountdown deadline={round.rank_opens_at} label="Ranking opens" />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="md" mt="md">
+      <Group justify="space-between" wrap="nowrap">
+        <Title order={4}>Submit a meme</Title>
+        <RoundCountdown deadline={round.rank_opens_at} label="Closes" />
+      </Group>
+
+      {!isAuthenticated ? (
+        <Text size="sm" c="dimmed">
+          Sign in to submit a meme.
+        </Text>
+      ) : (
+        <>
+          <SegmentedControl
+            value={mode}
+            onChange={(v) => {
+              setMode(v as ContentMode);
+            }}
+            data={[
+              { label: 'URL', value: 'url' },
+              { label: 'Image', value: 'image' },
+            ]}
+            size="sm"
+          />
+
+          {mode === 'url' ? (
+            <TextInput
+              label="Meme URL"
+              placeholder="https://example.com/meme.jpg"
+              value={url}
+              onChange={(e) => {
+                setUrl(e.currentTarget.value);
+              }}
+            />
+          ) : (
+            <FileInput
+              label="Upload image"
+              placeholder="Click to select file"
+              accept="image/*"
+              value={imageFile}
+              onChange={setImageFile}
+            />
+          )}
+
+          <TextInput
+            label="Caption (optional)"
+            placeholder="Add a caption..."
+            value={caption}
+            onChange={(e) => {
+              setCaption(e.currentTarget.value);
+            }}
+            maxLength={280}
+            rightSection={
+              <Text size="xs" c="dimmed">
+                {caption.length}/280
+              </Text>
+            }
+            rightSectionWidth={60}
+          />
+
+          {mode === 'url' && url.trim() ? (
+            <Card withBorder padding="sm" radius="sm">
+              <Stack gap="xs">
+                <Text size="xs" c="dimmed" fw={600}>
+                  Preview
+                </Text>
+                <Text size="sm" truncate>
+                  {url}
+                </Text>
+                {caption ? <Text size="sm">{caption}</Text> : null}
+              </Stack>
+            </Card>
+          ) : null}
+
+          {mode === 'image' && imageFile ? (
+            <Card withBorder padding="sm" radius="sm">
+              <Stack gap="xs">
+                <Text size="xs" c="dimmed" fw={600}>
+                  Preview
+                </Text>
+                <Image src={URL.createObjectURL(imageFile)} alt="Preview" maw={300} radius="sm" />
+                {caption ? <Text size="sm">{caption}</Text> : null}
+              </Stack>
+            </Card>
+          ) : null}
+
+          {submitMutation.error ? (
+            <Text size="sm" c="red">
+              {submitMutation.error.message}
+            </Text>
+          ) : null}
+
+          <Button onClick={handleSubmit} disabled={!hasContent} loading={submitMutation.isPending}>
+            Submit
+          </Button>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/web/src/engines/ranking/components/SubmitView.tsx
+++ b/web/src/engines/ranking/components/SubmitView.tsx
@@ -12,9 +12,10 @@ import {
   TextInput,
   Title,
 } from '@mantine/core';
+import { getApiBaseUrl } from '@/config';
 import { useCrypto } from '@/providers/CryptoProvider';
 import { useDevice } from '@/providers/DeviceProvider';
-import { useSubmitMeme, type Round, type Submission } from '../api';
+import { useSubmitMeme, useSubmitMemeWithImage, type Round, type Submission } from '../api';
 import { RoundCountdown } from './RoundCountdown';
 
 interface Props {
@@ -43,7 +44,7 @@ function SubmissionPreview({ submission }: { submission: Submission }) {
         ) : null}
         {submission.content_type === 'image' && submission.image_key ? (
           <Image
-            src={submission.image_key}
+            src={`${getApiBaseUrl()}/api/v1/uploads/${submission.image_key}`}
             alt="Submitted meme"
             maw={300}
             radius="sm"
@@ -64,6 +65,7 @@ export function SubmitView({ roomId, round }: Props) {
   const { deviceKid, privateKey } = useDevice();
   const { crypto } = useCrypto();
   const submitMutation = useSubmitMeme(roomId);
+  const submitImageMutation = useSubmitMemeWithImage(roomId);
 
   const [mode, setMode] = useState<ContentMode>('url');
   const [url, setUrl] = useState('');
@@ -73,6 +75,8 @@ export function SubmitView({ roomId, round }: Props) {
 
   const isAuthenticated = Boolean(deviceKid && privateKey && crypto);
   const hasContent = mode === 'url' ? url.trim().length > 0 : imageFile !== null;
+  const isPending = submitMutation.isPending || submitImageMutation.isPending;
+  const mutationError = submitMutation.error ?? submitImageMutation.error;
 
   const handleSubmit = () => {
     if (!deviceKid || !privateKey || !crypto) {
@@ -82,19 +86,29 @@ export function SubmitView({ roomId, round }: Props) {
       return;
     }
 
-    const body =
-      mode === 'url'
-        ? {
-            content_type: 'url' as const,
-            url: url.trim(),
-            caption: caption.trim() || undefined,
-          }
-        : {
-            content_type: 'image' as const,
-            // image_key would be set after upload; placeholder for now
-            image_key: imageFile?.name,
-            caption: caption.trim() || undefined,
-          };
+    if (mode === 'image' && imageFile) {
+      submitImageMutation.mutate(
+        {
+          image: imageFile,
+          caption: caption.trim() || undefined,
+          deviceKid,
+          privateKey,
+          wasmCrypto: crypto,
+        },
+        {
+          onSuccess: (result) => {
+            setSubmitted(result);
+          },
+        }
+      );
+      return;
+    }
+
+    const body = {
+      content_type: 'url' as const,
+      url: url.trim(),
+      caption: caption.trim() || undefined,
+    };
 
     submitMutation.mutate(
       { body, deviceKid, privateKey, wasmCrypto: crypto },
@@ -205,13 +219,13 @@ export function SubmitView({ roomId, round }: Props) {
             </Card>
           ) : null}
 
-          {submitMutation.error ? (
+          {mutationError ? (
             <Text size="sm" c="red">
-              {submitMutation.error.message}
+              {mutationError.message}
             </Text>
           ) : null}
 
-          <Button onClick={handleSubmit} disabled={!hasContent} loading={submitMutation.isPending}>
+          <Button onClick={handleSubmit} disabled={!hasContent} loading={isPending}>
             Submit
           </Button>
         </>

--- a/web/src/engines/ranking/index.ts
+++ b/web/src/engines/ranking/index.ts
@@ -1,0 +1,6 @@
+export { RankingEngineView as EngineView } from './RankingEngineView';
+export const engineMeta = {
+  type: 'ranking' as const,
+  displayName: 'Meme Ranking',
+  description: 'Daily meme tournaments with pairwise comparison',
+};

--- a/web/src/engines/registry.ts
+++ b/web/src/engines/registry.ts
@@ -6,4 +6,5 @@ export const engineMap: Record<
   () => Promise<{ EngineView: React.ComponentType<EngineViewProps> }>
 > = {
   polling: () => import('./polling'),
+  ranking: () => import('./ranking'),
 };


### PR DESCRIPTION
## Summary

New room engine for daily meme tournaments with pairwise comparison and Glicko-2 ratings.

- **New crate** `tc-engine-ranking` implementing the `RoomEngine` trait alongside `tc-engine-polling`
- **Game loop:** submit 1 meme/day → rank unlimited pairwise matchups → Glicko-2 leaderboard → hall of fame
- **Backend:** migration (5 tables + pgmq queue), repo layer, Glicko-2 algorithm, hybrid pair selection (uncertainty + near-frontier), service layer, round lifecycle consumer, 7 HTTP endpoints
- **Frontend:** API client, TanStack Query hooks, SubmitView, RankView, Leaderboard, HallOfFame, tabbed engine view, registered in engine map

### What works
- URL submissions (paste a link + optional caption)
- Pairwise ranking with blind matchups (no author info during ranking)
- Glicko-2 progressive rating updates
- Round lifecycle (submit → rank → close → next round)
- Hall of fame for daily winners
- Trust-gated participation via existing room role system

### Known gaps (follow-up work)
- Image upload infrastructure (backend object store + multipart handling) — next up
- OG metadata preview for submitted URLs
- `just codegen` for typed API client (needs running DB)
- Frontend component tests for ranking views

## Test plan

- [x] `just lint` passes (backend + frontend)
- [x] `just test` passes — 175 frontend + 31 crate unit tests
- [x] Integration tests: 55 repo tests + 10 service tests
- [ ] CI pipeline (this PR)
- [ ] Manual smoke test with local dev cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>