### PR TITLE
ci: use TLS when connecting to in-cluster BuildKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,7 +606,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://buildkitd.buildkit.svc.cluster.local:1234
+          endpoint: tcp+tls://buildkitd.buildkit.svc.cluster.local:1234
+          # CA for BuildKit's self-signed cert (issued by cert-manager
+          # internal-ca ClusterIssuer). Mounted into runners by homelab-gitops
+          # arc HelmRelease; path also exposed as $BUILDKIT_TLS_CA_CERT.
+          driver-opts: cacert=/etc/buildkit-ca/ca.crt
 
       - name: Set up Docker Buildx
         if: runner.environment != 'self-hosted'


### PR DESCRIPTION
## Summary

Homelab GitOps has enabled server-side TLS on in-cluster BuildKit ([icook/homelab-gitops#113](https://github.com/icook/homelab-gitops/issues/113)). BuildKit now listens on `tcp+tls://:1234` with a cert signed by the cluster's `internal-ca` ClusterIssuer (cert-manager). Plaintext `tcp://` connections will fail at TLS handshake.

This PR updates the remote buildx driver in `ci.yml` to speak TLS and point at the CA cert already mounted into every ARC runner pod by homelab-gitops (`/etc/buildkit-ca/ca.crt`, also exposed as `$BUILDKIT_TLS_CA_CERT`).

## Change

```diff
       - name: Set up Docker Buildx (remote in-cluster BuildKit)
         if: runner.environment == 'self-hosted'
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://buildkitd.buildkit.svc.cluster.local:1234
+          endpoint: tcp+tls://buildkitd.buildkit.svc.cluster.local:1234
+          driver-opts: cacert=/etc/buildkit-ca/ca.crt
```

The GHA-hosted path (local `docker-container` driver) is unchanged — it never talks to in-cluster BuildKit.

## Why this motion is necessary

Cross-job isolation. Previously, multiple ARC runner jobs sent build contexts (Dockerfiles, npm tokens, SSH keys passed as BuildKit secrets) over unauthenticated plaintext TCP to a shared BuildKit. Cilium WireGuard encrypts cross-node traffic, but **same-node traffic is not WireGuard-encrypted** — so a compromised runner job on the same node as BuildKit could sniff another job's build context via loopback. Server-side TLS closes that window without touching NetworkPolicy-based access control (BuildKit continues to only accept connections from the `arc-runners` and `gitlab-runner` namespaces).

## Coordination with homelab-gitops rollout

The companion changes in homelab-gitops:

1. `infrastructure: deploy cert-manager with self-signed internal CA` (commit 850c3e6)
2. `platform: enable BuildKit server-side TLS` (commit 74482bc) — enables TLS on the StatefulSet + mounts CA into ARC runners

The BuildKit StatefulSet will fail TLS handshake against plain-`tcp://` clients the moment it rolls. Suggested merge order to avoid a broken CI window:

1. Merge this PR first so `master` workflows are TLS-aware.
2. Push the homelab-gitops commits → Flux reconciles → BuildKit rolls with TLS.
3. Next CI run on any tiny-congress branch/PR uses TLS transparently.

If this PR merges *after* BuildKit rolls, self-hosted CI on existing branches will fail until they rebase onto the updated `ci.yml`.

## Test plan

- [ ] Open this PR → runs against the (still-plaintext) BuildKit on the ARC fast path. Expected: `setup-buildx-action` creates a TLS-enabled builder, then fails to connect because the server isn't yet TLS. That's the expected pre-rollout state. **Don't merge until homelab-gitops is staged.**
- [ ] Alternative: trigger a manual run with `use_arc: false` to validate GHA-hosted path is unaffected.
- [ ] After homelab-gitops rollout: verify a self-hosted CI run completes successfully via the TLS endpoint.

## Refs

- https://github.com/icook/homelab-gitops/issues/113
- homelab-gitops commits: [`850c3e6`](https://github.com/icook/homelab-gitops/commit/850c3e6), [`74482bc`](https://github.com/icook/homelab-gitops/commit/74482bc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)